### PR TITLE
Fix undefined variable errCodes

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,7 +51,7 @@ function writeConfigFile (config) {
 		console.log (
 			'An error occurred while writing to ' + SOLIUMRC_FILENAME_ABSOLUTE + ':\n' + e
 		);
-		process.exit (errCodes.WRITE_FAILED);
+		process.exit (errorCodes.WRITE_FAILED);
 	}
 }
 
@@ -87,7 +87,7 @@ function createDefaultSoliumIgnore () {
 		console.log (
 			'An error occurred while writing to ' + SOLIUMIGNORE_FILENAME_ABSOLUTE + ':\n' + e
 		);
-		process.exit (errCodes.WRITE_FAILED);
+		process.exit (errorCodes.WRITE_FAILED);
 	}
 }
 


### PR DESCRIPTION
The correct variable is `errorCodes`, defined in [line 25](https://github.com/federicobond/Solium/blob/5ec4731c7928236c2b7e92e9bb707539730d10b4/lib/cli.js#L25) of the same file.