### PR TITLE
Fix for issue #53 (Handle binary expression - op - literal case)

### DIFF
--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -160,4 +160,6 @@ Hopefully, you didn't have much trouble following this guide. If you think it ha
 
 ```getPrevChars (node, charCount)``` - get charCount no. of characters befre the code of specified node
 
+```isASTNode (arg)``` - Returns ```true``` if the given argument is a valid (Spider-Monkey compliant) AST Node
+
 ```getStringBetweenNodes (prevNode, nextNode)``` - get the complete code between 2 specified nodes. (The code ranges from ```prevNode.end``` (inclusive) to ```nextNode.start``` (exclusive) )

--- a/lib/rules/lbrace.js
+++ b/lib/rules/lbrace.js
@@ -417,8 +417,16 @@ module.exports = {
 			//stringBetwLastModifAndLBrace should start with \n, followed by any no. of spaces or tabs, then end.
 			if (node.modifiers) {
 				//Take string between last modifier and the opening brace (both exclusive)
-				var stringBetwLastModifAndLBrace = sourceCode.getStringBetweenNodes (
-					node.modifiers.slice (-1) [0], node.body
+				var stringBetwLastModifAndLBrace,
+				    modifierNode = node.modifiers.slice (-1) [0];
+
+				//Catch case where modifier has no brackets and alter node's location end appropriately
+				if (modifierNode.params !== null && modifierNode.params.length === 0){
+				    modifierNode.end = modifierNode.start + modifierNode.name.length;
+				}
+
+				stringBetwLastModifAndLBrace = sourceCode.getStringBetweenNodes (
+				    modifierNode, node.body
 				);
 
 				(!/^\n[ \t]*$/.test (stringBetwLastModifAndLBrace)) && context.report ({

--- a/lib/rules/operator-whitespace.js
+++ b/lib/rules/operator-whitespace.js
@@ -5,8 +5,6 @@
 
 'use strict';
 
-var astUtils = require ('../utils/ast-utils');
-
 module.exports = {
 
 	verify: function (context) {
@@ -22,7 +20,7 @@ module.exports = {
 			}
 
 			// Handle case where left node is a binary expression and right node may be a literal
-			if ( astUtils.isASTNode(node.left) && node.left.type === 'BinaryExpression'){
+			if ( sourceCode.isASTNode(node.left) && node.left.type === 'BinaryExpression'){
 				leftNode = node.left.right;
 			} else {
 				leftNode = node.left;

--- a/lib/rules/operator-whitespace.js
+++ b/lib/rules/operator-whitespace.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+var astUtils = require ('../utils/ast-utils');
+
 module.exports = {
 
 	verify: function (context) {
@@ -12,13 +14,21 @@ module.exports = {
 		var sourceCode = context.getSourceCode ();
 
 		context.on ('BinaryExpression', function (emitted) {
-			var node = emitted.node;
+			var leftNode,
+			    node = emitted.node;
 
 			if (emitted.exit) {
 				return;
 			}
 
-			var strBetweenLeftAndRight = sourceCode.getStringBetweenNodes (node.left, node.right).split (node.operator),
+			// Handle case where left node is a binary expression and right node may be a literal
+			if ( astUtils.isASTNode(node.left) && node.left.type === 'BinaryExpression'){
+				leftNode = node.left.right;
+			} else {
+				leftNode = node.left;
+			}
+
+			var strBetweenLeftAndRight = sourceCode.getStringBetweenNodes (leftNode, node.right).split (node.operator),
 				onlyCharsRegExp = /^[^\s\/]$/;
 
 			if (strBetweenLeftAndRight [0].slice (-1) === ' ' || strBetweenLeftAndRight [1] [0] === ' ') {

--- a/lib/utils/source-code-utils.js
+++ b/lib/utils/source-code-utils.js
@@ -8,6 +8,7 @@
 
 var astUtils = require ('./ast-utils');
 var INHERITABLE_METHODS = [
+		'isASTNode',
 		'getParent',
 		'getColumn',
 		'getEndingColumn',

--- a/test/lib/rules/lbrace/lbrace.js
+++ b/test/lib/rules/lbrace/lbrace.js
@@ -165,6 +165,17 @@ describe ('[RULE] lbrace: Acceptances', function () {
 		done ();
 	});
 
+	it ('should allow opening brace to be on its own line in case a function has modifiers (without brackets)', function (done) {
+		var code = 'function modifs ()\npublic\nowner\npriced(0)\npayable\n{\n\tfoobar ();\n}',
+		    errors = Solium.lint (code, userConfig);
+
+		errors.constructor.name.should.equal ('Array');
+		errors.length.should.equal (0);
+
+		Solium.reset ();
+		done ();
+	});
+
 	it ('should allow opening brace to be on its own line in case a function has base constructor arguments', function (done) {
 		var code = 'function baseArgs ()\n\tA (10)\n\tB ("hello")\n\tC (0x0)\n\tD (frodo)\n{\n\tfoobar ();\n}',
 			errors = Solium.lint (code, userConfig);

--- a/test/lib/solium.js
+++ b/test/lib/solium.js
@@ -34,22 +34,43 @@ describe ('Checking Exported Solium API', function () {
 		sourceCode.constructor.name.should.equal ('SourceCode');
 
 		sourceCode.should.have.ownProperty ('text', '');
+
 		sourceCode.should.have.property ('getLine');
 		sourceCode.getLine.should.be.type ('function');
+
 		sourceCode.should.have.property ('getColumn');
 		sourceCode.getColumn.should.be.type ('function');
+
+		sourceCode.should.have.property ('getEndingColumn');
+		sourceCode.getColumn.should.be.type ('function');
+		
 		sourceCode.should.have.property ('getParent');
+		sourceCode.getParent.should.be.type ('function');
+
+		sourceCode.should.have.property ('getEndingLine');
+		sourceCode.getParent.should.be.type ('function');
+		
+		sourceCode.should.have.property ('isASTNode');
 		sourceCode.getParent.should.be.type ('function');
 
 		sourceCode.should.have.property ('getText');
 		sourceCode.getText.should.be.type ('function');
 
+		sourceCode.should.have.property ('getTextOnLine');
+		sourceCode.getText.should.be.type ('function');
+		
+		sourceCode.should.have.property ('getStringBetweenNodes');
+		sourceCode.getText.should.be.type ('function');
+
 		sourceCode.should.have.property ('getNextChar');
 		sourceCode.getNextChar.should.be.type ('function');
+		
 		sourceCode.should.have.property ('getPrevChar');
 		sourceCode.getPrevChar.should.be.type ('function');
+		
 		sourceCode.should.have.property ('getNextChars');
 		sourceCode.getNextChars.should.be.type ('function');
+		
 		sourceCode.should.have.property ('getPrevChars');
 		sourceCode.getPrevChars.should.be.type ('function');
 


### PR DESCRIPTION
This PR is based on analysis and tests of @ulope and @duaraghav8 for issue #53. It checks to see if the left node of lint target is itself a binary expression. If it is, it substitutes the left node's right sub-node for left node in the call to `getStringBetweenNodes` in order to provide the correct start point value. 

*Think* this works without breaking anything (all tests pass). Needs sanity check due to trees.    