### PR TITLE
Adds --debug option that allows to print a stacktrace

### DIFF
--- a/config/schemas/config.js
+++ b/config/schemas/config.js
@@ -76,6 +76,7 @@ let Schema = {
             type: "object",
             properties: {
                 autofix: { type: "boolean" },
+                debug: { type: "boolean" },
                 returnInternalIssues: { type: "boolean" }
             },
             additionalProperties: false

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -102,9 +102,10 @@ function lintString(sourceCode, userConfig, errorReporter, fileName) {
     } catch (e) {
         // Don't abort in case of a parse error, just report it as a normal lint issue.
         if (e.name !== "SyntaxError") {
-            errorReporter.reportFatal(`An error occurred while linting over ${fileName}: ${e.message}`);
             if (userConfig.options.debug) {
                 errorReporter.reportFatal(e.stack);
+            } else {
+                errorReporter.reportFatal(`An error occurred while linting over ${fileName}: ${e.message}`);
             }
             process.exit(errorCodes.ERRORS_FOUND);
         }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -103,6 +103,9 @@ function lintString(sourceCode, userConfig, errorReporter, fileName) {
         // Don't abort in case of a parse error, just report it as a normal lint issue.
         if (e.name !== "SyntaxError") {
             errorReporter.reportFatal(`An error occurred while linting over ${fileName}: ${e.message}`);
+            if (userConfig.options.debug) {
+                errorReporter.reportFatal(e.stack);
+            }
             process.exit(errorCodes.ERRORS_FOUND);
         }
 
@@ -211,6 +214,7 @@ function createCliOptions(cliObject) {
         .option("-c, --config [path]", "Path to the .soliumrc configuration file")
         .option("-, --stdin", "Read input file from stdin")
         .option("--fix", "Fix Lint issues where possible")
+        .option("--debug", "Display debug information")
         .option("--watch", "Watch for file changes")
         .option("--hot", "(Deprecated) Same as --watch");
 }
@@ -255,11 +259,11 @@ function execute(programArgs) {
     }
 
     /**
-	 * If cli.config option is NOT specified, then resort to .soliumrc in current dir.
-	 * Else,
-	 *   If path is absolute, assign as-it-is.
-	 *   Else (relative pathing) join path with current dir.
-	 */
+     * If cli.config option is NOT specified, then resort to .soliumrc in current dir.
+     * Else,
+     *   If path is absolute, assign as-it-is.
+     *   Else (relative pathing) join path with current dir.
+     */
     const soliumrcAbsPath = cli.config ?
         (path.isAbsolute(cli.config) ? cli.config : path.join(CWD, cli.config)) :
         SOLIUMRC_FILENAME_ABSOLUTE;
@@ -284,7 +288,7 @@ function execute(programArgs) {
     //if custom rules' file is set, make sure we have its absolute path
     if (
         userConfig ["custom-rules-filename"] &&
-		!path.isAbsolute(userConfig ["custom-rules-filename"])
+        !path.isAbsolute(userConfig ["custom-rules-filename"])
     ) {
         userConfig ["custom-rules-filename"] = path.join(
             CWD, userConfig ["custom-rules-filename"]
@@ -292,7 +296,10 @@ function execute(programArgs) {
     }
 
     // Pass cli arguments that modify the behaviour of upstream functions.
-    userConfig.options = { autofix: Boolean(cli.fix) };
+    userConfig.options = {
+        autofix: Boolean(cli.fix),
+        debug: Boolean(cli.debug)
+    };
 
     //get all files & folders to ignore from .soliumignore
     try {

--- a/lib/reporters/pretty.js
+++ b/lib/reporters/pretty.js
@@ -34,7 +34,6 @@ module.exports = {
             (`\u2716 [Fatal error] ${message}\n`)[colorInternalIssue("error")]);
     },
 
-
     report(filename, sourceCode, lintErrors, fixesApplied) {
         // Remove internal issue, so only rule errors reach the next loop
         lintErrors.forEach((issue, index) => {


### PR DESCRIPTION
It prints a stacktrace and it looks like this:

![image](https://user-images.githubusercontent.com/592286/38440456-66ddb392-39d9-11e8-9454-17670f268fdc.png)

I am not sure about the design though. Does it align with your vision of the `userConfig` object and reporters?