### PR TITLE
Fix for issue #53 (Binary exp handling in operator whitespace)

### DIFF
--- a/lib/rules/operator-whitespace.js
+++ b/lib/rules/operator-whitespace.js
@@ -12,13 +12,21 @@ module.exports = {
 		var sourceCode = context.getSourceCode ();
 
 		context.on ('BinaryExpression', function (emitted) {
-			var node = emitted.node;
+			var leftNode,
+			    node = emitted.node;
 
 			if (emitted.exit) {
 				return;
 			}
 
-			var strBetweenLeftAndRight = sourceCode.getStringBetweenNodes (node.left, node.right).split (node.operator),
+			// Handle case where left node is a binary expression and right node may be a literal
+			if ( sourceCode.isASTNode(node.left) && node.left.type === 'BinaryExpression'){
+				leftNode = node.left.right;
+			} else {
+				leftNode = node.left;
+			}
+
+			var strBetweenLeftAndRight = sourceCode.getStringBetweenNodes (leftNode, node.right).split (node.operator),
 				onlyCharsRegExp = /^[^\s\/]$/;
 
 			if (strBetweenLeftAndRight [0].slice (-1) === ' ' || strBetweenLeftAndRight [1] [0] === ' ') {


### PR DESCRIPTION
This PR is based on analysis and tests of @ulope and @duaraghav8 for issue #53. It checks to see if the left node of lint target is itself a binary expression. If it is, it substitutes the left node's right sub-node for left node in the call to getStringBetweenNodes in order to provide the correct start point value.

