### PR TITLE
Allow trailing whitespace after last own-line modifier before next-line lbrace

### DIFF
--- a/lib/rules/lbrace.js
+++ b/lib/rules/lbrace.js
@@ -429,7 +429,7 @@ module.exports = {
 				    modifierNode, node.body
 				);
 
-				(!/^\n[ \t]*$/.test (stringBetwLastModifAndLBrace)) && context.report ({
+				(!/^[ \t]*\n[ \t]*$/.test (stringBetwLastModifAndLBrace)) && context.report ({
 					node: node.body,
 					message: 'Function \'' + node.name + '\': Opening brace must be on a new line immediately after the last modifier.'
 				});

--- a/test/lib/rules/lbrace/lbrace.js
+++ b/test/lib/rules/lbrace/lbrace.js
@@ -160,6 +160,12 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
+
+		code = 'function modifs (\n\tuint x,\n\tstring y\n)\npublic\nowner\npriced\nreturns (uint) \t\n{\n\tfoobar ();\n}';
+		errors = Solium.lint (code, userConfig);
+
+		errors.constructor.name.should.equal ('Array');
+		errors.length.should.equal (0);
 		
 		Solium.reset ();
 		done ();


### PR DESCRIPTION
This PR addresses issue #50 false positives when an own-line modifier has trailing whitespace before its carriage return. It changes the relevant regex to permit tabs and spaces before the `\n` and adds a test for that case. 