### PR TITLE
Add support for reading input from stdin

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -12,6 +12,7 @@ var cli = require ('commander'),
 	traverse = require ('sol-digger'),
 	solium = require ('./solium'),
 	soliumRules = require ('../config/solium.json').rules,
+	sum = require ('lodash/sum'),
 	version = require ('../package.json').version;
 
 var CWD = process.cwd (),
@@ -112,48 +113,76 @@ function createDefaultConfigJSON () {
 }
 
 /**
- * Function that calls Solium object's linter based on user settings
- * @param {Object} userConfig User's configurations that contain information about which linting rules to apply
- * @param {String} filename (optional) The single file to be linted. If not given, we lint the entire directory's (and sub-directories') solidity files
+ * Lint a source code string based on user settings
+ * @param {String} sourceCode The source code to be linted
+ * @param {Object} userConfig User configuration
+ * @param {Object} errorReporter The error reporter to use
+ * @param {String} fileName (optional) File name to use when reporting errors
  */
-function lint (userConfig, fileOrDir, ignore, errorReporter) {
-	var filesToLint, errorCount = 0;
-
-	//If filename is provided, lint it. Otherwise, lint over current directory & sub-directories
-	if (fileOrDir.file) {
-		filesToLint = [fileOrDir.file];
-	} else {
-		filesToLint = traverse (fileOrDir.dir || CWD, ignore);
-	}
-
-	filesToLint.forEach (function (codeFileName) {
-
-		var sourceCode = '', lintErrors;
-
-		try {
-			sourceCode = fs.readFileSync (
-				codeFileName, 'utf8'
-			);
-		} catch (e) {
-			console.error (
-				'[ERROR] Unable to read ' + codeFileName + ': ' + e
-			);
-		}
+function lintString (sourceCode, userConfig, errorReporter, fileName) {
+		var lintErrors;
 
 		try {
 			lintErrors = solium.lint (sourceCode, userConfig);
 		} catch (e) {
 			console.error (
-				'An error occurred while running the linter on ' + codeFileName + ':\n' + e.stack
+				'An error occurred while running the linter on ' + fileName + ':\n' + e.stack
 			);
 			return;
 		}
 
 		//if any lint errors exist, report them
-		lintErrors.length && errorReporter.report (codeFileName, lintErrors);
+		lintErrors.length && errorReporter.report (fileName || '[stdin]', sourceCode, lintErrors);
 
-		errorCount += lintErrors.length;
-	});
+		return lintErrors.length;
+}
+
+/**
+ * Lint a file based on user settings
+ * @param {String} fileName The path to the file to be linted
+ * @param {Object} userConfig User configuration
+ * @param {Object} errorReporter The error reporter to use
+ */
+function lintFile (fileName, userConfig, errorReporter) {
+	var sourceCode = '';
+
+	try {
+		sourceCode = fs.readFileSync (fileName, 'utf8');
+	} catch (e) {
+		console.error (
+			'[ERROR] Unable to read ' + fileName + ': ' + e
+		);
+	}
+
+	return lintString (sourceCode, userConfig, errorReporter, fileName)
+}
+
+/**
+ * Function that calls Solium object's linter based on user settings
+ * @param {Object} userConfig User's configurations that contain information about which linting rules to apply
+ * @param {String} filename (optional) The single file to be linted. If not given, we lint the entire directory's (and sub-directories') solidity files
+ */
+function lint (userConfig, input, ignore, errorReporter) {
+	var filesToLint, errorCount;
+
+	//If filename is provided, lint it. Otherwise, lint over current directory & sub-directories
+	if (input.file) {
+		filesToLint = [input.file];
+	} else if (input.dir) {
+		filesToLint = traverse (input.dir, ignore);
+	}
+
+	if (filesToLint) {
+		errorCount = sum (filesToLint.map(file => lintFile (file, userConfig, errorReporter)));
+	} else if (input.stdin) {
+		var sourceCode = fs.readFileSync ('/dev/stdin', 'utf-8');
+		errorCount = lintString (sourceCode, userConfig, errorReporter);
+	} else {
+		console.error(
+			'ERROR! Must specify input for linter using --file, --dir or --stdin'
+		);
+		process.exit (errorCodes.INVALID_PARAMS);
+	}
 
 	return errorCount;
 }
@@ -170,6 +199,7 @@ function createCliOptions (cliObject) {
 		.option ('-i, --init', 'Create default rule configuration')
 		.option ('-f, --file [filename]', 'Specify a file whose code you wish to lint')
 		.option ('-d, --dir [dirname]', 'Specify the directory to look for Solidity files in')
+		.option ('-, --stdin', 'Read input file from stdin')
 		.option ('--hot', 'Enable Hot Loading (Hot Swapping)')
 		.option ('-s, --sync', 'Make sure that all Solium rules enabled by default are specified in your ' + SOLIUMRC_FILENAME)
 		.option ('-R, --reporter <name>', 'Specify the format in which to report the issues found');
@@ -246,7 +276,13 @@ function execute (programArgs) {
 		);
 	}
 
-	var errorCount = lint (userConfig, { file: cli.file, dir: cli.dir}, ignore, errorReporter);
+	if (cli.hot && cli.stdin) {
+		console.error (
+			'ERROR! Cannot watch files when reading from stdin'
+		);
+	}
+
+	var errorCount = lint (userConfig, { file: cli.file, dir: cli.dir, stdin: cli.stdin }, ignore, errorReporter);
 
 	if (cli.hot) {
 
@@ -254,7 +290,7 @@ function execute (programArgs) {
 
 		spy.on ('change', function () {
 			console.log (Array (50).join ('*') + '\n');
-			lint (userConfig, { file: cli.file, dir: cli.dir}, ignore, errorReporter);	//lint on subsequent changes (hot)
+			lint (userConfig, { file: cli.file, dir: cli.dir }, ignore, errorReporter);	//lint on subsequent changes (hot)
 		});
 
 	} else {

--- a/lib/reporters/gcc.js
+++ b/lib/reporters/gcc.js
@@ -7,7 +7,7 @@
 
 module.exports = {
 
-	report: function (filename, lintErrors) {
+	report: function (filename, sourceCode, lintErrors) {
 
 		lintErrors.forEach (function (error) {
 

--- a/lib/reporters/pretty.js
+++ b/lib/reporters/pretty.js
@@ -21,8 +21,8 @@ function color (type) {
 
 module.exports = {
 
-	report: function (filename, lintErrors) {
-		var lines = fs.readFileSync (filename, 'utf-8').split ('\n');
+	report: function (filename, sourceCode, lintErrors) {
+		var lines = sourceCode.split ('\n');
 		var errorLine, line, tabCount;
 
 		lintErrors.forEach (function (error) {


### PR DESCRIPTION
To test it, run:
```
cat contracts/MetaCoin.sol | ./bin/solium.js --stdin
```
This also improves separation of concerns within the CLI code, and paves the way for creating a class later to avoid having to pass all those arguments several layers down.

**P.S.** I have a working prototype of Solium integration with the Atom text editor.