### PR TITLE
Add wrapper methods to utils/js-utils. Wrap Solidity snippets in tests

### DIFF
--- a/lib/utils/js-utils.js
+++ b/lib/utils/js-utils.js
@@ -16,6 +16,5 @@ module.exports = {
 			typeof possibleObject === 'object' &&
 			possibleObject.constructor !== Array
 		);
-	}
-
+	},
 };

--- a/test/lib/rules/array-declarations/array-declarations.js
+++ b/test/lib/rules/array-declarations/array-declarations.js
@@ -6,6 +6,8 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
 var userConfig = {
   "custom-rules-filename": null,
   "rules": {
@@ -17,7 +19,7 @@ describe ('[RULE] array-declarations: Acceptances', function () {
 
 	it ('should accept "uint[] x;"', function (done) {
 		var code = 'uint[] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -28,7 +30,7 @@ describe ('[RULE] array-declarations: Acceptances', function () {
 
 	it ('should accept "uint[10] x;"', function (done) {
 		var code = 'uint[10] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -43,7 +45,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "uint[ ] x;"', function (done) {
 		var code = 'uint[ ] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -55,7 +57,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "uint[	] x;" (\\t)', function (done) {
 		var code = 'uint[	] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -67,7 +69,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "uint[\n] x;"', function (done) {
 		var code = 'uint[\n] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -79,7 +81,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "uint[  ] x;" (2 spaces)', function (done) {
 		var code = 'uint[  ] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -91,7 +93,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "uint [] x;" (space between literal and opening brackets', function (done) {
 		var code = 'uint [] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -103,7 +105,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "string\n[] x;" (linebreak between literal and opening brackets', function (done) {
 		var code = 'string\n[] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -115,7 +117,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "bytes32\t[] x;" (tab between literal and opening brackets', function (done) {
 		var code = 'bytes32\t[] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -127,7 +129,7 @@ describe ('[RULE] array-declarations: Rejections', function () {
 
 	it ('should reject "uint  [  ] x;"', function (done) {
 		var code = 'uint  [  ] x;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);

--- a/test/lib/rules/blank-lines/blank-lines.js
+++ b/test/lib/rules/blank-lines/blank-lines.js
@@ -6,6 +6,7 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium'),
+	wrappers = require ('../../../utils/wrappers'),
 	fs = require ('fs'),
 	path = require ('path');
 
@@ -16,11 +17,13 @@ var userConfig = {
   }
 };
 
+var addPragma = wrappers.addPragma;
+
 describe ('[RULE] blank-lines: Acceptances', function () {
 
 	it ('should accept contract declarations succeded by 2 blank lines (all declarations except for last)', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './accept/contract.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -31,7 +34,7 @@ describe ('[RULE] blank-lines: Acceptances', function () {
 
 	it ('should accept library declarations succeded by 2 blank lines (all declarations except for last)', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './accept/library.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -42,7 +45,7 @@ describe ('[RULE] blank-lines: Acceptances', function () {
 
 	it ('should accept single contract declaration', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './accept/contract-single.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -53,7 +56,7 @@ describe ('[RULE] blank-lines: Acceptances', function () {
 
 	it ('should accept single library declaration', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './accept/library-single.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -64,7 +67,7 @@ describe ('[RULE] blank-lines: Acceptances', function () {
 
 	it ('should accept single-line functions without blank lines between them & multiline functions WITH them', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './accept/function.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -75,7 +78,7 @@ describe ('[RULE] blank-lines: Acceptances', function () {
 
 	it ('should not enforce blank line rules on top level declarations other than contract & library declarations', function (done) {
 		var code = 'import * as x from "y";\nimport * as x from "y";\nimport * as x from "y";\n\n\ncontract Yoda {} import * as foo from "bar.sol";',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -91,7 +94,7 @@ describe ('[RULE] blank-lines: Rejections', function () {
 
 	it ('should reject contract declarations with < 2 lines of gap between them', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './reject/contract.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (3);
@@ -106,7 +109,7 @@ describe ('[RULE] blank-lines: Rejections', function () {
 
 	it ('should reject library declarations with < 2 lines of gap between them', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './reject/library.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (3);
@@ -121,7 +124,7 @@ describe ('[RULE] blank-lines: Rejections', function () {
 
 	it ('should reject a multiline function that is not followed by a blank line', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './reject/function.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);

--- a/test/lib/rules/camelcase/camelcase.js
+++ b/test/lib/rules/camelcase/camelcase.js
@@ -6,6 +6,9 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
+var addPragma = wrappers.addPragma;
 
 var userConfig = {
   "custom-rules-filename": null,
@@ -28,6 +31,8 @@ describe ('[RULE] camelcase: Acceptances', function () {
 			'contract M123 {}'
 		];
 		var errors;
+
+		code = code.map(function(item){return addPragma(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -78,6 +83,8 @@ describe ('[RULE] camelcase: Acceptances', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return addPragma(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -127,6 +134,8 @@ describe ('[RULE] camelcase: Acceptances', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toContract(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -175,6 +184,8 @@ describe ('[RULE] camelcase: Acceptances', function () {
 			'struct M123 {}'
 		];
 		var errors;
+
+		code = code.map(function(item){return toContract(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -227,6 +238,8 @@ describe ('[RULE] camelcase: Rejections', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return addPragma(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -260,6 +273,8 @@ describe ('[RULE] camelcase: Rejections', function () {
 			'library hello_1world {}'
 		];
 		var errors;
+
+		code = code.map(function(item){return addPragma(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -295,6 +310,8 @@ describe ('[RULE] camelcase: Rejections', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toContract(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -328,6 +345,8 @@ describe ('[RULE] camelcase: Rejections', function () {
 			'struct hello_1world {}'
 		];
 		var errors;
+
+		code = code.map(function(item){return toContract(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');

--- a/test/lib/rules/deprecated-suicide/deprecated-suicide.js
+++ b/test/lib/rules/deprecated-suicide/deprecated-suicide.js
@@ -6,7 +6,8 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
-
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
 var userConfig = {
 	"custom-rules-filename": null,
 	"rules": {
@@ -17,7 +18,7 @@ var userConfig = {
 describe ('[RULE] deprecated-suicide', function () {
 
 	it ('should reject contracts using suicide', function (done) {
-		var code = 'function foo () { suicide(0x0); }',
+		var code = toContract('function foo () { suicide(0x0); }'),
 
 		errors = Solium.lint (code, userConfig);
 

--- a/test/lib/rules/double-quotes/double-quotes.js
+++ b/test/lib/rules/double-quotes/double-quotes.js
@@ -6,9 +6,11 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium'),
+	wrappers = require ('../../../utils/wrappers'),
 	fs = require ('fs'),
 	path = require ('path');
 
+var toContract = wrappers.toContract;
 var userConfig = {
   "custom-rules-filename": null,
   "rules": {
@@ -20,7 +22,7 @@ describe ('[RULE] double-quotes: Acceptances', function () {
 
 	it ('should accept strings quoted with double quotes', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './accept/double-quoted.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -36,7 +38,7 @@ describe ('[RULE] double-quotes: Rejections', function () {
 
 	it ('should reject strings quoted with single quotes', function (done) {
 		var code = fs.readFileSync (path.join (__dirname, './reject/single-quoted.sol'), 'utf8'),
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (5);

--- a/test/lib/rules/lbrace/lbrace.js
+++ b/test/lib/rules/lbrace/lbrace.js
@@ -6,7 +6,11 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
 
+var toContract = wrappers.toContract;
+var toFunction = wrappers.toFunction;
+var addPragma = wrappers.addPragma;
 var userConfig = {
   "custom-rules-filename": null,
   "rules": {
@@ -18,7 +22,7 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow abstract functions', function (done) {
 		var code = 'function abstractFunc (uint x, string y) public returns (boolean);',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -29,43 +33,43 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow (short-declaration) bodies with opening brace on same line after a single space', function (done) {
 		var code = 'contract Visual {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'library Visual {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'function foobar (bytes32 name) returns (address) {\n\t/*body*/\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'struct Student {\n\tstring name;\n\tuint age;\n\taddress account\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'for (var i = 0; i < 10; i++) {\n\thello ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'uint i = 0; while (i < 10) {\n\ti++;\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'uint i = 0; do {\n\ti++;\n}\nwhile (i < 10);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -76,25 +80,25 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow when closing brace is on its own line unless the body is declared on a single line like if (..) {...}', function (done) {
 		var code = 'if (true) { hello (); }',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true) {\n\thello ();\n} else if (true) {\n\tworld ();\n} else {\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'function foo () {hello ();}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'function foo () {\n\thello ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -108,19 +112,19 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 		//since this rule doesn't lint for indentation, only \n without \t should also be valid
 		code = 'if (true)\nnewNumber = (10 * 78 + 982 % 6**2);\nelse\nnewNumber = 0;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true)\n\tlaunchEvent ("foo bar!");';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true)\ncreateStructObject ({ name: "Chuck Norris", age: "inf" });';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -132,7 +136,7 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow functions with arguments spanning over multiple lines to NOT have opening brace on same line', function (done) {
 		var code = 'function lotsOfArgs (\n\tuint x,\n\tstring y,\n\taddress z\n) {\n\tfoobar ();\n}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -143,13 +147,13 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow opening brace to be on its own line in case a function has modifiers', function (done) {
 		var code = 'function modifs ()\npublic\nowner\npriced\nreturns (uint)\n{\n\tfoobar ();\n}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'function modifs (\n\tuint x,\n\tstring y\n)\npublic\nowner\npriced\nreturns (uint)\n{\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -161,7 +165,7 @@ describe ('[RULE] lbrace: Acceptances', function () {
 		errors.length.should.equal (0);
 
 		code = 'function modifs (\n\tuint x,\n\tstring y\n)\npublic\nowner\npriced\nreturns (uint) \t\n{\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -172,7 +176,7 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow opening brace to be on its own line in case a function has modifiers (without brackets)', function (done) {
 		var code = 'function modifs ()\npublic\nowner\npriced(0)\npayable\n{\n\tfoobar ();\n}',
-		    errors = Solium.lint (code, userConfig);
+		    errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -183,7 +187,7 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow opening brace to be on its own line in case a function has base constructor arguments', function (done) {
 		var code = 'function baseArgs ()\n\tA (10)\n\tB ("hello")\n\tC (0x0)\n\tD (frodo)\n{\n\tfoobar ();\n}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -194,31 +198,31 @@ describe ('[RULE] lbrace: Acceptances', function () {
 
 	it ('should allow else clauses beginning on the same line as closing brace of if consequent', function (done) {
 		var code = 'if (true) {h();} else if (true) {h();} else {h();}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true) {h();} else {h();}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true) {h();} else if (true) {h();}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true) {h();} else if (true)\nhello ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true) {h();} else if (true)\nhello ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -234,300 +238,300 @@ describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject any opening brace which is not preceded by EXACTLY single space (exception: functions with modifiers)', function (done) {
 		var code = 'contract FooBar{}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'contract FooBar  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'contract FooBar\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'contract FooBar/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'library FooBar{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'library FooBar  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'library FooBar\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'library FooBar/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'if (true){}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true)  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true)\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true)/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'if (true) {} else if (true){}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true)  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true)\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true)/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'if (true) {} else{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'while (true){}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'while (true)  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'while (true)\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'while (true)/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'for (;;){}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'for (;;)  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'for (;;)\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'for (;;)/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'do{}\nwhile (true);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'do  {}\nwhile (true);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'do\t{}\nwhile (true);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'do/*comment*/{}\nwhile (true);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'struct Student{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'struct Student  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'struct Student\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'struct Student/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'with (true){}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'with (true)  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'with (true)\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'with (true)/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'function foo (uint x) public modif returns (address){}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function foo (uint x) public modif returns (address)  {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function foo (uint x) public modif returns (address)\t{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function foo (uint x) public modif returns (address)/*comment*/{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 
 		code = 'function lotsOfArgs (\n\tuint x,\n\tstring y,\n\taddress z\n){\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function lotsOfArgs (\n\tuint x,\n\tstring y,\n\taddress z\n)  {\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function lotsOfArgs (\n\tuint x,\n\tstring y,\n\taddress z\n)\t{\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function lotsOfArgs (\n\tuint x,\n\tstring y,\n\taddress z\n)/*comment*/{\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -539,25 +543,25 @@ describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject all function declarations having multiple modifiers over multiple lines whose brace does not open on the line after the last modifier', function (done) {
 		var code = 'function lotsOfArgs ()\n\tpublic\n\treturns (address){\n\tfoobar ();\n}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function lotsOfArgs ()\n\tpublic\n\treturns (address) {\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function lotsOfArgs ()\n\tpublic\n\treturns (address)\t{\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function lotsOfArgs ()\n\tpublic\n\treturns (address)  {\n\tfoobar ();\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -569,37 +573,37 @@ describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject all short declarations whose opening brace is not on the same line as theirs', function (done) {
 		var code = 'contract Foo is Bar, Baz\n{}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'library Foo is Bar, Baz\n{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true)\n{} else if (true)\n{} else\n{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (3);
 
 		code = 'while (true)\n{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'for (;;)\n{}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function increment(uint x) public onlyowner returns (uint)\n{\n\treturn x + 1;\n}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -611,25 +615,25 @@ describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject clauses with empty statements', function (done) {
 		var code = 'if (true);',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {}\nelse;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true) {} else;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -641,25 +645,25 @@ describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject statements which are neither inside blocks nor completely reside on a single line', function (done) {
 		var code = 'if (true)\nPacman ({\n\tname: "Shannon"\n});',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {}\nelse\nPacman ({\n\tname: "Shannon"\n});';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true) {} else\nPacman ({\n\tname: "Shannon"\n});';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true)\nPacman ({\n\tname: "Shannon"\n});';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -671,25 +675,25 @@ describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject statements which exist on the same line as clause and are not brace-enclosed', function (done) {
 		var code = 'if (true) sayHello ();',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {}\nelse sayHello();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true) {} else sayHello();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {} else if (true) sayHello ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -701,37 +705,37 @@ describe ('[RULE] lbrace: Rejections', function () {
 
 	it ('should reject else clauses which are not on the same line as closing brace of if consequent', function (done) {
 		var code = 'if (true) {h();}\nelse if (true) {h();}\nelse {h();}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = 'if (true) {h();}\nelse {h();}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {h();}\nelse if (true) {h();}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {h();}\nelse if (true)\nhello ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {h();}\nelse if (true)\nhello ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'if (true) {h();}\nelse hello ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);

--- a/test/lib/rules/mixedcase/mixedcase.js
+++ b/test/lib/rules/mixedcase/mixedcase.js
@@ -6,6 +6,9 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
+var toFunction = wrappers.toFunction;
 
 var userConfig = {
   "custom-rules-filename": null,
@@ -29,6 +32,8 @@ describe ('[RULE] mixedcase: Acceptances', function () {
 			'function hello_ () {}'
 		];
 		var errors;
+
+		code = code.map(function(item){return toContract(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -84,6 +89,8 @@ describe ('[RULE] mixedcase: Acceptances', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toContract(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -137,6 +144,8 @@ describe ('[RULE] mixedcase: Acceptances', function () {
 			'var hello_;'
 		];
 		var errors;
+
+		code = code.map(function(item){return toFunction(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -192,6 +201,8 @@ describe ('[RULE] mixedcase: Acceptances', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toContract(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -234,7 +245,7 @@ describe ('[RULE] mixedcase: Acceptances', function () {
 
 	it ('should accept all valid function parameter names', function (done) {
 		var code = 'function foo (helloWorld, h, he, hE, _h, _hE, hello123World, _h123, hello_) {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -261,6 +272,8 @@ describe ('[RULE] mixedcase: Rejections', function () {
 			'function __ () {}'
 		];
 		var errors;
+
+		code = code.map(function(item){return toContract(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -316,6 +329,8 @@ describe ('[RULE] mixedcase: Rejections', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toContract(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -369,6 +384,8 @@ describe ('[RULE] mixedcase: Rejections', function () {
 			'var __;'
 		];
 		var errors;
+
+		code = code.map(function(item){return toFunction(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -424,6 +441,8 @@ describe ('[RULE] mixedcase: Rejections', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toContract(item)});
+
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -466,7 +485,7 @@ describe ('[RULE] mixedcase: Rejections', function () {
 
 	it ('should reject all invalid function parameter names', function (done) {
 		var code = 'function foo (uint _, uint _H, uint Hello, uint HELLOWORLD, uint hello_world, uint __h, uint hello$world, uint $helloWorld) {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (8);

--- a/test/lib/rules/no-empty-blocks/no-empty-blocks.js
+++ b/test/lib/rules/no-empty-blocks/no-empty-blocks.js
@@ -6,6 +6,10 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
+var toFunction = wrappers.toFunction;
+var addPragma = wrappers.addPragma;
 
 var userConfig = {
   "custom-rules-filename": null,
@@ -18,13 +22,13 @@ describe ('[RULE] no-empty-blocks: Acceptances', function () {
 
 	it ('should accept all non-empty contract & library statements', function (done) {
 		var code = 'contract Foo { event bar (); }',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'library Foo { event bar (); }';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -35,7 +39,7 @@ describe ('[RULE] no-empty-blocks: Acceptances', function () {
 
 	it ('should accept all non-empty function declarations', function (done) {
 		var code = 'function foo () { bar (); }',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -46,7 +50,7 @@ describe ('[RULE] no-empty-blocks: Acceptances', function () {
 
 	it ('should ACCEPT all EMPTY function declarations (see fallback functions)', function (done) {
 		var code = 'function foo () {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -57,7 +61,7 @@ describe ('[RULE] no-empty-blocks: Acceptances', function () {
 
 	it ('should accept all non-empty if-else declarations', function (done) {
 		var code = 'if (true) { foo (); } else { bar (); }',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -68,7 +72,7 @@ describe ('[RULE] no-empty-blocks: Acceptances', function () {
 
 	it ('should accept all non-empty for statements', function (done) {
 		var code = 'for (i = 0; i < 10; i++) { foo (); }',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -79,7 +83,7 @@ describe ('[RULE] no-empty-blocks: Acceptances', function () {
 
 	it ('should accept all non-empty do..while statements', function (done) {
 		var code = 'do { foo (); } while (i < 20);',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -90,7 +94,7 @@ describe ('[RULE] no-empty-blocks: Acceptances', function () {
 
 	it ('should accept all non-empty while statements', function (done) {
 		var code = 'while (i < 20) { bar (); }',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -106,13 +110,13 @@ describe ('[RULE] no-empty-blocks: Rejections', function () {
 
 	it ('should reject all empty contract & library statements', function (done) {
 		var code = 'contract Foo {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'library Foo {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -123,7 +127,7 @@ describe ('[RULE] no-empty-blocks: Rejections', function () {
 
 	it ('should reject all empty if-else declarations', function (done) {
 		var code = 'if (true) {} else {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
@@ -134,7 +138,7 @@ describe ('[RULE] no-empty-blocks: Rejections', function () {
 
 	it ('should reject all empty for statements', function (done) {
 		var code = 'for (i = 0; i < 10; i++) {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -145,7 +149,7 @@ describe ('[RULE] no-empty-blocks: Rejections', function () {
 
 	it ('should reject all empty do..while statements', function (done) {
 		var code = 'do {} while (i < 20);',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -156,7 +160,7 @@ describe ('[RULE] no-empty-blocks: Rejections', function () {
 
 	it ('should reject all empty while statements', function (done) {
 		var code = 'while (i < 20) {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);

--- a/test/lib/rules/no-unused-vars/no-unused-vars.js
+++ b/test/lib/rules/no-unused-vars/no-unused-vars.js
@@ -6,6 +6,9 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
+var toFunction = wrappers.toFunction;
 
 var userConfig = {
   "custom-rules-filename": null,
@@ -26,6 +29,8 @@ describe ('[RULE] no-unused-vars: Acceptances', function () {
 			'mapping (address => uint) x; function foo () returns (mapping) { return x; }'
 		];
 		var errors;
+
+		code = code.map(function(item){return toContract(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -69,6 +74,8 @@ describe ('[RULE] no-unused-vars: Rejections', function () {
 			'mapping (address => uint) x;'
 		];
 		var errors;
+
+		code = code.map(function(item){return toFunction(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');

--- a/test/lib/rules/operator-whitespace/operator-whitespace.js
+++ b/test/lib/rules/operator-whitespace/operator-whitespace.js
@@ -6,6 +6,9 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers')
+var toFunction = wrappers.toFunction;
+
 var userConfig = {
   "custom-rules-filename": null,
   "rules": {
@@ -37,6 +40,8 @@ describe ('[RULE] operator-whitespace: Acceptances', function () {
 			'1 + 8 - 67;'
 		];
 		var errors;
+
+		code = code.map(function(item){return toFunction(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -140,6 +145,8 @@ describe ('[RULE] operator-whitespace: Rejections', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toFunction(item)});
+		
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);

--- a/test/lib/rules/uppercase/uppercase.js
+++ b/test/lib/rules/uppercase/uppercase.js
@@ -6,6 +6,8 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
 
 var userConfig = {
   "custom-rules-filename": null,
@@ -24,6 +26,8 @@ describe ('[RULE] uppercase: Acceptances', function () {
 			'string constant HELLO = "dd";'
 		];
 		var errors;
+
+		code = code.map(function(item){return toContract(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -60,6 +64,8 @@ describe ('[RULE] uppercase: Rejections', function () {
 			'string constant H2O = "dd";'
 		];
 		var errors;
+
+		code = code.map(function(item){return toContract(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');

--- a/test/lib/rules/variable-declarations/variable-declarations.js
+++ b/test/lib/rules/variable-declarations/variable-declarations.js
@@ -6,6 +6,8 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toFunction = wrappers.toFunction;
 
 var userConfig = {
   "custom-rules-filename": null,
@@ -26,6 +28,8 @@ describe ('[RULE] variable-declarations: Rejections', function () {
 		];
 		var errors;
 
+		code = code.map(function(item){return toFunction(item)});
+		
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (3);

--- a/test/lib/rules/whitespace/whitespace.js
+++ b/test/lib/rules/whitespace/whitespace.js
@@ -6,6 +6,10 @@
 'use strict';
 
 var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toContract = wrappers.toContract;
+var toFunction = wrappers.toFunction;
+var addPragma = wrappers.addPragma;
 
 var userConfig = {
   "custom-rules-filename": null,
@@ -18,13 +22,13 @@ describe ('[RULE] whitespace: Acceptances', function () {
 
 	it ('should allow function / event calls with 0 args only if the name is followed by "()"', function (done) {
 		var code = 'func ();',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'foo.func ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -35,37 +39,37 @@ describe ('[RULE] whitespace: Acceptances', function () {
 
 	it ('should allow function / event calls with no extraneous whitespace', function (done) {
 		var code = 'spam(ham[1], Coin({name: "ham"}));',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'foo.bar (10, 20, 30);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'foo.bar (10, 20, 30);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'foo (10, 20).func ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'foo ["func ()"] ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'foo ["func (10, 20)"] ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -76,14 +80,14 @@ describe ('[RULE] whitespace: Acceptances', function () {
 
 	it ('should allow single-line function body to have 1 extraneous space on either side', function (done) {
 		var code = 'function singleLine() { spam(); }',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		//it is fine EVEN IF there is no extraneous space
 		code = 'function singleLine() {spam();}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -94,25 +98,25 @@ describe ('[RULE] whitespace: Acceptances', function () {
 
 	it ('should allow code which doesn\'t have whitespace immediately before a comma or semicolon', function (done) {
 		var code = 'function spam(uint i, Coin coin);',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'var foobar = "Hello World";';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'fooBar (baz ({\nhello: "world"\n}));';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'function foo (uint x, string y);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -123,31 +127,31 @@ describe ('[RULE] whitespace: Acceptances', function () {
 
 	it ('should allow exactly 1 space on either side of an assignment operator', function (done) {
 		var code = 'x = 100; y = "hello world"; string exa = "bytes";',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'x += 100; y *= 10; z -= 10;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'var x = 100;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'var (x, y, z) = (10, 20, 30);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'var (x, y, z) = fooBar ();';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -158,31 +162,31 @@ describe ('[RULE] whitespace: Acceptances', function () {
 
 	it ('should allow the code that provides nothing to check, i.e., no arguments in CallExpression / no properties in ObjectExpression', function (done) {
 		var code = 'call ();',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'call ({});';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = '[];';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'function foo () {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
 
 		code = 'if (true) {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (0);
@@ -198,37 +202,37 @@ describe ('[RULE] whitespace: Rejections', function () {
 
 	it ('should reject function / event calls with 0 args if the name is followed by brackets with whitespace between them', function (done) {
 		var code = 'func ( );',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'func (\t);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'func (\n);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'func (/**/);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'foo ["func ()"] ( );';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'foo ().func (\t);';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -239,19 +243,19 @@ describe ('[RULE] whitespace: Rejections', function () {
 
 	it ('should reject function / event calls with having extraneous whitespace', function (done) {
 		var code = 'spam( ham[ 1 ], Coin( { name: "ham" } ) );',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (8);
 
 		code = 'ham[/**/"1"/**/];';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = 'ham[\t"1"\t];';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
@@ -265,85 +269,85 @@ describe ('[RULE] whitespace: Rejections', function () {
 		// SEMICOLON
 
 		var code = 'function spam(uint i , Coin coin) ;',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		//errors.length.should.equal (2);
 
 		code = 'var foobar = 100 ;'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'var foobar = 100\n;'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'var foobar = 100\t;'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'var foobar = 100/*abc*/;'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function foo (uint x, string y) ;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function foo (uint x, string y)\t;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function foo (uint x, string y)\n;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'function foo (uint x, string y)/*abc*/;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'x [0] = fooBar () ;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'x [0] = fooBar ()/**/;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'import * as C from "chuh"/**/;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (addPragma(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'using Foo for *\t;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'using Foo for Bar.baz\t;';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toContract(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -354,25 +358,25 @@ describe ('[RULE] whitespace: Rejections', function () {
 		// COMMA
 
 		code = '[1 , 2, 3 , 4,5];',
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = 'call (10\t, 20, 30 ,40,50);',
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 		
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = 'call ({name: "foo"\n, age: 20,id: 1 ,dept: "math"})',
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 		
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = '(1 ,2\t,3\n,4);',
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 		
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (3);
@@ -403,6 +407,8 @@ describe ('[RULE] whitespace: Rejections', function () {
 			'var humpty\n="dumpty";'
 		];
 		var errors;
+
+		code = code.map(function(item){return toFunction(item)});
 
 		errors = Solium.lint (code [0], userConfig);
 		errors.constructor.name.should.equal ('Array');
@@ -445,37 +451,37 @@ describe ('[RULE] whitespace: Rejections', function () {
 		errors.length.should.equal (2);
 
 		code = 'var x\n=\n"hello world";'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = 'var x\t=\t"hello world";'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = 'var x = /*abc*/"hello world";'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'var x =/*abc*/ "hello world";'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'var x/*abc*/ = "hello world";'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'var x /*abc*/= "hello world";'
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
@@ -486,19 +492,19 @@ describe ('[RULE] whitespace: Rejections', function () {
 
 	it ('should reject control structures \'if\', \'while\', and \'for\' if there is no space between them and the parenthetic block representing their conditional.', function (done) {
 		var code = 'if(true) {}\nelse if(true) {}',
-			errors = Solium.lint (code, userConfig);
+			errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (2);
 
 		code = 'for(;;) {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);
 
 		code = 'while(true) {}';
-		errors = Solium.lint (code, userConfig);
+		errors = Solium.lint (toFunction(code), userConfig);
 
 		errors.constructor.name.should.equal ('Array');
 		errors.length.should.equal (1);

--- a/test/lib/utils/js-utils.js
+++ b/test/lib/utils/js-utils.js
@@ -5,7 +5,8 @@
 
 'use strict';
 
-var jsUtils = require ('../../../lib/utils/js-utils');
+var Solium = require ('../../../lib/solium'),
+	jsUtils = require('../../../lib/utils/js-utils');
 
 describe ('Test jsUtils functions', function () {
 
@@ -16,7 +17,7 @@ describe ('Test jsUtils functions', function () {
 		done ();
 	});
 
-	it ('should correctly classify whether argument is a non-array, non-null object', function (done) {
+	it ('isStrictlyObject: should correctly classify whether argument is a non-array, non-null object', function (done) {
 		var iso = jsUtils.isStrictlyObject;
 
 		iso ().should.equal (false);
@@ -29,5 +30,4 @@ describe ('Test jsUtils functions', function () {
 
 		done ();
 	});
-
 });

--- a/test/lib/utils/wrappers.js
+++ b/test/lib/utils/wrappers.js
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Tests for test/utils/wrappers.js
+ * @author cgewecke <christohergewecke@gmail.com>
+ */
+
+'use strict';
+
+var wrappers = require ('../../utils/wrappers'),
+    Solium = require ('../../../lib/solium');
+
+var userConfig = {
+    'custom-rules-filename': null,
+    rules: {}
+};
+
+describe ('Test wrappers', function () {
+
+    it ('should have a set of functions exposed as API', function (done) {
+        
+        wrappers.should.have.ownProperty ('toContract');
+        wrappers.toContract.should.be.type ('function');
+
+        wrappers.should.have.ownProperty ('toFunction');
+        wrappers.toFunction.should.be.type ('function');
+
+        wrappers.should.have.ownProperty ('addPragma');
+        wrappers.toFunction.should.be.type ('function');
+
+        done ();
+    });
+
+    it('toContract: should correctly wrap a solidity statement in contract code', function (done) {
+        var toContract = wrappers.toContract;
+        var statement = 'uint x = 1;'
+        var expected = 
+            'pragma solidity ^0.4.3;\n\n\n' +
+            'contract Wrap {\n' +
+            '\t' + statement + '\n' +
+            '}';
+
+        var errors = Solium.lint(expected, userConfig);
+        errors.constructor.name.should.equal ('Array');
+        errors.length.should.equal (0);
+        toContract(statement).should.equal(expected);
+
+        Solium.reset();
+        done ();
+    });
+
+    it('toFunction: should correctly wrap a solidity statement in contract/function code', function (done) {
+        var toFunction = wrappers.toFunction;
+        var statement = 'uint x = 1;'
+        var expected = 
+            'pragma solidity ^0.4.3;\n\n\n' +
+            'contract Wrap {\n' +
+            '\tfunction wrap() {\n' + 
+            '\t\t' + statement + '\n' +
+            '\t}\n' +
+            '}';
+
+        var errors = Solium.lint(expected, userConfig);
+        errors.constructor.name.should.equal ('Array');
+        errors.length.should.equal (0);
+        toFunction(statement).should.equal(expected);
+
+        Solium.reset();
+        done ();
+    });
+
+    it('addPragma: should correctly pre-pend a pragma statement to a solidity contract or library', function (done) {
+        var addPragma = wrappers.addPragma;
+        var contract = 'contract Abc { }'
+        var expected = 'pragma solidity ^0.4.3;\n\n\n' + contract;
+            
+        var errors = Solium.lint(expected, userConfig);
+        errors.constructor.name.should.equal ('Array');
+        errors.length.should.equal (0);
+        addPragma(contract).should.equal(expected);
+
+        Solium.reset();
+        done ();
+    });
+});

--- a/test/utils/wrappers.js
+++ b/test/utils/wrappers.js
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Utility functions to wrap solidity snippets with pragma, contract and/or 
+ * function code so they can be passed to solidity-parser without erroring. These allow
+ * the test cases to be presented in an easily legible form. 
+ * @author cgewecke <christophergewecke@gmail.com>
+ */
+
+module.exports = {
+    /**
+     * Wrap a solidity statement in valid contract boilerplate. 
+     * @param  {String} code Solidity snippet to wrap
+     * @return {String}      wrapped snippet
+     */
+    toContract: function (code) {
+        var pre = 'pragma solidity ^0.4.3;\n\n\ncontract Wrap {\n\t';
+        var post = '\n}';
+        return pre + code + post;
+    },
+
+    /**
+     * Wrap a solidity statement in valid contract and function boilerplate. 
+     * @param  {String} code Solidity snippet
+     * @return {String}      wrapped snippet
+     */
+    toFunction: function (code) {
+        var pre = 'pragma solidity ^0.4.3;\n\n\ncontract Wrap {\n\tfunction wrap() {\n\t\t';
+        var post = '\n\t}\n}';
+        return pre + code + post;
+    },
+
+    /**
+     * Prepend solidity contract / library with a pragma statement 
+     * @param  {String} code Solidity snippet
+     * @return {String}      snippet with pragma statement.
+     */
+    addPragma: function (code) {
+        var pre = 'pragma solidity ^0.4.3;\n\n\n';
+        return pre + code;
+    }
+}


### PR DESCRIPTION
This PR 
+ Adds three methods to the `js-utils` file that wrap in Solidity snippets in contract or contract / function boilerplate. 
+ Adds units tests for wrap methods
+ Wraps Solidity snippets in the `rules` unit tests.

Have left the `import`, `pragma`, and `with` rules untouched because those have their own issues with SP. 

This is a draft. If there's anything about the way this was done that could be improved please let me know and I will happily revise. And change whatever you want. 

I *think* I got everything in this sweep but it will be hard to know for sure until SP with your fixes is plugged in. 