### PR TITLE
Add tests for indentation rule

### DIFF
--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -243,7 +243,7 @@ module.exports = {
 				return;
 			}
 
-			//raise an error and stop linting if more than 3 attributes exist & declaration is on single line
+			// No need to lint further if entire struct declaration is on single line
 			if (sourceCode.getLine (node) === endingLineNum) {
 				return;
 			}
@@ -289,6 +289,7 @@ module.exports = {
 				return;
 			}
 
+			// No need to lint further if entire arary declaration is on single line
 			if (sourceCode.getLine (node) === endingLineNum) {
 				return;
 			}

--- a/test/lib/rules/indentation/accept/config-default.sol
+++ b/test/lib/rules/indentation/accept/config-default.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint public count;
+
+    function Counter() {
+        count = 0;
+    }
+
+    function inc() {
+        count++;
+    }
+}

--- a/test/lib/rules/indentation/accept/config-tabs.sol
+++ b/test/lib/rules/indentation/accept/config-tabs.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+	uint public count;
+
+	function Counter() {
+		count = 0;
+	}
+
+	function inc() {
+		count++;
+	}
+}

--- a/test/lib/rules/indentation/accept/config-two-spaces.sol
+++ b/test/lib/rules/indentation/accept/config-two-spaces.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+  uint public count;
+
+  function Counter() {
+    count = 0;
+  }
+
+  function inc() {
+    count++;
+  }
+}

--- a/test/lib/rules/indentation/accept/multiline-array.sol
+++ b/test/lib/rules/indentation/accept/multiline-array.sol
@@ -1,0 +1,19 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint public count;
+    uint[] public array;
+
+    function Counter() {
+        count = 0;
+        array = [
+            1,
+            2,
+            3
+        ];
+    }
+
+    function inc() {
+        count++;
+    }
+}

--- a/test/lib/rules/indentation/accept/multiline-call-declaration.sol
+++ b/test/lib/rules/indentation/accept/multiline-call-declaration.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint public count;
+
+    function Counter() {
+        count = 0;
+    }
+
+    function inc() {
+        count++;
+    }
+
+    function incBy(
+        uint n
+    ) {
+        count = count + n;
+    }
+
+    function incByTwo() {
+        incBy(
+            2
+        );
+    }
+}

--- a/test/lib/rules/indentation/accept/multiline-call-expression.sol
+++ b/test/lib/rules/indentation/accept/multiline-call-expression.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint public count;
+
+    function Counter() {
+        count = 0;
+    }
+
+    function inc() {
+        count++;
+    }
+
+    function incBy(uint n) {
+        count = count + n;
+    }
+
+    function incByTwo() {
+        incBy(
+            2
+        );
+    }
+}

--- a/test/lib/rules/indentation/accept/one-line-array.sol
+++ b/test/lib/rules/indentation/accept/one-line-array.sol
@@ -1,0 +1,3 @@
+contract Foo {
+    uint[] arr = [1,2];
+}

--- a/test/lib/rules/indentation/accept/one-line-function-call.sol
+++ b/test/lib/rules/indentation/accept/one-line-function-call.sol
@@ -1,0 +1,7 @@
+contract Foo {
+    function foo() {}
+
+    function bar() {
+        foo();
+    }
+}

--- a/test/lib/rules/indentation/accept/one-line-struct.sol
+++ b/test/lib/rules/indentation/accept/one-line-struct.sol
@@ -1,0 +1,3 @@
+contract Foo {
+    struct Bar { a uint; b char; }
+}

--- a/test/lib/rules/indentation/accept/struct.sol
+++ b/test/lib/rules/indentation/accept/struct.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.4;
+
+contract Foo {
+    uint public foo;
+
+    struct Bar {
+        string baz;
+        string qux;
+    }
+
+    function setFoo(uint _foo) {
+        foo = _foo;
+    }
+}

--- a/test/lib/rules/indentation/indentation.js
+++ b/test/lib/rules/indentation/indentation.js
@@ -145,8 +145,64 @@ describe ('[RULE] indentation: Acceptances', function () {
     Solium.reset ();
     done ();
   })
-});
 
+  it('should accept a file with a struct in one line', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'one-line-struct.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  })
+
+  it('should accept a file with an array in one line', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'one-line-array.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  })
+
+  it('should accept a file with a function call in one line', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'one-line-function-call.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  })
+});
 
 describe ('[RULE] indentation: Rejections', function () {
   it('should reject an invalid file under the default options', function (done) {
@@ -328,6 +384,25 @@ describe ('[RULE] indentation: Rejections', function () {
     };
 
     var file = 'chars-before-top-level.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (1);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject chars before top level declaration', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'indented-top-level-closing-brace.sol';
     var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
 
     var errors = Solium.lint (code, userConfig);

--- a/test/lib/rules/indentation/indentation.js
+++ b/test/lib/rules/indentation/indentation.js
@@ -1,0 +1,341 @@
+/**
+ * @fileoverview Tests for indentation rule
+ * @author Franco Victorio <victorio.franco@gmail.com>
+ */
+
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var Solium = require ('../../../../lib/solium');
+
+var acceptDir = path.join(__dirname, 'accept');
+var rejectDir = path.join(__dirname, 'reject');
+
+describe ('[RULE] indentation: Acceptances', function () {
+  it('should accept a valid file under the default options', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'config-default.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should accept a valid file with tabs', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": ["error", "tab"]
+      }
+    };
+
+    var file = 'config-tabs.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should accept a valid file with two spaces', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": ["error", 2]
+      }
+    };
+
+    var file = 'config-two-spaces.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should accept a file with a multiline array', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'multiline-array.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  })
+
+  it('should accept a file with a multiline call declaration', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'multiline-call-declaration.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  })
+
+  it('should accept a file with a multiline call expression', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'multiline-call-expression.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  })
+
+  it('should accept a file with a struct', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'struct.sol';
+    var code = fs.readFileSync(path.join(acceptDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (0);
+
+    Solium.reset ();
+    done ();
+  })
+});
+
+
+describe ('[RULE] indentation: Rejections', function () {
+  it('should reject an invalid file under the default options', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'config-default.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (7);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject an invalid file with tabs', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": ["error", "tab"]
+      }
+    };
+
+    var file = 'config-tabs.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (7);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject an invalid file with two spaces', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": ["error", 2]
+      }
+    };
+
+    var file = 'config-two-spaces.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (7);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject files with mixed tabs and spaces', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'mixed-tabs-spaces.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (1);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject an invalid file with a multiline array', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'multiline-array.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (8);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject an invalid file with a multiline call declaration', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'multiline-call-declaration.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (1);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject an invalid file with a multiline call expression', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'multiline-call-expression.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (1);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject an invalid file with a struct', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'struct.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (8);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject top level indentation', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'top-level-indent.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (1);
+
+    Solium.reset ();
+    done ();
+  });
+
+  it('should reject chars before top level declaration', function (done) {
+    var userConfig = {
+      "rules": {
+        "indentation": "error"
+      }
+    };
+
+    var file = 'chars-before-top-level.sol';
+    var code = fs.readFileSync(path.join(rejectDir, file), 'utf8');
+
+    var errors = Solium.lint (code, userConfig);
+
+    errors.constructor.name.should.equal ('Array');
+    errors.length.should.equal (1);
+
+    Solium.reset ();
+    done ();
+  });
+});

--- a/test/lib/rules/indentation/reject/chars-before-top-level.sol
+++ b/test/lib/rules/indentation/reject/chars-before-top-level.sol
@@ -1,0 +1,1 @@
+/**/contract Foo {}

--- a/test/lib/rules/indentation/reject/config-default.sol
+++ b/test/lib/rules/indentation/reject/config-default.sol
@@ -1,0 +1,35 @@
+pragma solidity ^0.4.4;
+
+contract Foo {
+    uint public a;
+    uint public b;
+    uint public c;
+
+    function singleLineWrong() {
+      a = 1;
+    }
+
+    function firstLineWrong() {
+      a = 1;
+        b = 2;
+        c = 3;
+    }
+
+    function secondLineWrong() {
+        a = 1;
+      b = 2;
+        c = 3;
+    }
+
+    function thirdLineWrong() {
+        a = 1;
+        b = 2;
+      c = 3;
+    }
+
+    function allLinesWrong() {
+      a = 1;
+      b = 2;
+      c = 3;
+    }
+}

--- a/test/lib/rules/indentation/reject/config-tabs.sol
+++ b/test/lib/rules/indentation/reject/config-tabs.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+		uint public count;
+
+		function Counter() {
+				count = 0;
+		}
+
+		function inc() {
+				count++;
+		}
+}

--- a/test/lib/rules/indentation/reject/config-two-spaces.sol
+++ b/test/lib/rules/indentation/reject/config-two-spaces.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint public count;
+
+    function Counter() {
+        count = 0;
+    }
+
+    function inc() {
+        count++;
+    }
+}

--- a/test/lib/rules/indentation/reject/indented-top-level-closing-brace.sol
+++ b/test/lib/rules/indentation/reject/indented-top-level-closing-brace.sol
@@ -1,0 +1,2 @@
+contract Foo {
+    }

--- a/test/lib/rules/indentation/reject/mixed-tabs-spaces.sol
+++ b/test/lib/rules/indentation/reject/mixed-tabs-spaces.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+	uint public count;
+
+    function Counter() {
+        count = 0;
+    }
+
+    function inc() {
+        count++;
+    }
+}

--- a/test/lib/rules/indentation/reject/multiline-array.sol
+++ b/test/lib/rules/indentation/reject/multiline-array.sol
@@ -1,0 +1,45 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint[] public array;
+
+    function allItemsWrong() {
+        array = [
+          1,
+          2,
+          3
+        ];
+    }
+
+    function firstItemWrong() {
+        array = [
+          1,
+            2,
+            3
+        ];
+    }
+
+    function secondItemWrong() {
+        array = [
+            1,
+          2,
+            3
+        ];
+    }
+
+    function thirdItemWrong() {
+        array = [
+            1,
+            2,
+          3
+        ];
+    }
+
+    function wholeLineWrong() {
+      array = [
+          1,
+          2,
+          3
+      ];
+    }
+}

--- a/test/lib/rules/indentation/reject/multiline-call-declaration.sol
+++ b/test/lib/rules/indentation/reject/multiline-call-declaration.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint public count;
+
+    function Counter() {
+        count = 0;
+    }
+
+    function inc() {
+        count++;
+    }
+
+    function incBy(
+      uint n
+    ) {
+        count = count + n;
+    }
+
+    function incByTwo() {
+        incBy(
+            2
+        );
+    }
+}

--- a/test/lib/rules/indentation/reject/multiline-call-expression.sol
+++ b/test/lib/rules/indentation/reject/multiline-call-expression.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.4;
+
+contract Counter {
+    uint public count;
+
+    function Counter() {
+        count = 0;
+    }
+
+    function inc() {
+        count++;
+    }
+
+    function incBy(uint n) {
+        count = count + n;
+    }
+
+    function incByTwo() {
+        incBy(
+          2
+        );
+    }
+}

--- a/test/lib/rules/indentation/reject/struct.sol
+++ b/test/lib/rules/indentation/reject/struct.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.4.4;
+
+contract Foo {
+    uint public foo;
+
+    struct FirstLineWrong {
+      string baz;
+        string qux;
+        string quux;
+    }
+
+    struct SecondLineWrong {
+        string baz;
+      string qux;
+        string quux;
+    }
+
+    struct ThirdLineWrong {
+        string baz;
+        string qux;
+      string quux;
+    }
+
+    struct AllLinesWrong {
+      string baz;
+      string qux;
+      string quux;
+    }
+
+  struct WholeDeclarationWrong {
+    string baz;
+    string qux;
+    string quux;
+  }
+
+    function setFoo(uint _foo) {
+        foo = _foo;
+    }
+}

--- a/test/lib/rules/indentation/reject/top-level-indent.sol
+++ b/test/lib/rules/indentation/reject/top-level-indent.sol
@@ -1,0 +1,1 @@
+    contract Foo {}


### PR DESCRIPTION
This increases the coverage of `rules/indentation.js` to 95% of the statements and 85% of the branches. There are several branches that I didn't cover because I didn't fully understand the scenario they were handling. I'll add comments to those parts of the code and maybe you can give me some insight so that I can create the proper fixtures.