### PR TITLE
Improve process error code reporting

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -23,8 +23,9 @@ var CWD = process.cwd (),
 	DEFAULT_SOLIUMIGNORE_PATH = __dirname + '/cli-utils/.default-solium-ignore';
 
 var errorCodes = {
-	NO_SOLIUMRC: 1,
-	WRITE_FAILED: 2
+	ERRORS_FOUND: 1,
+	NO_SOLIUMRC: 3,
+	WRITE_FAILED: 4
 };
 
 /**
@@ -116,7 +117,7 @@ function createDefaultConfigJSON () {
  * @param {String} filename (optional) The single file to be linted. If not given, we lint the entire directory's (and sub-directories') solidity files
  */
 function lint (userConfig, fileOrDir, ignore) {
-	var filesToLint, itemsToIgnore;
+	var filesToLint, errorCount = 0;
 
 	//If filename is provided, lint it. Otherwise, lint over current directory & sub-directories
 	if (fileOrDir.file) {
@@ -151,7 +152,10 @@ function lint (userConfig, fileOrDir, ignore) {
 		//if any lint errors exist, report them
 		lintErrors.length && errorReporter.report (codeFileName, lintErrors);
 
+		errorCount += lintErrors.length;
 	});
+
+	return errorCount;
 }
 
 /**
@@ -218,7 +222,7 @@ function execute (programArgs) {
 		);
 	}
 
-	lint (userConfig, { file: cli.file, dir: cli.dir}, ignore);
+	var errorCount = lint (userConfig, { file: cli.file, dir: cli.dir}, ignore);
 
 	if (cli.hot) {
 
@@ -229,8 +233,13 @@ function execute (programArgs) {
 			lint (userConfig, { file: cli.file, dir: cli.dir}, ignore);	//lint on subsequent changes (hot)
 		});
 
-	}
+	} else {
 
+		if (errorCount > 0) {
+			process.exit(errorCodes.ERRORS_FOUND);
+		}
+
+	}
 }
 
 module.exports = {


### PR DESCRIPTION
The most important change is that it now returns `1` if it finds any errors. This is the code returned by most linters when errors have been found and makes it easy to integrate Solium into an automated build process.

I skipped code number `2` because it has a [special meaning](http://www.tldp.org/LDP/abs/html/exitcodes.html) and redefined the other two errors with the next available numbers.