### PR TITLE
added lint rule that allows only max one break per while/for/do loop

### DIFF
--- a/config/rulesets/solium-all.js
+++ b/config/rulesets/solium-all.js
@@ -27,6 +27,7 @@ module.exports = {
 		'comma-whitespace': 'error',
 		'conditionals-whitespace': 'error',
 		'operator-whitespace': 'error',
+		'max-one-break-per-loop': 'error',
 		'deprecated-suicide': 'warning',
 		'pragma-on-top': 'warning',
 		'quotes': 'error',

--- a/config/solium.json
+++ b/config/solium.json
@@ -106,6 +106,13 @@
 			"description": "Flag all the variables that were declared but never used"
 		},
 
+		"max-one-break-per-loop": {
+			"enabled": true,
+			"recommended": true,
+			"type": "error",
+			"description": "Flag all loops which contain two or more break statements"
+		},
+
 		"double-quotes": {
 			"enabled": true,
 			"recommended": true,

--- a/lib/rules/max-one-break-per-loop.js
+++ b/lib/rules/max-one-break-per-loop.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Flags any loops which contain two or more break statements
+ * @author Artem Litchmanov <artem.litchmanov@gmail.com>
+ */
+
+'use strict';
+
+module.exports = {
+
+    meta: {
+
+        docs: {
+            recommended: true,
+            type: 'error',
+            description: 'Flag all loops which contain two or more break statements'
+        },
+
+        schema: []
+
+    },
+
+    create: function (context) {
+
+        var allBreakStatementDeclarations = 0;
+
+        function inspectBreakStatement(emitted) {
+
+            if (!emitted.exit) {
+                allBreakStatementDeclarations += 1;
+            }
+        }
+
+        //While exiting for loop Node, Report if Break statement declarations is more than 1
+        function inspectLoopStatement(emitted) {
+            var node = emitted.node;
+            if (emitted.exit) {
+                if (allBreakStatementDeclarations > 1) {
+                    context.report({
+                        node: node,
+                        message: 'Loop contains too many breaks.'
+                    });
+                }
+            } else {
+                // reset the count for break statements when entering the loop
+                allBreakStatementDeclarations = 0;
+            }
+        }
+
+        return {
+            ForStatement: inspectLoopStatement,
+            WhileStatement: inspectLoopStatement,
+            DoWhileStatement: inspectLoopStatement,
+            BreakStatement: inspectBreakStatement,
+        };
+
+    }
+
+};

--- a/test/lib/rules.js
+++ b/test/lib/rules.js
@@ -212,7 +212,7 @@ describe ('Checking exported rules object', function () {
 		// We extend ALL solium core rules and eliminate a few by setting their severity to 0.
 		// The rest of the rules should all be available.
 		// The below count will keep changing with every change in the number of core rules that exist in solium.
-		Object.keys (ruleDescriptions).length.should.equal (19);
+		Object.keys (ruleDescriptions).length.should.equal (20);
 
 		done ();
 	});

--- a/test/lib/rules/max-one-break-per-loop/max-one-break-per-loop.js
+++ b/test/lib/rules/max-one-break-per-loop/max-one-break-per-loop.js
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Tests for max-one-break-per-loop rule
+ * @author Artem Litchmanov <artem.litchmanov@gmail.com>
+ */
+
+'use strict';
+
+var Solium = require ('../../../../lib/solium');
+var wrappers = require ('../../../utils/wrappers');
+var toFunction = wrappers.toFunction;
+
+var userConfig = {
+    "custom-rules-filename": null,
+    "rules": {
+        "max-one-break-per-loop": true
+    }
+};
+
+describe ('[RULE] max-one-break-per-loop: Acceptances', function () {
+
+    it ('should accept all loops that have one or less breaks in them', function (done) {
+        var code = [
+            'for(uint i = 0; i<10; i++) {break;}',
+            'for(uint i = 0; i < 10; i++) { uint x=1; }',
+            'while(true) {break;}',
+            'while(x!=1) { x=1; }',
+            'do { foo (); } while (i < 20);',
+            'do { break; } while (i < 20);',
+            'if(1=1){break;} do { break; } while (i < 20);',
+        ];
+        var errors;
+
+        code = code.map(function(item){return toFunction(item)});
+
+        errors = Solium.lint (code [0], userConfig);
+        errors.length.should.equal (0);
+        errors = Solium.lint (code [1], userConfig);
+        errors.length.should.equal (0);
+        errors = Solium.lint (code [2], userConfig);
+        errors.length.should.equal (0);
+        errors = Solium.lint (code [3], userConfig);
+        errors.length.should.equal (0);
+        errors = Solium.lint (code [4], userConfig);
+        errors.length.should.equal (0);
+        errors = Solium.lint (code [5], userConfig);
+        errors.length.should.equal (0);
+        errors = Solium.lint (code [6], userConfig);
+        errors.length.should.equal (0);
+        Solium.reset ();
+        done ();
+    });
+});
+
+
+describe ('[RULE] max-one-break-per-loop: Rejections', function () {
+
+    it ('should reject all loops that have two or more breaks in them', function (done) {
+        var code = [
+            'for(uint i = 0; i<10; i++) {break; break;}',
+            'for(uint i = 0; i < 10; i++) { uint x=1; if(x=1){break;} if(x=2){break;} }',
+            'while(true) {break;break;}',
+            'while(x!=1) { x=1; if(x=1){break;} if(x=2){break;} if(x=3){break;} }',
+            'do { break; break; } while (i < 20);',
+            'do { if(x=1){break;} if(x=2){break;} if(x=3){break;} } while (i < 20);',
+        ];
+        var errors;
+
+        code = code.map(function(item){return toFunction(item)});
+
+        errors = Solium.lint (code [0], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code [1], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code [2], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code [3], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code [4], userConfig);
+        errors.length.should.equal (1);
+        errors = Solium.lint (code [5], userConfig);
+        errors.length.should.equal (1);
+        Solium.reset ();
+        done ();
+    });
+});


### PR DESCRIPTION
As requested on https://augur.net/bounties/. Added a lint rule to flag for/while/do loops which contain too many break statements. 