### PR TITLE
mixedcase: check state variable declarations

### DIFF
--- a/lib/rules/mixedcase.js
+++ b/lib/rules/mixedcase.js
@@ -68,7 +68,7 @@ module.exports = {
             }
         }
 
-        function inspectDeclarativeExpression(emitted) {
+        function inspectDeclaration(emitted) {
             let node = emitted.node;
 
             if (emitted.exit) {
@@ -100,7 +100,8 @@ module.exports = {
 
         let response = {
             InformalParameter: inspectInformalParameter,
-            DeclarativeExpression: inspectDeclarativeExpression,
+            StateVariableDeclaration: inspectDeclaration,
+            DeclarativeExpression: inspectDeclaration,
             VariableDeclarator: inspectVariableDeclarator
         };
 
@@ -109,7 +110,7 @@ module.exports = {
         });
 
         return response;
-		
+
     }
 
 };

--- a/test/lib/rules/mixedcase/mixedcase.js
+++ b/test/lib/rules/mixedcase/mixedcase.js
@@ -481,7 +481,7 @@ describe("[RULE] mixedcase: Rejections", function() {
         ];
         let errors;
 
-        code = code.map(function(item){return toFunction(item);});
+        code = code.map(function(item){return toContract(item);});
 
         errors = Solium.lint(code [0], userConfig);
         errors.constructor.name.should.equal("Array");


### PR DESCRIPTION
The problem here was that the tests `should reject all invalid variable declarations` and `should reject all invalid declarative expressions` were both checking the same thing, so all the tests passed without noticing the state variable case.

closes #181 
