### PR TITLE
Fix function-order rule

### DIFF
--- a/lib/rules/function-order.js
+++ b/lib/rules/function-order.js
@@ -11,7 +11,7 @@ const functionOrder = ["constructor", "fallback", "external", "public", "interna
 
 
 function findFuncPosInOrder(contractNode, funcNode) {
-    if (funcNode.name === contractNode.name) {
+    if (funcNode.name === contractNode.name || funcNode.name === "constructor") {
         return functionOrder.indexOf("constructor");
     }
 

--- a/test/lib/rules/function-order/function-order.js
+++ b/test/lib/rules/function-order/function-order.js
@@ -131,6 +131,16 @@ describe("[RULE] function-order: Acceptances", function() {
 			}
 		`);
 
+        codes.push(`
+			contract Foo {
+				function constructor() {}
+				string myName = "Hello";
+				function() {}
+
+				function a() private {}
+			}
+		`);
+
         codes.forEach(code => {
             const errors = Solium.lint(code, userConfig);
             errors.should.be.Array();


### PR DESCRIPTION
Fix that function-order rule is not accepting the new constructor syntax introduced in solidity 4.22

Hey. I had problems with the new constructor syntax. Because it was a small issue, I wrote a fix. Let me know if something is missing. 