### PR TITLE
Fix markdown formatting for GFM

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@ It internally uses [solparse](https://github.com/duaraghav8/solparse) to parse y
 
 Solium aims to comply with the official [Solidity Style Guide](http://solidity.readthedocs.io/en/latest/style-guide.html). Follow our [blog](https://medium.com/solium) in order to stay up to date with the latest news.
 
-#Install
+# Install
 ```bash
 npm install -g solium
 ```
 
-#Usage
+# Usage
 In the root directory of your DApp, run the following:
 ```bash
 solium --init
@@ -33,7 +33,7 @@ solium --dir .
 
 This lints all the files inside your project with ```.sol``` extension.
 
-#Additional Options
+# Additional Options
 
 1. Use ```solium --watch``` to enable Hot loading (Hot swapping).
 
@@ -43,7 +43,7 @@ This lints all the files inside your project with ```.sol``` extension.
 
 4. Use `solium --reporter=gcc` or `solium --reporter=pretty` to configure the output
 
-#Plugging in your custom rules
+# Plugging in your custom rules
 -> Open up the ```.soliumrc.json``` configuration file and set the value of ```custom-rules-filename``` to the path of the file that defines your rules. You can either provide an absolute path or a path relative to the directory in which .soliumrc.json resides. For example: ```"custom-rules-filename": "./my-rules.js"```
 
 The format for writing your custom rule file (for example, ```my-rules.js```) is:
@@ -97,13 +97,13 @@ See the [existing rules](https://github.com/duaraghav8/Solium/tree/master/lib/ru
 
 **NOTE**: If you write a rule whose name clashes with the name of a pre-defined rule, your custom rule overrides the pre-defined one.
 
-#Integrate Solium in your app
+# Integrate Solium in your app
 To access Solium's API, first install it:
 
 ```bash
 npm install --save solium
 ```
-##Usage
+## Usage
 ```js
 let Solium = require ('solium'),
   sourceCode = 'contract fOO_bar { function HELLO_WORLD () {} }';
@@ -124,22 +124,22 @@ errorObjects.forEach ( (err) => {
 
 For a list of all available rules, see [solium.json](https://github.com/duaraghav8/Solium/blob/master/config/solium.json).
 
-#Contributing
+# Contributing
 Please see the [Developer Guide](https://github.com/duaraghav8/Solium/blob/master/docs/DEVELOPER.md) to understand how to contribute rules to this repository.
 
-##Setup
+## Setup
 
 Clone the repository, traverse to the root directory of the project, then install dependencies:
 ```
 npm install
 ```
 
-##Running Tests
+## Running Tests
 ```
 npm test
 ```
 
-##Contributors and Testers
+## Contributors and Testers
 [Elena Dimitrova](https://github.com/elenadimitrova)
 
 [Federico Bond](https://github.com/federicobond)
@@ -148,5 +148,5 @@ npm test
 
 [Ulrich Petri](https://github.com/ulope)
 
-#License
-##MIT
+# License
+## MIT

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,4 +1,4 @@
-#Contributing rules to this repository
+# Contributing rules to this repository
 
 Ideally, you would want to write a rule that complies with the Solidity [Style Guide](http://solidity.readthedocs.io/en/latest/style-guide.html). However, if you feel that a certain rule is not mentioned in the guide or contradicts a rule mentioned in the guide but is crucial to the linter, please raise an Issue to discuss this rule. Once, finalized, you may proceed to develop the rule, test it, and make a PR.
 
@@ -130,12 +130,12 @@ Use ```Should.js``` to implement tests for your rule. Write code snippets of bot
 
 See the [existing rule tests](https://github.com/duaraghav8/Solium/tree/master/test/lib/rules) for a better understanding.
 
-##That's it!
+## That's it!
 Yep, you're done and ready to make a Pull Request.
 
 Hopefully, you didn't have much trouble following this guide. If you think it has some flaws or it could be improved in some way, please open up an issue.
 
-#Functions available to rule implementers
+# Functions available to rule implementers
 
 ```getText (node)``` - get source code for the specified node. If no arguments given, it returns the complete source code
 


### PR DESCRIPTION
Awesome tool! 

Just a small fix to make the docs more readable. [Github Flavored Markdown](https://help.github.com/articles/basic-writing-and-formatting-syntax/) appears to require a space between the `#` and the first character of the title string. 