### PR TITLE
Add the packaging metadata to build the solium snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: solium
+version: git
+summary: A customizable, stand-alone linter for Ethereum Solidity
+description: |
+  Solium is a linter for Solidity which uses Abstract Syntax Trees and allows
+  the user to enable/disable existing rules and add their own ones!
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict
+
+apps:
+  solium:
+    command: solium
+    plugs: [home, network]
+
+parts:
+  solium:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This package will let you publish the latest solium in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and more Linux distributions in progress. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.