### PR TITLE
Fix issue #35 - false positive for blank lines around functions with comments 

### DIFF
--- a/lib/rules/blank-lines.js
+++ b/lib/rules/blank-lines.js
@@ -10,7 +10,8 @@ module.exports = {
 	verify: function (context) {
 
 		var sourceCode = context.getSourceCode (),
-			noCodeRegExp = /^[ \t]*$/;
+			noCodeRegExp = /^[ \t]*$/,
+			isCommentRegExp = /\s*(\/\/*)|(\*\\*)|(\/\**)$/;
 		var topLevelDeclarations = [ 'ContractStatement', 'LibraryStatement' ];
 
 		context.on ('Program', function (emitted) {
@@ -67,16 +68,18 @@ module.exports = {
 
 			for (var i = 0; i < body.length-1; i++) {
 				var endingLineNumber = sourceCode.getEndingLine (body [i]),
-					a, b;
+					a, b, c;
 
 				try {
 					a = sourceCode.getTextOnLine (endingLineNumber+1);
 					b = sourceCode.getTextOnLine (endingLineNumber+2);
+					c = sourceCode.getTextOnLine (endingLineNumber);
 				} catch (e) {}
 
 				if (
 					body [i].type === 'FunctionDeclaration' &&
 					sourceCode.getLine (body [i]) !== endingLineNumber &&
+					!isCommentRegExp.test(c) &&
 					(
 						(!noCodeRegExp.test (a)) || noCodeRegExp.test (b) || endingLineNumber === sourceCode.getLine (body [i+1])
 					)

--- a/test/lib/rules/blank-lines/accept/function.sol
+++ b/test/lib/rules/blank-lines/accept/function.sol
@@ -31,4 +31,13 @@ contract Chumma {
     {
         return 2;
     }
+
+    /**
+     * @notice this function returns something important
+     * @return description
+     */
+    function yetAnotherFunction() constant returns(uint256)
+    {
+        return 3;
+    }
 }


### PR DESCRIPTION
This PR 

+ adds a comment detection regex to the blank-lines rule, allowing functions to be preceded by comments with form `//`, `///`, and `/** ... lines  ...*/`
+ adds a function preceded by a block of asterisk-style comments to the test's solidity file.
+ lets [this test](https://github.com/duaraghav8/Solium/blob/master/test/lib/rules/blank-lines/blank-lines.js#L66) pass



