### PR TITLE
Fix and improve tests. Configure linter

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "env": {
+        "node": true,
+        "jasmine": true,
+        "es6": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "no-console": 0,
+        "no-mixed-spaces-and-tabs": 0
+    }
+}

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -97,7 +97,6 @@ See the [existing rules](https://github.com/duaraghav8/Solium/tree/master/lib/ru
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium');
 
 //INSERT YOUR RULE'S NAME IN THE BELOW userConfig Object, leave the rest of the object untouched

--- a/lib/reporters/pretty.js
+++ b/lib/reporters/pretty.js
@@ -5,9 +5,9 @@
 
 'use strict';
 
-var colors = require ('colors'),
-	fs = require ('fs'),
-	sort = require('lodash/sortBy');
+require ('colors');
+
+var sort = require('lodash/sortBy');
 
 function repeat (str, count) {
 	return Array (count+1).join (str);
@@ -49,7 +49,7 @@ module.exports = {
 				+ ('^-- ' + error.type.toUpperCase() + ': ' + error.message)[color(error.type)]
 			);
 
-			if (!counts[error.type]) {
+			if (!counts[error.type]) {
 				counts[error.type] = 0;
 			}
 

--- a/lib/rules/blank-lines.js
+++ b/lib/rules/blank-lines.js
@@ -74,7 +74,7 @@ module.exports = {
 					a = sourceCode.getTextOnLine (endingLineNumber+1);
 					b = sourceCode.getTextOnLine (endingLineNumber+2);
 					c = sourceCode.getTextOnLine (endingLineNumber);
-				} catch (e) {}
+				} catch (e) { /* ignore */ }
 
 				if (
 					body [i].type === 'FunctionDeclaration' &&

--- a/lib/rules/pragma-on-top.js
+++ b/lib/rules/pragma-on-top.js
@@ -26,7 +26,8 @@ module.exports = {
 		context.on ('PragmaStatement', function (emitted) {
 			var node = emitted.node,
 				sourceCode = context.getSourceCode (),
-				pragmaParent = sourceCode.getParent (node);
+				pragmaParent = sourceCode.getParent (node),
+				error;
 
 			if (emitted.exit) {
 				return;
@@ -37,7 +38,7 @@ module.exports = {
 			 * i.e., if a pragma directive is found inside another node (like BlockStatement, etc.)
 			 */
 			if (pragmaParent.type !== 'Program') {
-				var error = {
+				error = {
 					node: node,
 					message: 'Pragma Directive \"' + sourceCode.getText (node) +
 						'\" cannot be inside ' + pragmaParent.type
@@ -48,7 +49,7 @@ module.exports = {
 
 			//Raise error if this pragma dir is not at top of file
 			if (node.start !== pragmaParent.body [0].start) {
-				var error = {
+				error = {
 					node: node,
 					message: 'Pragma Directive \"' + sourceCode.getText (node) +
 						'\" should only be at the top of the file.'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "solium": "./bin/solium.js"
   },
   "scripts": {
-    "test": "./node_modules/.bin/mocha ./test/*/*.js ./test/*/*/*.js ./test/*/*/*/*.js --reporter spec"
+    "test": "mocha --require should --reporter spec --recursive",
+    "lint": "eslint ."
   },
   "keywords": [
     "Lint",
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "eslint": "^3.12.2",
     "mocha": "^3.0.2",
     "should": "^11.0.0",
     "supertest": "^2.0.0"

--- a/test/lib/rule-context.js
+++ b/test/lib/rule-context.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var RuleContext = require ('../../lib/rule-context'),
 	Solium = require ('../../lib/solium'),
 	_ = require ('lodash');
@@ -105,7 +104,7 @@ describe ('Testing RuleContext object', function () {
 	it ('should behave as expected upon calling on ()', function (done) {
 		var rcObject = new RuleContext ('foo', ruleMeta, Solium);
 
-		rcObject.on ('ContractStatement', function (emitted) {
+		rcObject.on ('ContractStatement', function () {
 			Solium.reset ();
 			done ();
 		});

--- a/test/lib/rules.js
+++ b/test/lib/rules.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var rules = require ('../../lib/rules'),
 	path = require ('path');
 

--- a/test/lib/rules/array-declarations/array-declarations.js
+++ b/test/lib/rules/array-declarations/array-declarations.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium');
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/blank-lines/blank-lines.js
+++ b/test/lib/rules/blank-lines/blank-lines.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium'),
 	fs = require ('fs'),
 	path = require ('path');

--- a/test/lib/rules/camelcase/camelcase.js
+++ b/test/lib/rules/camelcase/camelcase.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium');
 
 var userConfig = {

--- a/test/lib/rules/deprecated-suicide/deprecated-suicide.js
+++ b/test/lib/rules/deprecated-suicide/deprecated-suicide.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
 	"custom-rules-filename": null,

--- a/test/lib/rules/double-quotes/double-quotes.js
+++ b/test/lib/rules/double-quotes/double-quotes.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium'),
 	fs = require ('fs'),
 	path = require ('path');

--- a/test/lib/rules/imports-on-top/imports-on-top.js
+++ b/test/lib/rules/imports-on-top/imports-on-top.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium'),
 	fs = require ('fs'),
 	path = require ('path');

--- a/test/lib/rules/lbrace/lbrace.js
+++ b/test/lib/rules/lbrace/lbrace.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
@@ -231,7 +230,7 @@ describe ('[RULE] lbrace: Acceptances', function () {
 });
 
 
-describe ('[RULE] lbrace: Rejections', function (done) {
+describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject any opening brace which is not preceded by EXACTLY single space (exception: functions with modifiers)', function (done) {
 		var code = 'contract FooBar{}',

--- a/test/lib/rules/mixedcase/mixedcase.js
+++ b/test/lib/rules/mixedcase/mixedcase.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
@@ -125,7 +124,7 @@ describe ('[RULE] mixedcase: Acceptances', function () {
 		done ();
 	});
 
-	if ('should accept all valid variable declarations', function (done) {
+	it ('should accept all valid variable declarations', function (done) {
 		var code = [
 			'var helloWorld;',
 			'var h;',
@@ -179,7 +178,7 @@ describe ('[RULE] mixedcase: Acceptances', function () {
 		done ();
 	});
 
-	if ('should accept all valid declarative expressions', function (done) {
+	it ('should accept all valid declarative expressions', function (done) {
 		var code = [
 			'uint helloWorld;',
 			'address h;',

--- a/test/lib/rules/no-empty-blocks/no-empty-blocks.js
+++ b/test/lib/rules/no-empty-blocks/no-empty-blocks.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/no-unused-vars/no-unused-vars.js
+++ b/test/lib/rules/no-unused-vars/no-unused-vars.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/no-with/no-with.js
+++ b/test/lib/rules/no-with/no-with.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/operator-whitespace/operator-whitespace.js
+++ b/test/lib/rules/operator-whitespace/operator-whitespace.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../../../lib/solium');
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/pragma-on-top/pragma-on-top.js
+++ b/test/lib/rules/pragma-on-top/pragma-on-top.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/uppercase/uppercase.js
+++ b/test/lib/rules/uppercase/uppercase.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/variable-declarations/variable-declarations.js
+++ b/test/lib/rules/variable-declarations/variable-declarations.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/rules/whitespace/whitespace.js
+++ b/test/lib/rules/whitespace/whitespace.js
@@ -5,10 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var Solium = require ('../../../../lib/solium'),
-	fs = require ('fs'),
-	path = require ('path');
+var Solium = require ('../../../../lib/solium');
 
 var userConfig = {
   "custom-rules-filename": null,

--- a/test/lib/solium.js
+++ b/test/lib/solium.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var Solium = require ('../../lib/solium'),
 	EventEmitter = require ('events').EventEmitter;
 

--- a/test/lib/utils/ast-utils.js
+++ b/test/lib/utils/ast-utils.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var astUtils = require ('../../../lib/utils/ast-utils');
 
 describe ('Testing astUtils Object', function () {
@@ -81,7 +80,7 @@ describe ('Testing astUtils Object', function () {
 	});
 
 	it ('should correctly classify argument as AST Node or non-AST Node upon calling isASTNode ()', function (done) {
-		var ian = astUtils.isASTNode, temp;
+		var ian = astUtils.isASTNode;
 
 		ian ().should.equal (false);
 		ian (null).should.equal (false);

--- a/test/lib/utils/js-utils.js
+++ b/test/lib/utils/js-utils.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var jsUtils = require ('../../../lib/utils/js-utils');
 
 describe ('Test jsUtils functions', function () {

--- a/test/lib/utils/node-event-generator.js
+++ b/test/lib/utils/node-event-generator.js
@@ -5,7 +5,6 @@
 
 'use strict';
 
-var should = require ('should');
 var EventGenerator = require ('../../../lib/utils/node-event-generator'),
 	Solium = require ('../../../lib/solium');
 

--- a/test/lib/utils/source-code-utils.js
+++ b/test/lib/utils/source-code-utils.js
@@ -5,9 +5,7 @@
 
 'use strict';
 
-var should = require ('should');
-var SourceCode = require ('../../../lib/utils/source-code-utils'),
-	Solium = require ('../../../lib/solium');
+var SourceCode = require ('../../../lib/utils/source-code-utils');
 
 describe ('Testing SourceCode instance for exposed functionality', function () {
 	var sourceCodeText = 'contract Visual {\n\n\tfunction foo () {\n\t\tvar x = 100;\n\t}\n\n}',


### PR DESCRIPTION
I configured `eslint` and fixed all errors. Some tests were not running because of typos.

The test script in `package.json` is also much cleaner now.