### PR TITLE
Improved codebase formatting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,13 @@
 module.exports = {
+    "plugins": ["prettier"],
     "env": {
         "browser": true,
         "commonjs": true,
         "es6": true
     },
-    "extends": "eslint:recommended",
+    "extends": "prettier",
     "rules": {
+        "prettier/prettier": "error",
         "indent": [
             "error",
             4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+package.json
+package-lock.json

--- a/config/rulesets/solium-all.js
+++ b/config/rulesets/solium-all.js
@@ -6,42 +6,40 @@
 "use strict";
 
 module.exports = {
+  rules: {
+    "imports-on-top": "error",
+    "variable-declarations": "error",
+    "array-declarations": "error",
+    "operator-whitespace": "error",
+    lbrace: "error",
+    "function-whitespace": "error",
+    "semicolon-whitespace": "error",
+    "comma-whitespace": "error",
+    "conditionals-whitespace": "error",
+    "value-in-payable": "error",
+    "no-unused-vars": "error",
+    quotes: "error",
 
-    rules: {
-        "imports-on-top": "error",
-        "variable-declarations": "error",
-        "array-declarations": "error",
-        "operator-whitespace": "error",
-        "lbrace": "error",
-        "function-whitespace": "error",
-        "semicolon-whitespace": "error",
-        "comma-whitespace": "error",
-        "conditionals-whitespace": "error",
-        "value-in-payable": "error",
-        "no-unused-vars": "error",
-        "quotes": "error",
+    mixedcase: "warning",
+    camelcase: "warning",
+    uppercase: "warning",
+    "no-empty-blocks": "warning",
+    "blank-lines": "warning",
+    indentation: "warning",
+    "arg-overflow": "warning",
+    whitespace: "warning",
+    "deprecated-suicide": "warning",
+    "pragma-on-top": "warning",
+    "function-order": "warning",
+    emit: "warning",
+    "no-constant": "warning",
+    "no-experimental": "warning",
+    "max-len": "warning",
+    "error-reason": "warning",
+    "visibility-first": "warning",
 
-        "mixedcase": "warning",
-        "camelcase": "warning",
-        "uppercase": "warning",
-        "no-empty-blocks": "warning",
-        "blank-lines": "warning",
-        "indentation": "warning",
-        "arg-overflow": "warning",
-        "whitespace": "warning",
-        "deprecated-suicide": "warning",
-        "pragma-on-top": "warning",
-        "function-order": "warning",
-        "emit": "warning",
-        "no-constant": "warning",
-        "no-experimental": "warning",
-        "max-len": "warning",
-        "error-reason": "warning",
-        "visibility-first": "warning",
-
-        // Turn OFF all deprecated rules
-        "double-quotes": "off",
-        "no-with": "off"
-    }
-
+    // Turn OFF all deprecated rules
+    "double-quotes": "off",
+    "no-with": "off"
+  }
 };

--- a/config/rulesets/solium-recommended.js
+++ b/config/rulesets/solium-recommended.js
@@ -6,43 +6,41 @@
 "use strict";
 
 module.exports = {
+  rules: {
+    "imports-on-top": "error",
+    "variable-declarations": "error",
+    "array-declarations": "error",
+    "no-unused-vars": "error",
+    quotes: "error",
+    "value-in-payable": "error",
 
-    rules: {
-        "imports-on-top": "error",
-        "variable-declarations": "error",
-        "array-declarations": "error",
-        "no-unused-vars": "error",
-        "quotes": "error",
-        "value-in-payable": "error",
+    "no-empty-blocks": "warning",
+    indentation: "warning",
+    whitespace: "warning",
+    "deprecated-suicide": "warning",
+    "pragma-on-top": "warning",
+    "function-whitespace": "warning",
+    "semicolon-whitespace": "warning",
+    "comma-whitespace": "warning",
+    "operator-whitespace": "warning",
+    emit: "warning",
+    "no-constant": "warning",
+    "max-len": "warning",
+    "error-reason": "warning",
+    "visibility-first": "warning",
 
-        "no-empty-blocks": "warning",
-        "indentation": "warning",
-        "whitespace": "warning",
-        "deprecated-suicide": "warning",
-        "pragma-on-top": "warning",
-        "function-whitespace": "warning",
-        "semicolon-whitespace": "warning",
-        "comma-whitespace": "warning",
-        "operator-whitespace": "warning",
-        "emit": "warning",
-        "no-constant": "warning",
-        "max-len": "warning",
-        "error-reason": "warning",
-        "visibility-first": "warning",
+    lbrace: "off",
+    mixedcase: "off",
+    camelcase: "off",
+    uppercase: "off",
+    "blank-lines": "off",
+    "arg-overflow": "off",
+    "function-order": "off",
+    "conditionals-whitespace": "off",
+    "no-experimental": "off",
 
-        "lbrace": "off",
-        "mixedcase": "off",
-        "camelcase": "off",
-        "uppercase": "off",
-        "blank-lines": "off",
-        "arg-overflow": "off",
-        "function-order": "off",
-        "conditionals-whitespace": "off",
-        "no-experimental": "off",
-
-        // Disable deprecated rules
-        "double-quotes": "off",
-        "no-with": "off"
-    }
-
+    // Disable deprecated rules
+    "double-quotes": "off",
+    "no-with": "off"
+  }
 };

--- a/config/schemas/ast-node.js
+++ b/config/schemas/ast-node.js
@@ -17,29 +17,30 @@
 }
 */
 
-let array = { type: "array" }, number = { type: "number" }, bool = { type: "boolean" },
-    string = { type: "string" }, object = { type: "object" }, attrNull = { type: "null" };
+let array = { type: "array" },
+  number = { type: "number" },
+  bool = { type: "boolean" },
+  string = { type: "string" },
+  object = { type: "object" },
+  attrNull = { type: "null" };
 
 let Schema = {
+  type: "object",
 
-    type: "object",
+  properties: {
+    type: { type: "string", minLength: 1 },
+    start: { type: "integer", minimum: 0 },
+    end: { type: "integer", minimum: 0 }
+  },
 
-    properties: {
-        type: { type: "string", minLength: 1 },
-        start: { type: "integer", minimum: 0 },
-        end: { type: "integer", minimum: 0 }
-    },
+  patternProperties: {
+    "^.+$": {
+      oneOf: [array, string, object, number, attrNull, bool]
+    }
+  },
 
-    patternProperties: {
-        "^.+$": {
-            oneOf: [array, string, object, number, attrNull, bool]
-        }
-    },
-
-    required: ["type", "start", "end"],
-    additionalProperties: false
-
+  required: ["type", "start", "end"],
+  additionalProperties: false
 };
-
 
 module.exports = Schema;

--- a/config/schemas/config.js
+++ b/config/schemas/config.js
@@ -32,60 +32,58 @@
 "use strict";
 
 let severityString = { type: "string", enum: ["off", "warning", "error"] },
-    severityInt = { type: "integer", minimum: 0, maximum: 2 },
-    severityArray = {
-        type: "array",
-        minItems: 1,
-        items: [{ oneOf: [severityString, severityInt] }]
-    };
+  severityInt = { type: "integer", minimum: 0, maximum: 2 },
+  severityArray = {
+    type: "array",
+    minItems: 1,
+    items: [{ oneOf: [severityString, severityInt] }]
+  };
 
 let Schema = {
-    type: "object",
+  type: "object",
 
-    anyOf: [
-        { required: ["extends"] },
-        { required: ["rules"] },
-        { required: ["plugins"] }
-    ],
+  anyOf: [
+    { required: ["extends"] },
+    { required: ["rules"] },
+    { required: ["plugins"] }
+  ],
 
-    properties: {
-
-        plugins: {
-            type: "array",
-            items: {
-                type: "string", minLength: 1
-            }
-        },
-
-        extends: {
-            type: "string",
-            minLength: 1
-        },
-
-        rules: {
-            type: "object",
-            patternProperties: {
-                "^.+$": {
-                    oneOf: [severityString, severityInt, severityArray]
-                }
-            },
-            additionalProperties: false
-        },
-
-        options: {
-            type: "object",
-            properties: {
-                autofix: { type: "boolean" },
-                debug: { type: "boolean" },
-                returnInternalIssues: { type: "boolean" }
-            },
-            additionalProperties: false
-        }
-
+  properties: {
+    plugins: {
+      type: "array",
+      items: {
+        type: "string",
+        minLength: 1
+      }
     },
 
-    additionalProperties: false
-};
+    extends: {
+      type: "string",
+      minLength: 1
+    },
 
+    rules: {
+      type: "object",
+      patternProperties: {
+        "^.+$": {
+          oneOf: [severityString, severityInt, severityArray]
+        }
+      },
+      additionalProperties: false
+    },
+
+    options: {
+      type: "object",
+      properties: {
+        autofix: { type: "boolean" },
+        debug: { type: "boolean" },
+        returnInternalIssues: { type: "boolean" }
+      },
+      additionalProperties: false
+    }
+  },
+
+  additionalProperties: false
+};
 
 module.exports = Schema;

--- a/config/schemas/core-rule-response.js
+++ b/config/schemas/core-rule-response.js
@@ -21,16 +21,15 @@
 let SchemaValidator = require("./core-rule").SchemaValidator;
 
 let Schema = {
-    type: "object",
+  type: "object",
 
-    patternProperties: {
-        "^.+$": {
-            shouldBeOfTypeFunction: true	// This custom attribute is defined in SchemaValidator of ./core-rule.js
-        }
-    },
+  patternProperties: {
+    "^.+$": {
+      shouldBeOfTypeFunction: true // This custom attribute is defined in SchemaValidator of ./core-rule.js
+    }
+  },
 
-    additionalProperties: false
+  additionalProperties: false
 };
-
 
 module.exports = { Schema: Schema, SchemaValidator: SchemaValidator };

--- a/config/schemas/core-rule.js
+++ b/config/schemas/core-rule.js
@@ -31,63 +31,58 @@
 */
 
 let Ajv = require("ajv"),
-    SchemaValidator = new Ajv({ allErrors: true });
+  SchemaValidator = new Ajv({ allErrors: true });
 
 // If this constraint is set to true on any attribute, then that attribute MUST be of type function. If set to false, attr MUST NOT be a function.
 SchemaValidator.addKeyword("shouldBeOfTypeFunction", {
-    validate: function(isSet, attr) {
-        return isSet === (typeof attr === "function");
-    }
+  validate: function(isSet, attr) {
+    return isSet === (typeof attr === "function");
+  }
 });
 
-
 let Schema = {
-    type: "object",
+  type: "object",
 
-    properties: {
+  properties: {
+    meta: {
+      type: "object",
+      properties: {
+        docs: {
+          type: "object",
+          properties: {
+            recommended: { type: "boolean" },
+            type: { type: "string", enum: ["error", "warning", "off"] },
+            description: { type: "string", minLength: 1 },
 
-        meta: {
-            type: "object",
-            properties: {
-
-                docs: {
-                    type: "object",
-                    properties: {
-                        recommended: { type: "boolean" },
-                        type: { type: "string", enum: ["error", "warning", "off"] },
-                        description: { type: "string", minLength: 1 },
-
-                        replacedBy: {
-                            type: "array",
-                            minItems: 1,
-                            items: { type: "string", minLength: 1 }
-                        }
-                    },
-                    required: ["recommended", "type", "description"]
-                },
-
-                schema: { type: "array", items: { type: "object" } },
-
-                fixable: {
-                    type: "string", enum: ["code", "whitespace"]
-                },
-
-                deprecated: { type: "boolean" }
-
-            },
-            required: ["docs", "schema"]
+            replacedBy: {
+              type: "array",
+              minItems: 1,
+              items: { type: "string", minLength: 1 }
+            }
+          },
+          required: ["recommended", "type", "description"]
         },
 
-        create: {
-            shouldBeOfTypeFunction: true
-        }
+        schema: { type: "array", items: { type: "object" } },
 
+        fixable: {
+          type: "string",
+          enum: ["code", "whitespace"]
+        },
+
+        deprecated: { type: "boolean" }
+      },
+      required: ["docs", "schema"]
     },
 
-    required: ["meta", "create"],
+    create: {
+      shouldBeOfTypeFunction: true
+    }
+  },
 
-    additionalProperties: false
+  required: ["meta", "create"],
+
+  additionalProperties: false
 };
-
 
 module.exports = { Schema: Schema, SchemaValidator: SchemaValidator };

--- a/config/schemas/deprecated/config-v0.5.5.js
+++ b/config/schemas/deprecated/config-v0.5.5.js
@@ -20,31 +20,27 @@ let optionsSchema = require("../config").properties.options;
 */
 
 let Schema = {
-    type: "object",
+  type: "object",
 
-    properties: {
-        "custom-rules-filename": {
-            oneOf: [
-                { type: "string", minLength: 1 },
-                { type: "null" }
-            ]
-        },
-
-        rules: {
-            type: "object",
-            patternProperties: {
-                "^.+$": { type: "boolean" }
-            },
-            additionalProperties: false
-        },
-
-        options: optionsSchema
+  properties: {
+    "custom-rules-filename": {
+      oneOf: [{ type: "string", minLength: 1 }, { type: "null" }]
     },
 
-    required: ["rules"],
+    rules: {
+      type: "object",
+      patternProperties: {
+        "^.+$": { type: "boolean" }
+      },
+      additionalProperties: false
+    },
 
-    additionalProperties: false
+    options: optionsSchema
+  },
+
+  required: ["rules"],
+
+  additionalProperties: false
 };
-
 
 module.exports = Schema;

--- a/config/schemas/error-reported-by-rule.js
+++ b/config/schemas/error-reported-by-rule.js
@@ -27,41 +27,36 @@
 */
 
 let Ajv = require("ajv"),
-    astNode = require("./ast-node"),
-    SchemaValidator = new Ajv({ allErrors: true });
-
+  astNode = require("./ast-node"),
+  SchemaValidator = new Ajv({ allErrors: true });
 
 SchemaValidator.addKeyword("shouldBeOfTypeFunction", {
-    validate: function(isSet, attr) {
-        return isSet === (typeof attr === "function");
-    }
+  validate: function(isSet, attr) {
+    return isSet === (typeof attr === "function");
+  }
 });
 
 let Schema = {
+  type: "object",
+  properties: {
+    message: { type: "string", minLength: 1 },
+    node: astNode,
+    fix: { shouldBeOfTypeFunction: true },
+    location: {
+      type: "object",
+      properties: {
+        line: { type: "integer", minimum: 1 }, // line starts from 1
+        column: { type: "integer", minimum: 0 } // column starts from 0
+      },
+      additionalProperties: false
+    }
+  },
 
-    type: "object",
-    properties: {
-
-        message: { type: "string", minLength: 1 },
-        node: astNode,
-        fix: { shouldBeOfTypeFunction: true },
-        location: {
-            type: "object",
-            properties: {
-                line: { type: "integer", minimum: 1 },	// line starts from 1
-                column: { type: "integer", minimum: 0 }	// column starts from 0
-            },
-            additionalProperties: false
-        }
-
-    },
-
-    required: ["message", "node"],
-    additionalProperties: false
-
+  required: ["message", "node"],
+  additionalProperties: false
 };
 
-
 module.exports = {
-    schema: Schema, validationFunc: SchemaValidator.compile(Schema)
+  schema: Schema,
+  validationFunc: SchemaValidator.compile(Schema)
 };

--- a/config/schemas/error-supplied-to-solium.js
+++ b/config/schemas/error-supplied-to-solium.js
@@ -7,46 +7,41 @@
 "use strict";
 
 let Ajv = require("ajv"),
-    astNode = require("./ast-node"),
-    coreRule = require("./core-rule").Schema,
-    SchemaValidator = new Ajv({ allErrors: true });
-
+  astNode = require("./ast-node"),
+  coreRule = require("./core-rule").Schema,
+  SchemaValidator = new Ajv({ allErrors: true });
 
 SchemaValidator.addKeyword("shouldBeOfTypeFunction", {
-    validate: function(isSet, attr) {
-        return isSet === (typeof attr === "function");
-    }
+  validate: function(isSet, attr) {
+    return isSet === (typeof attr === "function");
+  }
 });
 
 let Schema = {
+  type: "object",
+  properties: {
+    message: { type: "string", minLength: 1 },
+    node: astNode,
+    fix: { shouldBeOfTypeFunction: true },
+    ruleName: { type: "string", minLength: 1 },
+    ruleMeta: coreRule.properties.meta,
+    type: { type: "string", enum: ["error", "warning"] },
 
-    type: "object",
-    properties: {
+    location: {
+      type: "object",
+      properties: {
+        line: { type: "integer", minimum: 1 }, // line starts from 1
+        column: { type: "integer", minimum: 0 } // column starts from 0
+      },
+      additionalProperties: false
+    }
+  },
 
-        message: { type: "string", minLength: 1 },
-        node: astNode,
-        fix: { shouldBeOfTypeFunction: true },
-        ruleName: { type: "string", minLength: 1 },
-        ruleMeta: coreRule.properties.meta,
-        type: { type: "string", enum: ["error", "warning"] },
-
-        location: {
-            type: "object",
-            properties: {
-                line: { type: "integer", minimum: 1 },	// line starts from 1
-                column: { type: "integer", minimum: 0 }	// column starts from 0
-            },
-            additionalProperties: false
-        }
-
-    },
-
-    required: ["message", "node", "ruleName", "ruleMeta", "type"],
-    additionalProperties: false
-
+  required: ["message", "node", "ruleName", "ruleMeta", "type"],
+  additionalProperties: false
 };
 
-
 module.exports = {
-    schema: Schema, validationFunc: SchemaValidator.compile(Schema)
+  schema: Schema,
+  validationFunc: SchemaValidator.compile(Schema)
 };

--- a/config/schemas/fixer-packet.js
+++ b/config/schemas/fixer-packet.js
@@ -15,46 +15,45 @@
 ]
 */
 
-let Ajv = require("ajv"), validator = new Ajv({ allErrors: true });
+let Ajv = require("ajv"),
+  validator = new Ajv({ allErrors: true });
 
 let singleFixerPacket = {
-    type: "object",
+  type: "object",
 
-    properties: {
-
-        range: {
-            type: "array",
-            minItems: 2,
-            maxItems: 2,
-            items: {
-                type: "integer", minimum: 0
-            }
-        },
-
-        text: {
-            type: "string"
-        }
-
+  properties: {
+    range: {
+      type: "array",
+      minItems: 2,
+      maxItems: 2,
+      items: {
+        type: "integer",
+        minimum: 0
+      }
     },
 
-    required: ["range", "text"],
-    additionalProperties: false
+    text: {
+      type: "string"
+    }
+  },
+
+  required: ["range", "text"],
+  additionalProperties: false
 };
 
 let Schema = {
-    oneOf: [
-        {
-            type: "array",
-            minItems: 1,
-            items: singleFixerPacket
-        },
+  oneOf: [
+    {
+      type: "array",
+      minItems: 1,
+      items: singleFixerPacket
+    },
 
-        singleFixerPacket
-    ]
+    singleFixerPacket
+  ]
 };
 
-
 module.exports = {
-    Schema: Schema,
-    validationFunc: validator.compile(Schema)
+  Schema: Schema,
+  validationFunc: validator.compile(Schema)
 };

--- a/config/schemas/plugin.js
+++ b/config/schemas/plugin.js
@@ -36,36 +36,34 @@
 }
 */
 
-let coreRule = require("./core-rule"), SchemaValidator = coreRule.SchemaValidator;
-
+let coreRule = require("./core-rule"),
+  SchemaValidator = coreRule.SchemaValidator;
 
 let Schema = {
+  type: "object",
 
-    type: "object",
-
-    properties: {
-
-        rules: {
-            type: "object",
-            patternProperties: { "^.+$": coreRule.Schema },
-            additionalProperties: false
-        },
-
-        meta: {
-            type: "object",
-            properties: {
-                description: { type: "string", minLength: 1	}
-            },
-            required: ["description"],
-            additionalProperties: false
-        }
-
+  properties: {
+    rules: {
+      type: "object",
+      patternProperties: { "^.+$": coreRule.Schema },
+      additionalProperties: false
     },
 
-    required: ["rules", "meta"],
-    additionalProperties: false
+    meta: {
+      type: "object",
+      properties: {
+        description: { type: "string", minLength: 1 }
+      },
+      required: ["description"],
+      additionalProperties: false
+    }
+  },
 
+  required: ["rules", "meta"],
+  additionalProperties: false
 };
 
-
-module.exports = { Schema: Schema, validationFunc: SchemaValidator.compile(Schema) };
+module.exports = {
+  Schema: Schema,
+  validationFunc: SchemaValidator.compile(Schema)
+};

--- a/config/schemas/sharable-config.js
+++ b/config/schemas/sharable-config.js
@@ -18,19 +18,15 @@
 
 let rulesSchema = require("./config").properties.rules;
 
-
 let Schema = {
+  type: "object",
 
-    type: "object",
+  properties: {
+    rules: rulesSchema
+  },
 
-    properties: {
-        rules: rulesSchema
-    },
-
-    required: ["rules"],
-    additionalProperties: false
-
+  required: ["rules"],
+  additionalProperties: false
 };
-
 
 module.exports = Schema;

--- a/lib/autofix/merge-fixer-packets.js
+++ b/lib/autofix/merge-fixer-packets.js
@@ -5,58 +5,61 @@
 
 "use strict";
 
-
 /**
  * Merge all fixer packets into 1 packet and return it.
  * @params {(Array|Object)} fixesArrayOrObject Fixer packet(s) to be merged into a single fixer packet.
  * @params {String} sourceCode Source code.
  */
 module.exports = function(fixesArrayOrObject, sourceCode) {
-    // If argument is already a single fixes packet, return.
-    if (!Array.isArray(fixesArrayOrObject)) {
-        return fixesArrayOrObject;
+  // If argument is already a single fixes packet, return.
+  if (!Array.isArray(fixesArrayOrObject)) {
+    return fixesArrayOrObject;
+  }
+
+  let fixes = fixesArrayOrObject;
+
+  if (fixes.length === 1) {
+    return fixesArrayOrObject[0];
+  }
+
+  // Sort fixer packets in top-down approach
+  fixes.sort(function(a, b) {
+    return a.range[0] - b.range[0] || a.range[1] - b.range[1];
+  });
+
+  // Take start of first fix and end of last fix to merge them all into 1 big fixer packet,
+  // combining all the code in between.
+  let start = fixes[0].range[0],
+    end = fixes[fixes.length - 1].range[1];
+  let text = "",
+    cursor = Number.MIN_SAFE_INTEGER;
+
+  fixes.forEach(function(fix) {
+    /**
+     * Condition below is '>' instead of '>=' on purpose.
+     * Say we have 2 packets- {range: [12, 20]} & {range: [20, 28], text: 'world'}.
+     * These should NOT conflict. After 1st packet (which actually makes changes to only 12 to 19 index),
+     * cursor is set to 20. At start of 2nd packet, the slice (20, 20) returns empty string and hence,
+     * there is no damage.
+     */
+    if (cursor > fix.range[0]) {
+      throw new Error(
+        "2 or more fix objects in the Fixer Array must not overlap."
+      );
     }
 
-    let fixes = fixesArrayOrObject;
-
-    if (fixes.length === 1) {
-        return fixesArrayOrObject [0];
+    if (fix.range[0] >= 0) {
+      text += sourceCode.slice(Math.max(0, start, cursor), fix.range[0]);
     }
 
-    // Sort fixer packets in top-down approach
-    fixes.sort(function(a, b) {
-        return (a.range [0] - b.range [0]) || (a.range [1] - b.range [1]);
-    });
+    text += fix.text;
+    cursor = fix.range[1];
+  });
 
-    // Take start of first fix and end of last fix to merge them all into 1 big fixer packet,
-    // combining all the code in between.
-    let start = fixes [0].range [0], end = fixes [fixes.length - 1].range [1];
-    let text = "", cursor = Number.MIN_SAFE_INTEGER;
+  text += sourceCode.slice(Math.max(0, start, cursor), end);
 
-    fixes.forEach(function(fix) {
-        /**
-		 * Condition below is '>' instead of '>=' on purpose.
-		 * Say we have 2 packets- {range: [12, 20]} & {range: [20, 28], text: 'world'}.
-		 * These should NOT conflict. After 1st packet (which actually makes changes to only 12 to 19 index),
-		 * cursor is set to 20. At start of 2nd packet, the slice (20, 20) returns empty string and hence,
-		 * there is no damage.
-		 */
-        if (cursor > fix.range [0]) {
-            throw new Error("2 or more fix objects in the Fixer Array must not overlap.");
-        }
-
-        if (fix.range [0] >= 0) {
-            text += sourceCode.slice(Math.max(0, start, cursor), fix.range [0]);
-        }
-
-        text += fix.text;
-        cursor = fix.range [1];
-    });
-
-    text += sourceCode.slice(Math.max(0, start, cursor), end);
-
-    return {
-        range: [start, end],
-        text: text
-    };
+  return {
+    range: [start, end],
+    text: text
+  };
 };

--- a/lib/autofix/rule-fixer.js
+++ b/lib/autofix/rule-fixer.js
@@ -8,122 +8,128 @@
 let astUtils = require("../utils/ast-utils");
 
 function validateArgs(args) {
-    if (args.hasOwnProperty("node")) {
-        if (!astUtils.isASTNode(args.node)) {
-            throw new Error("A valid AST node was not provided.");
-        }
+  if (args.hasOwnProperty("node")) {
+    if (!astUtils.isASTNode(args.node)) {
+      throw new Error("A valid AST node was not provided.");
     }
+  }
 
-    if (args.hasOwnProperty("text")) {
-        let text = args.text;
+  if (args.hasOwnProperty("text")) {
+    let text = args.text;
 
-        // There are no restriction on string length
-        if (typeof text !== "string") {
-            throw new Error("A valid string was not provided.");
-        }
+    // There are no restriction on string length
+    if (typeof text !== "string") {
+      throw new Error("A valid string was not provided.");
     }
+  }
 
-    if (args.hasOwnProperty("range")) {
-        let range = args.range;
+  if (args.hasOwnProperty("range")) {
+    let range = args.range;
 
-        if (!(Array.isArray(range) && range.length === 2 && Number.isInteger(range [0]) &&
-			Number.isInteger(range [1]) && range [0] >= 0 && range [1] >= 0)) {
-            throw new Error(
-                "A valid range object was not provided. Should be an Array of 2 unsigned Integers.");
-        }
+    if (
+      !(
+        Array.isArray(range) &&
+        range.length === 2 &&
+        Number.isInteger(range[0]) &&
+        Number.isInteger(range[1]) &&
+        range[0] >= 0 &&
+        range[1] >= 0
+      )
+    ) {
+      throw new Error(
+        "A valid range object was not provided. Should be an Array of 2 unsigned Integers."
+      );
     }
+  }
 
-    if (args.hasOwnProperty("index")) {
-        let index = args.index;
+  if (args.hasOwnProperty("index")) {
+    let index = args.index;
 
-        if (!(Number.isInteger(index) && index >= 0)) {
-            throw new Error("A valid index was not provided. Must be an unsigned Integer.");
-        }
+    if (!(Number.isInteger(index) && index >= 0)) {
+      throw new Error(
+        "A valid index was not provided. Must be an unsigned Integer."
+      );
     }
+  }
 
-    if (args.hasOwnProperty("char")) {
-        let char = args.char;
+  if (args.hasOwnProperty("char")) {
+    let char = args.char;
 
-        if (!(typeof char === "string" && char.length === 1)) {
-            throw new Error("A valid character was not provided. Must be a string with length of 1.");
-        }
+    if (!(typeof char === "string" && char.length === 1)) {
+      throw new Error(
+        "A valid character was not provided. Must be a string with length of 1."
+      );
     }
+  }
 }
-
 
 function insertTextAt(index, text) {
-    validateArgs({index, text});
+  validateArgs({ index, text });
 
-    return {
-        range: [index, index],
-        text: text
-    };
+  return {
+    range: [index, index],
+    text: text
+  };
 }
 
-
 let ruleFixerAPI = {
+  insertTextAt,
 
-    insertTextAt,
+  insertTextAfter(node, text) {
+    validateArgs({ node: node, text: text });
+    return this.insertTextAfterRange([node.start, node.end], text);
+  },
 
-    insertTextAfter(node, text) {
-        validateArgs({node: node, text: text});
-        return this.insertTextAfterRange([node.start, node.end], text);
-    },
+  insertTextBefore(node, text) {
+    validateArgs({ node: node, text: text });
+    return this.insertTextBeforeRange([node.start, node.end], text);
+  },
 
-    insertTextBefore(node, text) {
-        validateArgs({node: node, text: text});
-        return this.insertTextBeforeRange([node.start, node.end], text);
-    },
+  remove(node) {
+    return this.removeRange([node.start, node.end]);
+  },
 
-    remove(node) {
-        return this.removeRange([node.start, node.end]);
-    },
+  replaceText(node, text) {
+    validateArgs({ node: node, text: text });
+    return this.replaceTextRange([node.start, node.end], text);
+  },
 
-    replaceText(node, text) {
-        validateArgs({node: node, text: text});
-        return this.replaceTextRange([node.start, node.end], text);
-    },
+  insertTextAfterRange(range, text) {
+    validateArgs({ range: range, text: text });
+    return insertTextAt(range[1], text);
+  },
 
-    insertTextAfterRange(range, text) {
-        validateArgs({range: range, text: text});
-        return insertTextAt(range [1], text);
-    },
+  insertTextBeforeRange(range, text) {
+    validateArgs({ range: range, text: text });
+    return insertTextAt(range[0], text);
+  },
 
-    insertTextBeforeRange(range, text) {
-        validateArgs({range: range, text: text});
-        return insertTextAt(range [0], text);
-    },
+  removeRange(range) {
+    validateArgs({ range: range });
+    return this.replaceTextRange(range, "");
+  },
 
-    removeRange(range) {
-        validateArgs({range: range});
-        return this.replaceTextRange(range, "");
-    },
+  replaceChar(index, newChar) {
+    validateArgs({ index: index, char: newChar });
+    return this.replaceTextRange([index, index + 1], newChar);
+  },
 
-    replaceChar(index, newChar) {
-        validateArgs({index: index, char: newChar});
-        return this.replaceTextRange([index, index + 1], newChar);
-    },
-
-    replaceTextRange(range, text) {
-        validateArgs({range: range, text: text});
-        return {
-            range: range,
-            text: text
-        };
-    }
-
+  replaceTextRange(range, text) {
+    validateArgs({ range: range, text: text });
+    return {
+      range: range,
+      text: text
+    };
+  }
 };
-
 
 // eslint-disable-next-line no-unused-vars
 function RuleFixer(fixType) {
-    Object.assign(this, ruleFixerAPI);
+  Object.assign(this, ruleFixerAPI);
 }
 
-
 RuleFixer.prototype = {
-    constructor: RuleFixer
+  constructor: RuleFixer
 };
-
 
 module.exports = RuleFixer;

--- a/lib/autofix/source-code-fixer.js
+++ b/lib/autofix/source-code-fixer.js
@@ -5,83 +5,91 @@
 
 "use strict";
 
-
 let mergeFixes = require("./merge-fixer-packets");
 
-
 function compareMessagesByLocation(a, b) {
-    return (a.line - b.line) || (a.column - b.column);
+  return a.line - b.line || a.column - b.column;
 }
 
 function compareMessagesByFixRange(a, b) {
-    return (a.fix.range [0] - b.fix.range [0]) || (a.fix.range [1] - b.fix.range [1]);
+  return a.fix.range[0] - b.fix.range[0] || a.fix.range[1] - b.fix.range[1];
 }
 
-
 module.exports = {
+  /**
+   * Apply fixes to source code depending on whichever errors can be fixed.
+   * @param {String} sourceCode Code to fix
+   * @param {Array} errorMessages Error objects that describe the error and possibly how to fix it.
+   * @returns {Object} fixed Contains fixed code and information about fixes applied & remaining un-fixed errors.
+   */
+  applyFixes: function(sourceCode, errorMessages) {
+    let fixedSourceCode = "",
+      fixes = [],
+      fixesApplied = [],
+      remainingMessages = [];
+    let cursor = Number.NEGATIVE_INFINITY;
 
-    /**
-	 * Apply fixes to source code depending on whichever errors can be fixed.
-	 * @param {String} sourceCode Code to fix
-	 * @param {Array} errorMessages Error objects that describe the error and possibly how to fix it.
-	 * @returns {Object} fixed Contains fixed code and information about fixes applied & remaining un-fixed errors.
-	 */
-    applyFixes: function(sourceCode, errorMessages) {
-        let fixedSourceCode = "", fixes = [], fixesApplied = [], remainingMessages = [];
-        let cursor = Number.NEGATIVE_INFINITY;
+    function attemptFix(fix) {
+      let start = fix.range[0],
+        end = fix.range[1];
 
-        function attemptFix(fix) {
-            let start = fix.range [0], end = fix.range [1];
+      // If this fix overlaps with the previous one or has negaive range, return.
+      // Note that when cursor === start, its NOT an overlap since when source code in range
+      // [i, j] is being edited, the code covered is actually from i to j-1.
+      if (cursor > start || start > end) {
+        return false;
+      }
 
-            // If this fix overlaps with the previous one or has negaive range, return.
-            // Note that when cursor === start, its NOT an overlap since when source code in range
-            // [i, j] is being edited, the code covered is actually from i to j-1.
-            if (cursor > start || start > end) {
-                return false;
-            }
-
-            fixedSourceCode += sourceCode.slice(Math.max(0, cursor), Math.max(0, start));
-            fixedSourceCode += fix.text;
-            cursor = end;
-            return true;
-        }
-
-        // Segregate errors that can be fixed from those that can't for sure.
-        errorMessages.forEach(function(msg) {
-            if (msg.fix) {
-                // If msg.fix is an Array of fix packets, merge them into a single fix packet.
-                try {
-                    msg.fix = mergeFixes(msg.fix, sourceCode);
-                } catch (e) {
-                    throw new Error("An error occured while applying fix of rule \""
-						+ msg.ruleName + "\" for error \"" + msg.message + "\": " + e.message);
-                }
-
-                return fixes.push(msg);
-            }
-
-            remainingMessages.push(msg);
-        });
-
-        // Fixes will be applied in top-down approach. The fix that arrives first (line-wise, followed by column-wise)
-        // gets applied first. But if current fix is applied successfully & the next one overlaps the current one,
-        // then the next one is simply skipped. Hence, it is NOT guranteed that all fixes will be applied.
-        fixes.sort(compareMessagesByFixRange).forEach(function(msg) {
-            if (attemptFix(msg.fix)) {
-                return fixesApplied.push(msg);
-            }
-
-            remainingMessages.push(msg);
-        });
-
-        fixedSourceCode += sourceCode.slice(Math.max(0, cursor));
-        remainingMessages.sort(compareMessagesByLocation);
-
-        return {
-            fixesApplied: fixesApplied,
-            fixedSourceCode: fixedSourceCode,
-            remainingErrorMessages: remainingMessages
-        };
+      fixedSourceCode += sourceCode.slice(
+        Math.max(0, cursor),
+        Math.max(0, start)
+      );
+      fixedSourceCode += fix.text;
+      cursor = end;
+      return true;
     }
 
+    // Segregate errors that can be fixed from those that can't for sure.
+    errorMessages.forEach(function(msg) {
+      if (msg.fix) {
+        // If msg.fix is an Array of fix packets, merge them into a single fix packet.
+        try {
+          msg.fix = mergeFixes(msg.fix, sourceCode);
+        } catch (e) {
+          throw new Error(
+            'An error occured while applying fix of rule "' +
+              msg.ruleName +
+              '" for error "' +
+              msg.message +
+              '": ' +
+              e.message
+          );
+        }
+
+        return fixes.push(msg);
+      }
+
+      remainingMessages.push(msg);
+    });
+
+    // Fixes will be applied in top-down approach. The fix that arrives first (line-wise, followed by column-wise)
+    // gets applied first. But if current fix is applied successfully & the next one overlaps the current one,
+    // then the next one is simply skipped. Hence, it is NOT guranteed that all fixes will be applied.
+    fixes.sort(compareMessagesByFixRange).forEach(function(msg) {
+      if (attemptFix(msg.fix)) {
+        return fixesApplied.push(msg);
+      }
+
+      remainingMessages.push(msg);
+    });
+
+    fixedSourceCode += sourceCode.slice(Math.max(0, cursor));
+    remainingMessages.sort(compareMessagesByLocation);
+
+    return {
+      fixesApplied: fixesApplied,
+      fixedSourceCode: fixedSourceCode,
+      remainingErrorMessages: remainingMessages
+    };
+  }
 };

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -6,33 +6,39 @@
 "use strict";
 
 let cli = require("commander"),
-    fs = require("fs"),
-    fsUtils = require("./utils/fs-utils"),
-    path = require("path"),
-    { EOL } = require("os"),
-    chokidar = require("chokidar"),
-    traverse = require("sol-digger"),
-    solium = require("./solium"),
-    sum = require("lodash/sum"),
-    version = require("../package.json").version;
+  fs = require("fs"),
+  fsUtils = require("./utils/fs-utils"),
+  path = require("path"),
+  { EOL } = require("os"),
+  chokidar = require("chokidar"),
+  traverse = require("sol-digger"),
+  solium = require("./solium"),
+  sum = require("lodash/sum"),
+  version = require("../package.json").version;
 
 let CWD = process.cwd(),
-    SOLIUMRC_FILENAME = ".soliumrc.json",
-    SOLIUMRC_FILENAME_ABSOLUTE = path.join(CWD, SOLIUMRC_FILENAME),
-    SOLIUMIGNORE_FILENAME = ".soliumignore",
-    SOLIUMIGNORE_FILENAME_ABSOLUTE = path.join(CWD, SOLIUMIGNORE_FILENAME),
-    DEFAULT_SOLIUMIGNORE_PATH = `${__dirname}/cli-utils/.default-solium-ignore`,
-    DEFAULT_SOLIUMRC_PATH = `${__dirname}/cli-utils/.default-soliumrc.json`;
+  SOLIUMRC_FILENAME = ".soliumrc.json",
+  SOLIUMRC_FILENAME_ABSOLUTE = path.join(CWD, SOLIUMRC_FILENAME),
+  SOLIUMIGNORE_FILENAME = ".soliumignore",
+  SOLIUMIGNORE_FILENAME_ABSOLUTE = path.join(CWD, SOLIUMIGNORE_FILENAME),
+  DEFAULT_SOLIUMIGNORE_PATH = `${__dirname}/cli-utils/.default-solium-ignore`,
+  DEFAULT_SOLIUMRC_PATH = `${__dirname}/cli-utils/.default-soliumrc.json`;
 
-let errorCodes = { ERRORS_FOUND: 1, NO_SOLIUMRC: 3, WRITE_FAILED: 4, INVALID_PARAMS: 5, FILE_NOT_FOUND: 6 };
+let errorCodes = {
+  ERRORS_FOUND: 1,
+  NO_SOLIUMRC: 3,
+  WRITE_FAILED: 4,
+  INVALID_PARAMS: 5,
+  FILE_NOT_FOUND: 6
+};
 
 /**
  * Create default configuration files in the user's directory
  * @returns {void}
  */
 function setupDefaultUserConfig() {
-    createDefaultConfigJSON();
-    createDefaultSoliumIgnore();
+  createDefaultConfigJSON();
+  createDefaultSoliumIgnore();
 }
 
 /**
@@ -41,16 +47,19 @@ function setupDefaultUserConfig() {
  * @returns {void}
  */
 function writeConfigFile(config) {
-    try {
-        fs.writeFileSync(
-            SOLIUMRC_FILENAME_ABSOLUTE,
-            JSON.stringify(config, null, 2)
-        );
-    } catch (e) {
-        errorReporter.reportFatal(
-            `An error occurred while writing to ${SOLIUMRC_FILENAME_ABSOLUTE}:${EOL}${e.message}`);
-        process.exit(errorCodes.WRITE_FAILED);
-    }
+  try {
+    fs.writeFileSync(
+      SOLIUMRC_FILENAME_ABSOLUTE,
+      JSON.stringify(config, null, 2)
+    );
+  } catch (e) {
+    errorReporter.reportFatal(
+      `An error occurred while writing to ${SOLIUMRC_FILENAME_ABSOLUTE}:${EOL}${
+        e.message
+      }`
+    );
+    process.exit(errorCodes.WRITE_FAILED);
+  }
 }
 
 /**
@@ -58,16 +67,19 @@ function writeConfigFile(config) {
  * @returns {void}
  */
 function createDefaultSoliumIgnore() {
-    try {
-        fs.writeFileSync(
-            SOLIUMIGNORE_FILENAME_ABSOLUTE,
-            fs.readFileSync(DEFAULT_SOLIUMIGNORE_PATH)
-        );
-    } catch (e) {
-        errorReporter.reportFatal(
-            `An error occurred while writing to ${SOLIUMIGNORE_FILENAME_ABSOLUTE}:${EOL}${e.message}`);
-        process.exit(errorCodes.WRITE_FAILED);
-    }
+  try {
+    fs.writeFileSync(
+      SOLIUMIGNORE_FILENAME_ABSOLUTE,
+      fs.readFileSync(DEFAULT_SOLIUMIGNORE_PATH)
+    );
+  } catch (e) {
+    errorReporter.reportFatal(
+      `An error occurred while writing to ${SOLIUMIGNORE_FILENAME_ABSOLUTE}:${EOL}${
+        e.message
+      }`
+    );
+    process.exit(errorCodes.WRITE_FAILED);
+  }
 }
 
 /**
@@ -75,7 +87,7 @@ function createDefaultSoliumIgnore() {
  * This file enables all the built-in lint rules
  */
 function createDefaultConfigJSON() {
-    writeConfigFile(require(DEFAULT_SOLIUMRC_PATH));
+  writeConfigFile(require(DEFAULT_SOLIUMRC_PATH));
 }
 
 /**
@@ -87,45 +99,50 @@ function createDefaultConfigJSON() {
  * @returns {Integer} numOfErrors Number of Lint ERRORS that occured.
  */
 function lintString(sourceCode, userConfig, errorReporter, fileName) {
-    let lintErrors, fixesApplied;
+  let lintErrors, fixesApplied;
 
-    try {
-        if (userConfig.options.autofix) {
-            let result = solium.lintAndFix(sourceCode, userConfig);
+  try {
+    if (userConfig.options.autofix) {
+      let result = solium.lintAndFix(sourceCode, userConfig);
 
-            lintErrors = result.errorMessages;
-            result.fixesApplied.length && fs.writeFileSync(fileName, result.fixedSourceCode);
-            fixesApplied = result.fixesApplied;
-        } else {
-            lintErrors = solium.lint(sourceCode, userConfig);
-        }
-    } catch (e) {
-        // Don't abort in case of a parse error, just report it as a normal lint issue.
-        if (e.name !== "SyntaxError") {
-            if (userConfig.options.debug) {
-                errorReporter.reportFatal(e.stack);
-            } else {
-                errorReporter.reportFatal(`An error occurred while linting over ${fileName}: ${e.message}`);
-            }
-            process.exit(errorCodes.ERRORS_FOUND);
-        }
-
-        lintErrors = [{
-            ruleName: "",
-            type: "error",
-            message: `Syntax error: unexpected token ${e.found}`,
-            line: e.location.start.line,
-            column: e.location.start.column
-        }];
+      lintErrors = result.errorMessages;
+      result.fixesApplied.length &&
+        fs.writeFileSync(fileName, result.fixedSourceCode);
+      fixesApplied = result.fixesApplied;
+    } else {
+      lintErrors = solium.lint(sourceCode, userConfig);
+    }
+  } catch (e) {
+    // Don't abort in case of a parse error, just report it as a normal lint issue.
+    if (e.name !== "SyntaxError") {
+      if (userConfig.options.debug) {
+        errorReporter.reportFatal(e.stack);
+      } else {
+        errorReporter.reportFatal(
+          `An error occurred while linting over ${fileName}: ${e.message}`
+        );
+      }
+      process.exit(errorCodes.ERRORS_FOUND);
     }
 
-    // If any lint/internal errors/warnings exist, report them
-    lintErrors.length &&
-        errorReporter.report(fileName, sourceCode, lintErrors, fixesApplied);
+    lintErrors = [
+      {
+        ruleName: "",
+        type: "error",
+        message: `Syntax error: unexpected token ${e.found}`,
+        line: e.location.start.line,
+        column: e.location.start.column
+      }
+    ];
+  }
 
-    return lintErrors.reduce(function(numOfErrors, err) {
-        return err.type === "error" ? numOfErrors+1 : numOfErrors;
-    }, 0);
+  // If any lint/internal errors/warnings exist, report them
+  lintErrors.length &&
+    errorReporter.report(fileName, sourceCode, lintErrors, fixesApplied);
+
+  return lintErrors.reduce(function(numOfErrors, err) {
+    return err.type === "error" ? numOfErrors + 1 : numOfErrors;
+  }, 0);
 }
 
 /**
@@ -136,16 +153,16 @@ function lintString(sourceCode, userConfig, errorReporter, fileName) {
  * @returns {Integer} numOfErrors Number of Lint ERRORS that occured (the result returned by lintString())
  */
 function lintFile(fileName, userConfig, errorReporter) {
-    let sourceCode;
+  let sourceCode;
 
-    try {
-        sourceCode = fs.readFileSync(fileName, "utf8");
-    } catch (e) {
-        errorReporter.reportFatal("Unable to read " + fileName + ": " + e.message);
-        process.exit(errorCodes.FILE_NOT_FOUND);
-    }
+  try {
+    sourceCode = fs.readFileSync(fileName, "utf8");
+  } catch (e) {
+    errorReporter.reportFatal("Unable to read " + fileName + ": " + e.message);
+    process.exit(errorCodes.FILE_NOT_FOUND);
+  }
 
-    return lintString(sourceCode, userConfig, errorReporter, fileName);
+  return lintString(sourceCode, userConfig, errorReporter, fileName);
 }
 
 /**
@@ -156,46 +173,47 @@ function lintFile(fileName, userConfig, errorReporter) {
  * @returns {Integer} totalNumOfErrors Total no. of errors found throughout the codebase (directory) linted.
  */
 function lint(userConfig, input, ignore, errorReporter) {
-    let filesToLint, errorCount;
+  let filesToLint, errorCount;
 
-    //If filename is provided, lint it. Otherwise, lint over current directory & sub-directories
-    if (input.file) {
-
-        if (!fsUtils.isFile(input.file)) {
-            errorReporter.reportFatal(`${input.file} is not a valid file`);
-            process.exit(errorCodes.INVALID_PARAMS);
-        }
-
-        filesToLint = [input.file];
-
-    } else if (input.dir) {
-
-        if (!fsUtils.isDirectory(input.dir)) {
-            errorReporter.reportFatal(`${input.dir} is not a valid directory`);
-            process.exit(errorCodes.INVALID_PARAMS);
-        }
-
-        filesToLint = traverse(input.dir, ignore);
+  //If filename is provided, lint it. Otherwise, lint over current directory & sub-directories
+  if (input.file) {
+    if (!fsUtils.isFile(input.file)) {
+      errorReporter.reportFatal(`${input.file} is not a valid file`);
+      process.exit(errorCodes.INVALID_PARAMS);
     }
 
-    if (filesToLint) {
-        errorCount = sum(filesToLint.map(function(file, index) {
-            userConfig.options.returnInternalIssues = (index === 0);
-            return lintFile(file, userConfig, errorReporter);
-        }));
-    } else if (input.stdin) {
-        // This only works on *nix. Need to fix to enable stdin input in windows.
-        let sourceCode = fs.readFileSync("/dev/stdin", "utf-8");
-
-        userConfig.options.returnInternalIssues = true;
-        errorCount = lintString(sourceCode, userConfig, errorReporter, "[stdin]");
-    } else {
-        errorReporter.reportFatal("Must specify input for linter using --file, --dir or --stdin");
-        process.exit(errorCodes.INVALID_PARAMS);
+    filesToLint = [input.file];
+  } else if (input.dir) {
+    if (!fsUtils.isDirectory(input.dir)) {
+      errorReporter.reportFatal(`${input.dir} is not a valid directory`);
+      process.exit(errorCodes.INVALID_PARAMS);
     }
 
-    errorReporter.finalize && errorReporter.finalize();
-    return errorCount;
+    filesToLint = traverse(input.dir, ignore);
+  }
+
+  if (filesToLint) {
+    errorCount = sum(
+      filesToLint.map(function(file, index) {
+        userConfig.options.returnInternalIssues = index === 0;
+        return lintFile(file, userConfig, errorReporter);
+      })
+    );
+  } else if (input.stdin) {
+    // This only works on *nix. Need to fix to enable stdin input in windows.
+    let sourceCode = fs.readFileSync("/dev/stdin", "utf-8");
+
+    userConfig.options.returnInternalIssues = true;
+    errorCount = lintString(sourceCode, userConfig, errorReporter, "[stdin]");
+  } else {
+    errorReporter.reportFatal(
+      "Must specify input for linter using --file, --dir or --stdin"
+    );
+    process.exit(errorCodes.INVALID_PARAMS);
+  }
+
+  errorReporter.finalize && errorReporter.finalize();
+  return errorCount;
 }
 
 /**
@@ -203,21 +221,32 @@ function lint(userConfig, input, ignore, errorReporter) {
  * @param {Object} cliObject Commander Object handling the cli
  */
 function createCliOptions(cliObject) {
-    cliObject
-        .version(`Solium version ${version}`)
-        .description("Linter to find & fix style and security issues in Solidity smart contracts.")
-        .usage("[options] <keyword>")
+  cliObject
+    .version(`Solium version ${version}`)
+    .description(
+      "Linter to find & fix style and security issues in Solidity smart contracts."
+    )
+    .usage("[options] <keyword>")
 
-        .option("-i, --init", "Create default rule configuration files")
-        .option("-f, --file [filepath::String]", "Solidity file to lint")
-        .option("-d, --dir [dirpath::String]", "Directory containing Solidity files to lint")
-        .option("-R, --reporter [name::String]", "Format to report lint issues in (pretty | gcc)")
-        .option("-c, --config [filepath::String]", "Path to the .soliumrc configuration file")
-        .option("-, --stdin", "Read input file from stdin")
-        .option("--fix", "Fix Lint issues where possible")
-        .option("--debug", "Display debug information")
-        .option("--watch", "Watch for file changes")
-        .option("--hot", "(Deprecated) Same as --watch");
+    .option("-i, --init", "Create default rule configuration files")
+    .option("-f, --file [filepath::String]", "Solidity file to lint")
+    .option(
+      "-d, --dir [dirpath::String]",
+      "Directory containing Solidity files to lint"
+    )
+    .option(
+      "-R, --reporter [name::String]",
+      "Format to report lint issues in (pretty | gcc)"
+    )
+    .option(
+      "-c, --config [filepath::String]",
+      "Path to the .soliumrc configuration file"
+    )
+    .option("-, --stdin", "Read input file from stdin")
+    .option("--fix", "Fix Lint issues where possible")
+    .option("--debug", "Display debug information")
+    .option("--watch", "Watch for file changes")
+    .option("--hot", "(Deprecated) Same as --watch");
 }
 
 /**
@@ -226,15 +255,15 @@ function createCliOptions(cliObject) {
  * @returns {Object} reporter The reporter whose name was supplied.
  */
 function getErrorReporter(name) {
-    name = name || "pretty";
+  name = name || "pretty";
 
-    try {
-        return require("./reporters/" + name);
-    } catch (e) {
-        throw new Error(
-            `Invalid reporter "${name}". Valid reporters are "gcc" and "pretty"`
-        );
-    }
+  try {
+    return require("./reporters/" + name);
+  } catch (e) {
+    throw new Error(
+      `Invalid reporter "${name}". Valid reporters are "gcc" and "pretty"`
+    );
+  }
 }
 
 /**
@@ -242,108 +271,125 @@ function getErrorReporter(name) {
  * @param {Array} programArgs Commandline arguments
  */
 function execute(programArgs) {
+  let userConfig, ignore, errorReporter;
 
-    let userConfig, ignore, errorReporter;
+  createCliOptions(cli);
+  programArgs.length === 2 ? cli.help() : cli.parse(programArgs);
 
-    createCliOptions(cli);
-    programArgs.length === 2 ? cli.help() : cli.parse(programArgs);
+  if (cli.init) {
+    return setupDefaultUserConfig();
+  }
 
-    if (cli.init) {
-        return setupDefaultUserConfig();
-    }
+  try {
+    errorReporter = getErrorReporter(cli.reporter);
+  } catch (e) {
+    console.error(`[Fatal error] ${e.message}`);
+    process.exit(errorCodes.INVALID_PARAMS);
+  }
 
-    try {
-        errorReporter = getErrorReporter(cli.reporter);
-    } catch (e) {
-        console.error(`[Fatal error] ${e.message}`);
-        process.exit(errorCodes.INVALID_PARAMS);
-    }
+  /**
+   * If cli.config option is NOT specified, then resort to .soliumrc in current dir.
+   * Else,
+   *   If path is absolute, assign as-it-is.
+   *   Else (relative pathing) join path with current dir.
+   */
+  const soliumrcAbsPath = cli.config
+    ? path.isAbsolute(cli.config)
+      ? cli.config
+      : path.join(CWD, cli.config)
+    : SOLIUMRC_FILENAME_ABSOLUTE;
 
-    /**
-     * If cli.config option is NOT specified, then resort to .soliumrc in current dir.
-     * Else,
-     *   If path is absolute, assign as-it-is.
-     *   Else (relative pathing) join path with current dir.
-     */
-    const soliumrcAbsPath = cli.config ?
-        (path.isAbsolute(cli.config) ? cli.config : path.join(CWD, cli.config)) :
-        SOLIUMRC_FILENAME_ABSOLUTE;
-
-    try {
-        userConfig = require(soliumrcAbsPath);
-    } catch (e) {
-        // Check if soliumrc file exists. If yes, then the file is in an invalid format.
-        if (fs.existsSync(soliumrcAbsPath)) {
-            errorReporter.reportFatal(`An invalid ${SOLIUMRC_FILENAME} was provided. ${e.message}`);
-        } else {
-            if (cli.config) {
-                errorReporter.reportFatal(`${soliumrcAbsPath} does not exist.`);
-            } else {
-                errorReporter.reportFatal(`Couldn't find ${SOLIUMRC_FILENAME} in the current directory.`);
-            }
-        }
-
-        process.exit(errorCodes.NO_SOLIUMRC);
-    }
-
-    //if custom rules' file is set, make sure we have its absolute path
-    if (
-        userConfig ["custom-rules-filename"] &&
-        !path.isAbsolute(userConfig ["custom-rules-filename"])
-    ) {
-        userConfig ["custom-rules-filename"] = path.join(
-            CWD, userConfig ["custom-rules-filename"]
+  try {
+    userConfig = require(soliumrcAbsPath);
+  } catch (e) {
+    // Check if soliumrc file exists. If yes, then the file is in an invalid format.
+    if (fs.existsSync(soliumrcAbsPath)) {
+      errorReporter.reportFatal(
+        `An invalid ${SOLIUMRC_FILENAME} was provided. ${e.message}`
+      );
+    } else {
+      if (cli.config) {
+        errorReporter.reportFatal(`${soliumrcAbsPath} does not exist.`);
+      } else {
+        errorReporter.reportFatal(
+          `Couldn't find ${SOLIUMRC_FILENAME} in the current directory.`
         );
+      }
     }
 
-    // Pass cli arguments that modify the behaviour of upstream functions.
-    userConfig.options = {
-        autofix: Boolean(cli.fix),
-        debug: Boolean(cli.debug)
-    };
+    process.exit(errorCodes.NO_SOLIUMRC);
+  }
 
-    //get all files & folders to ignore from .soliumignore
-    try {
-        ignore = fs.readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8").split("\n");
-    } catch (e) {
-        errorReporter.reportInternal(
-            `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`
-        );
+  //if custom rules' file is set, make sure we have its absolute path
+  if (
+    userConfig["custom-rules-filename"] &&
+    !path.isAbsolute(userConfig["custom-rules-filename"])
+  ) {
+    userConfig["custom-rules-filename"] = path.join(
+      CWD,
+      userConfig["custom-rules-filename"]
+    );
+  }
+
+  // Pass cli arguments that modify the behaviour of upstream functions.
+  userConfig.options = {
+    autofix: Boolean(cli.fix),
+    debug: Boolean(cli.debug)
+  };
+
+  //get all files & folders to ignore from .soliumignore
+  try {
+    ignore = fs
+      .readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8")
+      .split("\n");
+  } catch (e) {
+    errorReporter.reportInternal(
+      `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${
+        e.message
+      }`
+    );
+  }
+
+  if (cli.hot) {
+    // --hot is equivalent to --watch in functionality, is a legacy option
+    cli.watch = true;
+  }
+
+  if (cli.watch) {
+    if (cli.stdin) {
+      return errorReporter.reportFatal(
+        "Cannot watch files when reading from stdin"
+      );
     }
 
-    if (cli.hot) {
-        // --hot is equivalent to --watch in functionality, is a legacy option
-        cli.watch = true;
+    if (cli.fix) {
+      return errorReporter.reportFatal(
+        "Automatic code formatting is not supported in watch mode."
+      );
     }
+  }
 
-    if (cli.watch) {
-        if (cli.stdin) {
-            return errorReporter.reportFatal("Cannot watch files when reading from stdin");
-        }
+  let errorCount = lint(
+    userConfig,
+    { file: cli.file, dir: cli.dir, stdin: cli.stdin },
+    ignore,
+    errorReporter
+  );
 
-        if (cli.fix) {
-            return errorReporter.reportFatal("Automatic code formatting is not supported in watch mode.");
-        }
-    }
+  if (cli.watch) {
+    let spy = chokidar.watch(CWD);
 
-    let errorCount = lint(userConfig, { file: cli.file, dir: cli.dir, stdin: cli.stdin }, ignore, errorReporter);
-
-    if (cli.watch) {
-
-        let spy = chokidar.watch(CWD);
-
-        spy.on("change", function() {
-            console.log("\x1Bc"); // clear the console
-            console.log(`File change detected. Start linting.${EOL}`);
-            lint(userConfig, { file: cli.file, dir: cli.dir }, ignore, errorReporter);	//lint on subsequent changes (hot)
-            console.log(`Linting complete. Watching for file changes.${EOL}`);
-        });
-
-    } else if (errorCount > 0) {
-        process.exit(errorCodes.ERRORS_FOUND);
-    }
+    spy.on("change", function() {
+      console.log("\x1Bc"); // clear the console
+      console.log(`File change detected. Start linting.${EOL}`);
+      lint(userConfig, { file: cli.file, dir: cli.dir }, ignore, errorReporter); //lint on subsequent changes (hot)
+      console.log(`Linting complete. Watching for file changes.${EOL}`);
+    });
+  } else if (errorCount > 0) {
+    process.exit(errorCodes.ERRORS_FOUND);
+  }
 }
 
 module.exports = {
-    execute: execute
+  execute: execute
 };

--- a/lib/comment-directive-parser.js
+++ b/lib/comment-directive-parser.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-
 const astUtils = require("./utils/ast-utils");
 
 /**
@@ -17,117 +16,129 @@ const astUtils = require("./utils/ast-utils");
  * NOTE: Constructor & Public functions of this class should have argument validations
  */
 class CommentDirectiveParser {
-
-    constructor(commentTokens, AST) {
-        if (!Array.isArray(commentTokens)) {
-            throw new Error("First argument should be an array of comment tokens.");
-        }
-
-        // AST gets validated by astUtils.getEndingLine(), no need to explicitly validate it here
-        this.lastLine = astUtils.getEndingLine(AST); // relies on astUtils.init(code) being called before it
-        this.commentTokens = commentTokens;
-        this.lineConfigurations = {};   // mapping: line => list of rules to disable on line (Array / this.ALL_RULES)
-        this.ALL_RULES = "all";
-
-        this._constructLineConfigurations();
+  constructor(commentTokens, AST) {
+    if (!Array.isArray(commentTokens)) {
+      throw new Error("First argument should be an array of comment tokens.");
     }
 
-    // Check if, for a given line, there is any rule disabling configuration present
-    // and if yes, determine whether a specific rule is enabled on the line or not.
-    isRuleEnabledOnLine(ruleName, line) {
-        // Need not ensure that line > this.lastLine. This func's purpose is only to determine whether
-        // given rule is disabled on given line, regardless of whether line is within bounds or not.
-        if (typeof ruleName !== "string" || ruleName.length < 1) {
-            throw new Error("Rule name should be a non-empty string string.");
-        }
+    // AST gets validated by astUtils.getEndingLine(), no need to explicitly validate it here
+    this.lastLine = astUtils.getEndingLine(AST); // relies on astUtils.init(code) being called before it
+    this.commentTokens = commentTokens;
+    this.lineConfigurations = {}; // mapping: line => list of rules to disable on line (Array / this.ALL_RULES)
+    this.ALL_RULES = "all";
 
-        if (!Number.isInteger(line) || line < 1) {
-            throw new Error("Line number should be a positive integer.");
-        }
+    this._constructLineConfigurations();
+  }
 
-        // entry can be undefined because we only record config for the lines which have any comment configuration.
-        const entry = this.lineConfigurations[line] || "";
-        return (entry !== this.ALL_RULES && !entry.includes(ruleName));
+  // Check if, for a given line, there is any rule disabling configuration present
+  // and if yes, determine whether a specific rule is enabled on the line or not.
+  isRuleEnabledOnLine(ruleName, line) {
+    // Need not ensure that line > this.lastLine. This func's purpose is only to determine whether
+    // given rule is disabled on given line, regardless of whether line is within bounds or not.
+    if (typeof ruleName !== "string" || ruleName.length < 1) {
+      throw new Error("Rule name should be a non-empty string string.");
     }
 
-    _constructLineConfigurations() {
-        this.commentTokens.forEach(token => {
-            this._constructLineConfigurationFromComment(token);
-        });
+    if (!Number.isInteger(line) || line < 1) {
+      throw new Error("Line number should be a positive integer.");
     }
 
-    _addRulesToLineConfig(line, rules) {
-        // If line configuration is "all", then we've already covered all rules.
-        // No need to add any more to list.
-        if (this.lineConfigurations[line] === this.ALL_RULES) {
-            return;
-        }
+    // entry can be undefined because we only record config for the lines which have any comment configuration.
+    const entry = this.lineConfigurations[line] || "";
+    return entry !== this.ALL_RULES && !entry.includes(ruleName);
+  }
 
-        if (rules === this.ALL_RULES) {
-            // set line config to "all" to cover all rules regardless of
-            // whether it was previously undefined or a set of rules
-            this.lineConfigurations[line] = this.ALL_RULES;
-            return;
-        }
+  _constructLineConfigurations() {
+    this.commentTokens.forEach(token => {
+      this._constructLineConfigurationFromComment(token);
+    });
+  }
 
-        // If line config is undefined, assign array of rule names.
-        // If array already exists, append the new rules list to it.
-        this.lineConfigurations[line] = (this.lineConfigurations[line] || []).concat(rules);
+  _addRulesToLineConfig(line, rules) {
+    // If line configuration is "all", then we've already covered all rules.
+    // No need to add any more to list.
+    if (this.lineConfigurations[line] === this.ALL_RULES) {
+      return;
     }
 
-    _constructLineConfigurationFromComment(token) {
-        const SD = "solium-disable", SDL = `${SD}-line`,
-            SDNL = `${SD}-next-line`, text = this._cleanCommentText(token.text);
-
-        // Important that we check for SDNL & SDL first. If they exist, then includes() will return true for SD anyway.
-        if (text.includes(SDL)) {
-            return this._addRulesToLineConfig(astUtils.getLine(token), this._parseRuleNames(text, SDL));
-        }
-
-        // Notice how we use getEndingLine() for SDNL & SD to ensure that in case of block
-        // comment directive spanning over multiple lines, the disabling starts after the comment ends.
-        // (SDL should disable on line on which the comment starts, so getLine() is used for it)
-        if (text.includes(SDNL)) {
-            return this._addRulesToLineConfig(astUtils.getEndingLine(token) + 1, this._parseRuleNames(text, SDNL));
-        }
-
-        if (text.includes(SD)) {
-            const currLine = astUtils.getEndingLine(token), rulesToDisable = this._parseRuleNames(text, SD);
-            const objContext = this;
-
-            // Set desired configuration for all lines below the SD comment directive
-            this._toEndOfFile(
-                currLine + 1, lineNum => { objContext._addRulesToLineConfig(lineNum, rulesToDisable); });
-        }
-
-        // If none of the above branches were executed, then the current comment is not a solium directive.
+    if (rules === this.ALL_RULES) {
+      // set line config to "all" to cover all rules regardless of
+      // whether it was previously undefined or a set of rules
+      this.lineConfigurations[line] = this.ALL_RULES;
+      return;
     }
 
-    // Remove all comment-related syntax so we only have configuration string + whitespace
-    _cleanCommentText(text) {
-        return text.replace("//", "").replace("/*", "").replace("*/", "");
+    // If line config is undefined, assign array of rule names.
+    // If array already exists, append the new rules list to it.
+    this.lineConfigurations[line] = (
+      this.lineConfigurations[line] || []
+    ).concat(rules);
+  }
+
+  _constructLineConfigurationFromComment(token) {
+    const SD = "solium-disable",
+      SDL = `${SD}-line`,
+      SDNL = `${SD}-next-line`,
+      text = this._cleanCommentText(token.text);
+
+    // Important that we check for SDNL & SDL first. If they exist, then includes() will return true for SD anyway.
+    if (text.includes(SDL)) {
+      return this._addRulesToLineConfig(
+        astUtils.getLine(token),
+        this._parseRuleNames(text, SDL)
+      );
     }
 
-    // If the directive is followed by a list of rule names, extract them into Array.
-    // If not, it means all rules must be disabled for the line(s) covered by that directive.
-    _parseRuleNames(text, prefixToRemove) {
-        text = text.replace(prefixToRemove, "");
-        const rulesToDisable = text
-            .split(",")
-            .map(r => r.trim())
-            .filter(r => r.length > 0);
-
-        return rulesToDisable.length > 0 ? rulesToDisable : this.ALL_RULES;
+    // Notice how we use getEndingLine() for SDNL & SD to ensure that in case of block
+    // comment directive spanning over multiple lines, the disabling starts after the comment ends.
+    // (SDL should disable on line on which the comment starts, so getLine() is used for it)
+    if (text.includes(SDNL)) {
+      return this._addRulesToLineConfig(
+        astUtils.getEndingLine(token) + 1,
+        this._parseRuleNames(text, SDNL)
+      );
     }
 
-    // Performs the given action (callback) from the given line no. to last line of source code.
-    _toEndOfFile(from, action) {
-        for (let i = from; i <= this.lastLine; i++) {
-            action(i);
-        }
+    if (text.includes(SD)) {
+      const currLine = astUtils.getEndingLine(token),
+        rulesToDisable = this._parseRuleNames(text, SD);
+      const objContext = this;
+
+      // Set desired configuration for all lines below the SD comment directive
+      this._toEndOfFile(currLine + 1, lineNum => {
+        objContext._addRulesToLineConfig(lineNum, rulesToDisable);
+      });
     }
 
+    // If none of the above branches were executed, then the current comment is not a solium directive.
+  }
+
+  // Remove all comment-related syntax so we only have configuration string + whitespace
+  _cleanCommentText(text) {
+    return text
+      .replace("//", "")
+      .replace("/*", "")
+      .replace("*/", "");
+  }
+
+  // If the directive is followed by a list of rule names, extract them into Array.
+  // If not, it means all rules must be disabled for the line(s) covered by that directive.
+  _parseRuleNames(text, prefixToRemove) {
+    text = text.replace(prefixToRemove, "");
+    const rulesToDisable = text
+      .split(",")
+      .map(r => r.trim())
+      .filter(r => r.length > 0);
+
+    return rulesToDisable.length > 0 ? rulesToDisable : this.ALL_RULES;
+  }
+
+  // Performs the given action (callback) from the given line no. to last line of source code.
+  _toEndOfFile(from, action) {
+    for (let i = from; i <= this.lastLine; i++) {
+      action(i);
+    }
+  }
 }
-
 
 module.exports = CommentDirectiveParser;

--- a/lib/reporters/gcc.js
+++ b/lib/reporters/gcc.js
@@ -6,42 +6,46 @@
 "use strict";
 
 module.exports = {
+  reportFatal: function(message) {
+    console.log("[Fatal Error] " + message);
+  },
 
-    reportFatal: function(message) {
-        console.log("[Fatal Error] " + message);
-    },
+  reportInternal: function(message) {
+    console.log("[Warning] " + message);
+  },
 
-    reportInternal: function(message) {
-        console.log("[Warning] " + message);
-    },
+  report: function(filename, sourceCode, lintErrors, fixesApplied) {
+    let internalIssuesExist = false;
 
-    report: function(filename, sourceCode, lintErrors, fixesApplied) {
-        let internalIssuesExist = false;
+    // Examine internal issues first
+    lintErrors.forEach(function(issue, index) {
+      if (!issue.internal) {
+        return;
+      }
 
-        // Examine internal issues first
-        lintErrors.forEach(function(issue, index) {
-            if (!issue.internal) {
-                return;
-            }
+      console.log(issue.message);
 
-            console.log(issue.message);
+      delete lintErrors[index];
+      internalIssuesExist = true;
+    });
 
-            delete lintErrors [index];
-            internalIssuesExist = true;
-        });
+    internalIssuesExist && console.log("\n");
 
-        internalIssuesExist && console.log("\n");
+    lintErrors.forEach(function(error) {
+      console.log(
+        filename +
+          ":" +
+          error.line +
+          ":" +
+          error.column +
+          ": " +
+          error.type +
+          ": " +
+          error.message
+      );
+    });
 
-        lintErrors.forEach(function(error) {
-
-            console.log(
-                filename + ":" + error.line + ":" + error.column + ": "
-				+ error.type + ": " + error.message
-            );
-
-        });
-
-        Array.isArray(fixesApplied) && console.log("\nNumber of fixes applied: " + fixesApplied.length);
-    }
-
+    Array.isArray(fixesApplied) &&
+      console.log("\nNumber of fixes applied: " + fixesApplied.length);
+  }
 };

--- a/lib/reporters/pretty.js
+++ b/lib/reporters/pretty.js
@@ -6,113 +6,115 @@
 "use strict";
 
 const path = require("path"),
-    sort = require("lodash/sortBy"), Table = require("text-table");
+  sort = require("lodash/sortBy"),
+  Table = require("text-table");
 require("colors");
 
 let counts = {};
 
-
 function color(type) {
-    return type === "warning" ? "yellow" : "red";
+  return type === "warning" ? "yellow" : "red";
 }
 
 function colorInternalIssue(type) {
-    return type === "warning" ? "blue" : "red";
+  return type === "warning" ? "blue" : "red";
 }
 
-
 module.exports = {
+  // Convenience method when only a message needs to be passed as part of an internal issue
+  reportInternal(message) {
+    process.stdout.write(
+      `[Warning] ${message}\n`[colorInternalIssue("warning")]
+    );
+  },
 
-    // Convenience method when only a message needs to be passed as part of an internal issue
-    reportInternal(message) {
+  reportFatal(message) {
+    process.stdout.write(
+      `\u2716 [Fatal error] ${message}\n`[colorInternalIssue("error")]
+    );
+  },
+
+  report(filename, sourceCode, lintErrors, fixesApplied) {
+    // Remove internal issue, so only rule errors reach the next loop
+    lintErrors.forEach((issue, index) => {
+      if (!issue.internal) {
+        return;
+      }
+
+      const { message, type } = issue;
+      process.stdout.write(`${message[colorInternalIssue(type)]}\n`);
+
+      delete lintErrors[index];
+    });
+
+    // Print the file name
+    process.stdout.write(
+      `\n${filename.replace(path.join(process.cwd(), "/"), "")}\n`.underline
+    );
+
+    const errorEntries = [];
+
+    lintErrors.forEach(error => {
+      const { line, column, type, message, ruleName } = error;
+
+      // Collect the file's errors as rows to feed to text-table
+      errorEntries.push([
+        `  ${line}:${column}  `.bold,
+        `${type}  `[color(type)],
+        `${message}  `,
+        ruleName.grey
+      ]);
+
+      // When the first issue of its type is encountered, create its attribute inside counts object & init to 0
+      if (!counts[error.type]) {
+        counts[error.type] = 0;
+      }
+
+      counts[error.type] += 1;
+    });
+
+    // Generate & print the aligned table of errors
+    process.stdout.write(Table(errorEntries) + "\n");
+
+    if (Array.isArray(fixesApplied)) {
+      counts.fixes = (counts.fixes || 0) + fixesApplied.length;
+    }
+  },
+
+  finalize() {
+    process.stdout.write("\n");
+
+    if (typeof counts.fixes !== "undefined") {
+      if (counts.fixes === 1) {
+        process.stdout.write("\u2714".green + " 1 fix was");
+      } else {
         process.stdout.write(
-            (`[Warning] ${message}\n`)[colorInternalIssue("warning")]);
-    },
+          (counts.fixes === 0 ? "No" : "\u2714 ".green + counts.fixes) +
+            " fixes were"
+        );
+      }
 
-    reportFatal(message) {
-        process.stdout.write(
-            (`\u2716 [Fatal error] ${message}\n`)[colorInternalIssue("error")]);
-    },
-
-    report(filename, sourceCode, lintErrors, fixesApplied) {
-        // Remove internal issue, so only rule errors reach the next loop
-        lintErrors.forEach((issue, index) => {
-            if (!issue.internal) {
-                return;
-            }
-
-            const {message, type} = issue;
-            process.stdout.write(`${message[colorInternalIssue(type)]}\n`);
-
-            delete lintErrors[index];
-        });
-
-        // Print the file name
-        process.stdout.write(
-            (`\n${filename.replace(path.join(process.cwd(), "/"), "")}\n`).underline);
-
-        const errorEntries = [];
-
-        lintErrors.forEach(error => {
-            const { line, column, type, message, ruleName } = error;
-
-            // Collect the file's errors as rows to feed to text-table
-            errorEntries.push([(`  ${line}:${column}  `).bold,
-                (`${type}  `)[color(type)], `${message}  `, (ruleName).grey]);
-
-            // When the first issue of its type is encountered, create its attribute inside counts object & init to 0
-            if (!counts[error.type]) {
-                counts[error.type] = 0;
-            }
-
-            counts[error.type] += 1;
-        });
-
-        // Generate & print the aligned table of errors
-        process.stdout.write(Table(errorEntries) + "\n");
-
-        if (Array.isArray(fixesApplied)) {
-            counts.fixes = (counts.fixes || 0) + fixesApplied.length;
-        }
-    },
-
-
-    finalize() {
-
-        process.stdout.write("\n");
-
-        if (typeof counts.fixes !== "undefined") {
-            if (counts.fixes === 1) {
-                process.stdout.write(("\u2714").green + " 1 fix was");
-            } else {
-                process.stdout.write(
-                    (counts.fixes === 0 ? "No" : ((("\u2714 ").green) + counts.fixes)) + " fixes were");
-            }
-
-            process.stdout.write(" applied.\n");
-        }
-
-        delete counts.fixes;
-        const errorTypes = sort(Object.keys(counts));
-
-        if (errorTypes.length === 0) {
-            process.stdout.write(("No issues found.\n\n").green);
-        } else {
-
-            process.stdout.write(("\u2716 ").red);
-
-            errorTypes.forEach((type, i) => {
-                const sep = (i === 0) ? "" : ", ";
-                const plural = (counts[type] !== 1) ? "s" : "";
-
-                process.stdout.write((sep + (counts[type] + " " + type + plural)).red);
-            });
-
-            process.stdout.write((" found.\n\n").red);
-        }
-
-        counts = {};
-
+      process.stdout.write(" applied.\n");
     }
 
+    delete counts.fixes;
+    const errorTypes = sort(Object.keys(counts));
+
+    if (errorTypes.length === 0) {
+      process.stdout.write("No issues found.\n\n".green);
+    } else {
+      process.stdout.write("\u2716 ".red);
+
+      errorTypes.forEach((type, i) => {
+        const sep = i === 0 ? "" : ", ";
+        const plural = counts[type] !== 1 ? "s" : "";
+
+        process.stdout.write((sep + (counts[type] + " " + type + plural)).red);
+      });
+
+      process.stdout.write(" found.\n\n".red);
+    }
+
+    counts = {};
+  }
 };

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -6,12 +6,11 @@
 "use strict";
 
 let util = require("util"),
-    { EOL } = require("os"),
-    isErrObjectValid = require("../config/schemas/error-reported-by-rule").validationFunc;
+  { EOL } = require("os"),
+  isErrObjectValid = require("../config/schemas/error-reported-by-rule")
+    .validationFunc;
 
-let INHERITABLE_METHODS = [
-    "getSourceCode"
-];
+let INHERITABLE_METHODS = ["getSourceCode"];
 
 /**
  * context object Constructor to set read-only properties and provide additional functionality to the rules using it
@@ -21,51 +20,54 @@ let INHERITABLE_METHODS = [
  * @param {Object} Solium Main Solium object from which to inherit functionality to provide to the rules
  */
 function RuleContext(ruleName, ruleDesc, ruleMeta, Solium) {
-    let contextObject = this;
+  let contextObject = this;
 
-    // Set contect attribute 'options' iff options were provided.
-    ruleDesc.options && Object.assign(contextObject, { options: ruleDesc.options });
+  // Set contect attribute 'options' iff options were provided.
+  ruleDesc.options &&
+    Object.assign(contextObject, { options: ruleDesc.options });
 
-    //set read-only properties of the context object
-    Object.defineProperties(contextObject, {
+  //set read-only properties of the context object
+  Object.defineProperties(contextObject, {
+    name: {
+      value: ruleName,
+      writable: false //though the default is false anyway, I think its better to express your intention clearly
+    },
 
-        name: {
-            value: ruleName,
-            writable: false	//though the default is false anyway, I think its better to express your intention clearly
-        },
+    meta: {
+      value: ruleDesc,
+      writable: false
+    }
+  });
 
-        meta: {
-            value: ruleDesc,
-            writable: false
-        }
-
-    });
-
-    //inherit all Solium methods which are of relevance to the rule
-    INHERITABLE_METHODS.forEach(function(methodName) {
-        contextObject [methodName] = function(s, z, a, b, o) {	//every method will receive 5 arguments tops
-            return Solium [methodName].call(Solium, s, z, a, b, o);
-        };
-    });
-
-    /**
-     * wrapper around Solium.report () which adds some additional information to the error object
-     * @param {Object} error An object describing the lint error, sent by the rule currently running
-     */
-    contextObject.report = function(error) {
-
-        if (!isErrObjectValid(error)) {
-            throw new Error(
-                `Rule "${ruleName}": invalid error object was passed. AJV message:${EOL}${util.inspect(isErrObjectValid.errors)}`
-            );
-        }
-
-        Object.assign(error, { ruleName: ruleName, ruleMeta: ruleMeta, type: contextObject.meta.type });
-        Solium.report(error);
-
+  //inherit all Solium methods which are of relevance to the rule
+  INHERITABLE_METHODS.forEach(function(methodName) {
+    contextObject[methodName] = function(s, z, a, b, o) {
+      //every method will receive 5 arguments tops
+      return Solium[methodName].call(Solium, s, z, a, b, o);
     };
-}
+  });
 
+  /**
+   * wrapper around Solium.report () which adds some additional information to the error object
+   * @param {Object} error An object describing the lint error, sent by the rule currently running
+   */
+  contextObject.report = function(error) {
+    if (!isErrObjectValid(error)) {
+      throw new Error(
+        `Rule "${ruleName}": invalid error object was passed. AJV message:${EOL}${util.inspect(
+          isErrObjectValid.errors
+        )}`
+      );
+    }
+
+    Object.assign(error, {
+      ruleName: ruleName,
+      ruleMeta: ruleMeta,
+      type: contextObject.meta.type
+    });
+    Solium.report(error);
+  };
+}
 
 RuleContext.prototype = { constructor: RuleContext };
 module.exports = RuleContext;

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -6,242 +6,267 @@
 "use strict";
 
 let fs = require("fs"),
-    path = require("path"),
-    util = require("util"),
-    jsUtils = require("./utils/js-utils"),
-    ruleLoader = require("./utils/rule-loader"),
-    soliumRules = require("../config/solium").rules,	//list of all rules available inside solium
-    rules = {};
+  path = require("path"),
+  util = require("util"),
+  jsUtils = require("./utils/js-utils"),
+  ruleLoader = require("./utils/rule-loader"),
+  soliumRules = require("../config/solium").rules, //list of all rules available inside solium
+  rules = {};
 
-let RULES_DIR = path.join(__dirname, ruleLoader.constants.SOLIUM_CORE_RULES_DIRNAME),
-    JS_EXT = ".js";
+let RULES_DIR = path.join(
+    __dirname,
+    ruleLoader.constants.SOLIUM_CORE_RULES_DIRNAME
+  ),
+  JS_EXT = ".js";
 
 // Utilities for getRuleSeverity()
 let configSchema = require("../config/schemas/config"),
-    SchemaValidator = new require("ajv")({ allErrors: true }),
-    severityValueSchemas = configSchema.properties.rules.patternProperties ["^.+$"].oneOf;
+  SchemaValidator = new require("ajv")({ allErrors: true }),
+  severityValueSchemas =
+    configSchema.properties.rules.patternProperties["^.+$"].oneOf;
 
-let isValidSeverityString = SchemaValidator.compile(severityValueSchemas [0]),
-    isValidSeverityInt = SchemaValidator.compile(severityValueSchemas [1]),
-    isValidSeverityArray = SchemaValidator.compile(severityValueSchemas [2]),
-    isAValidPlugin = require("../config/schemas/plugin").validationFunc;
+let isValidSeverityString = SchemaValidator.compile(severityValueSchemas[0]),
+  isValidSeverityInt = SchemaValidator.compile(severityValueSchemas[1]),
+  isValidSeverityArray = SchemaValidator.compile(severityValueSchemas[2]),
+  isAValidPlugin = require("../config/schemas/plugin").validationFunc;
 
 module.exports = {
+  /**
+   * Reset state so previous lint's configuration doesn't interfere with the next one
+   * @returns {void}
+   */
+  reset: function() {
+    rules = {}; //clear rule cache before populating them
+  },
 
-    /**
-	 * Reset state so previous lint's configuration doesn't interfere with the next one
-	 * @returns {void}
-	 */
-    reset: function() {
-        rules = {};	//clear rule cache before populating them
-    },
+  /**
+   * load the user-specified rules from the rules/ directory and custom rules from specified file
+   * This function loads rule information from a DEPRECATED config format.
+   * @param {Object} userRules object whose keys specify the rule name and boolean values specify whether to include it
+   * @param {String} customRulesFilePath The file from where definitions of user-defined rules are loaded
+   * @returns {Object} userRules Definitions of all user-requested rules. Throws error if a rule in userRules is not amongst available rules
+   */
+  loadUsingDeprecatedConfigFormat: function(
+    userRules,
+    customRulesFilePath,
+    noReset
+  ) {
+    let ruleFiles,
+      idCounter = 1;
 
-    /**
-	 * load the user-specified rules from the rules/ directory and custom rules from specified file
-	 * This function loads rule information from a DEPRECATED config format.
-	 * @param {Object} userRules object whose keys specify the rule name and boolean values specify whether to include it
-	 * @param {String} customRulesFilePath The file from where definitions of user-defined rules are loaded
-	 * @returns {Object} userRules Definitions of all user-requested rules. Throws error if a rule in userRules is not amongst available rules
-	 */
-    loadUsingDeprecatedConfigFormat: function(userRules, customRulesFilePath, noReset) {
-        let ruleFiles, idCounter = 1;
-
-        if (!jsUtils.isStrictlyObject(userRules)) {
-            throw new Error("Invalid rules object");
-        }
-
-        try {
-            ruleFiles = fs.readdirSync(RULES_DIR);
-        } catch (e) {
-            throw new Error("Unable to read " + RULES_DIR + ": " + e.message);
-        }
-
-        !noReset && this.reset();
-
-        ruleFiles.forEach(function(filename) {
-            let ruleName = filename.slice(0, -JS_EXT.length),
-                absoluteRuleFilePath = path.join(RULES_DIR, filename);
-
-            if (path.extname(filename) === JS_EXT && userRules [ruleName]) {
-                try {
-                    rules [ruleName] = require(absoluteRuleFilePath);
-                } catch (e) {
-                    throw new Error("Unable to read " + absoluteRuleFilePath + ": " + e.message);
-                }
-            }
-        });
-
-        Object.keys(userRules).forEach(function(key) {
-
-            /**
-			 * If a rule is set to false, remove it from config object.
-			 * Otherwise, include its definition if its the name of a built-in rule
-			 */
-            if (!userRules [key]) {
-                delete userRules [key];
-            } else if (soliumRules [key] && soliumRules [key].enabled) {
-
-                userRules [key] = soliumRules [key];
-                Object.assign(userRules [key], {
-                    id: idCounter++,
-                    custom: false
-                });
-
-            }
-
-        });
-
-        //if there is still a rule set to true and not yet expanded, its an invalid rule (neither built-in nor custom)
-        Object.keys(userRules).forEach(function(ruleName) {
-            if (typeof userRules [ruleName] !== "object") {
-                throw new Error("Rule " + ruleName + " was not found");
-            }
-        });
-
-        return userRules;
-    },
-
-    /**
-	 * Load Solium rules as described in the configuration object provided.
-	 * @param {Object} config The configuration object (read from soliumrc) that describes what rules the user wishes to apply.
-	 * @param {Boolean} noReset Determines whether to re-initilize internal variables or not. If this param has a false-equivalent value, data is reset.
-	 * @returns {Object} userRules Definitions of all user-requested rules. Throws error if a rule in userRules is not amongst available rules
-	 */
-    load: function(config, noReset) {
-        let ruleDescriptions = {}, ruleConfigs = {}, getRuleSeverity = this.getRuleSeverity;
-
-        !noReset && this.reset();
-
-        // If plugins are passed, ensure all of them are installed in the same scope as Solium.
-        // If not, provide appropriate error messages, instructions & doc links.
-        if (config.plugins && config.plugins.length) {
-            // eslint-disable-next-line no-inner-declarations
-            function validatePlugin(pName) {
-                // User must only provide the plugin name, not the solium plugin prefix string
-                let plugin, pNameWithoutPrefix = pName;
-                pName = ruleLoader.constants.SOLIUM_PLUGIN_PREFIX + pName;
-
-                try {
-                    plugin = require(pName);
-                } catch (e) {
-                    if (e.code === "MODULE_NOT_FOUND") {
-                        // Plugin is not installed in Solium's scope
-                        throw new Error(
-                            "Oops! The Plugin \"" + pName + "\" was not found." +
-							"\n\nPlease make sure that it is installed globally by running \"npm install -g " + pName + "\""
-                        );
-                    }
-
-                    // Some other error
-                    throw new Error(
-                        "Oops! An error occured while trying to load the plugin \"" +
-						pName + "\"." + e.message +
-						"\n\nPlease see http://solium.readthedocs.io/en/latest/user-guide.html#plugins for plugin usage."
-                    );
-                }
-
-                // If plugin was loaded successfully, validate it using schema.
-                if (!isAValidPlugin(plugin)) {
-                    throw new Error(
-                        "\"" + pName + "\" is not a valid plugin." +
-						"\nPlease see http://solium.readthedocs.io/en/latest/developer-guide.html#developing-a-plugin" + 
-						" for plugin development. AJV Message:\n" +	util.inspect(isAValidPlugin.errors)
-                    );
-                }
-
-                // Finally, load plugin's default rule configuration into ruleConfigs
-                Object.assign(ruleConfigs, ruleLoader.resolvePluginConfig(pNameWithoutPrefix, plugin));
-            }
-
-            config.plugins.forEach(validatePlugin);
-        }
-
-        if (config.extends) {
-            try {
-                Object.assign(ruleConfigs, ruleLoader.resolveUpstream(config.extends));
-            } catch (e) {
-                throw new Error(
-                    `An error occured while trying to resolve dependancy "${config.extends}": ${e.message}`
-                );
-            }
-        }
-
-        // If both extends & rules attributes exist, the rules imported from "rules" attr will override any rules
-        // imported from "extends" in case of a name clash.
-        if (config.rules && Object.keys(config.rules).length) {
-            Object.assign(ruleConfigs, config.rules);
-        }
-
-        // Remove all rules that are disabled.
-        Object.keys(ruleConfigs).forEach(function(name) {
-            getRuleSeverity(ruleConfigs [name]) < 1 && delete ruleConfigs [name];
-        });
-
-
-        // Load all enabled rules.
-        try {
-            Object.assign(rules, ruleLoader.load(Object.keys(ruleConfigs)));
-        } catch (e) {
-            throw new Error(`An error occured while trying to load rules: ${e.message}`);
-        }
-
-        // Use rule definitions & configs to generate ruleDescriptions
-        Object.keys(rules).forEach(function(name) {
-            if (rules [name] === undefined) {
-                // If undefined, it means we didn't require() any rule by this name, ie, none exists
-                throw new Error(`"${name}" - No such rule exists.`);
-            }
-
-            let desc = {
-                description: rules [name].meta.docs.description,
-                recommended: rules [name].meta.docs.recommended,
-                type: (getRuleSeverity(ruleConfigs [name]) === 1) ? "warning" : "error"
-            };
-
-            // Only set "options" attribute if the rule config is an array of length is at least 2.
-            if (Array.isArray(ruleConfigs [name]) && ruleConfigs [name].length > 1) {
-                desc.options = ruleConfigs [name].slice(1);
-            }
-
-            ruleDescriptions [name] = desc;
-        });
-
-        return ruleDescriptions;
-    },
-
-    /**
-	 * context object Constructor to set read-only properties and provide additional functionality to the rules using it
-	 * @returns {Object} rule Rule object containing function to execute rule, exported by the rule's file
-	 */
-    get: function(name) {
-        if (name && typeof name === "string") {
-            return rules [name];
-        } else {
-            throw new Error(name + " is an invalid argument");
-        }
-    },
-
-    /**
-	 * Get severity value for a rule from its given configuration description.
-	 * @param {Integer|String|Array} ruleConfig configuration for the rule (picked up from soliumrc)
-	 * @returns {Integer} severity Either 0 (rule turned off), 1 (warning) or 2 (error).
-	 */
-    getRuleSeverity: function getRuleSeverity(ruleConfig) {
-        if (isValidSeverityInt(ruleConfig)) {
-            return ruleConfig;
-        }
-
-        if (isValidSeverityString(ruleConfig)) {
-            return ({
-                "off": 0, "warning": 1, "error": 2
-            }) [ruleConfig];
-        }
-
-        if (isValidSeverityArray(ruleConfig)) {
-            return getRuleSeverity(ruleConfig [0]);
-        }
-
-        throw new Error("Invalid configuration value for rule.");
+    if (!jsUtils.isStrictlyObject(userRules)) {
+      throw new Error("Invalid rules object");
     }
 
+    try {
+      ruleFiles = fs.readdirSync(RULES_DIR);
+    } catch (e) {
+      throw new Error("Unable to read " + RULES_DIR + ": " + e.message);
+    }
+
+    !noReset && this.reset();
+
+    ruleFiles.forEach(function(filename) {
+      let ruleName = filename.slice(0, -JS_EXT.length),
+        absoluteRuleFilePath = path.join(RULES_DIR, filename);
+
+      if (path.extname(filename) === JS_EXT && userRules[ruleName]) {
+        try {
+          rules[ruleName] = require(absoluteRuleFilePath);
+        } catch (e) {
+          throw new Error(
+            "Unable to read " + absoluteRuleFilePath + ": " + e.message
+          );
+        }
+      }
+    });
+
+    Object.keys(userRules).forEach(function(key) {
+      /**
+       * If a rule is set to false, remove it from config object.
+       * Otherwise, include its definition if its the name of a built-in rule
+       */
+      if (!userRules[key]) {
+        delete userRules[key];
+      } else if (soliumRules[key] && soliumRules[key].enabled) {
+        userRules[key] = soliumRules[key];
+        Object.assign(userRules[key], {
+          id: idCounter++,
+          custom: false
+        });
+      }
+    });
+
+    //if there is still a rule set to true and not yet expanded, its an invalid rule (neither built-in nor custom)
+    Object.keys(userRules).forEach(function(ruleName) {
+      if (typeof userRules[ruleName] !== "object") {
+        throw new Error("Rule " + ruleName + " was not found");
+      }
+    });
+
+    return userRules;
+  },
+
+  /**
+   * Load Solium rules as described in the configuration object provided.
+   * @param {Object} config The configuration object (read from soliumrc) that describes what rules the user wishes to apply.
+   * @param {Boolean} noReset Determines whether to re-initilize internal variables or not. If this param has a false-equivalent value, data is reset.
+   * @returns {Object} userRules Definitions of all user-requested rules. Throws error if a rule in userRules is not amongst available rules
+   */
+  load: function(config, noReset) {
+    let ruleDescriptions = {},
+      ruleConfigs = {},
+      getRuleSeverity = this.getRuleSeverity;
+
+    !noReset && this.reset();
+
+    // If plugins are passed, ensure all of them are installed in the same scope as Solium.
+    // If not, provide appropriate error messages, instructions & doc links.
+    if (config.plugins && config.plugins.length) {
+      // eslint-disable-next-line no-inner-declarations
+      function validatePlugin(pName) {
+        // User must only provide the plugin name, not the solium plugin prefix string
+        let plugin,
+          pNameWithoutPrefix = pName;
+        pName = ruleLoader.constants.SOLIUM_PLUGIN_PREFIX + pName;
+
+        try {
+          plugin = require(pName);
+        } catch (e) {
+          if (e.code === "MODULE_NOT_FOUND") {
+            // Plugin is not installed in Solium's scope
+            throw new Error(
+              'Oops! The Plugin "' +
+                pName +
+                '" was not found.' +
+                '\n\nPlease make sure that it is installed globally by running "npm install -g ' +
+                pName +
+                '"'
+            );
+          }
+
+          // Some other error
+          throw new Error(
+            'Oops! An error occured while trying to load the plugin "' +
+              pName +
+              '".' +
+              e.message +
+              "\n\nPlease see http://solium.readthedocs.io/en/latest/user-guide.html#plugins for plugin usage."
+          );
+        }
+
+        // If plugin was loaded successfully, validate it using schema.
+        if (!isAValidPlugin(plugin)) {
+          throw new Error(
+            '"' +
+              pName +
+              '" is not a valid plugin.' +
+              "\nPlease see http://solium.readthedocs.io/en/latest/developer-guide.html#developing-a-plugin" +
+              " for plugin development. AJV Message:\n" +
+              util.inspect(isAValidPlugin.errors)
+          );
+        }
+
+        // Finally, load plugin's default rule configuration into ruleConfigs
+        Object.assign(
+          ruleConfigs,
+          ruleLoader.resolvePluginConfig(pNameWithoutPrefix, plugin)
+        );
+      }
+
+      config.plugins.forEach(validatePlugin);
+    }
+
+    if (config.extends) {
+      try {
+        Object.assign(ruleConfigs, ruleLoader.resolveUpstream(config.extends));
+      } catch (e) {
+        throw new Error(
+          `An error occured while trying to resolve dependancy "${
+            config.extends
+          }": ${e.message}`
+        );
+      }
+    }
+
+    // If both extends & rules attributes exist, the rules imported from "rules" attr will override any rules
+    // imported from "extends" in case of a name clash.
+    if (config.rules && Object.keys(config.rules).length) {
+      Object.assign(ruleConfigs, config.rules);
+    }
+
+    // Remove all rules that are disabled.
+    Object.keys(ruleConfigs).forEach(function(name) {
+      getRuleSeverity(ruleConfigs[name]) < 1 && delete ruleConfigs[name];
+    });
+
+    // Load all enabled rules.
+    try {
+      Object.assign(rules, ruleLoader.load(Object.keys(ruleConfigs)));
+    } catch (e) {
+      throw new Error(
+        `An error occured while trying to load rules: ${e.message}`
+      );
+    }
+
+    // Use rule definitions & configs to generate ruleDescriptions
+    Object.keys(rules).forEach(function(name) {
+      if (rules[name] === undefined) {
+        // If undefined, it means we didn't require() any rule by this name, ie, none exists
+        throw new Error(`"${name}" - No such rule exists.`);
+      }
+
+      let desc = {
+        description: rules[name].meta.docs.description,
+        recommended: rules[name].meta.docs.recommended,
+        type: getRuleSeverity(ruleConfigs[name]) === 1 ? "warning" : "error"
+      };
+
+      // Only set "options" attribute if the rule config is an array of length is at least 2.
+      if (Array.isArray(ruleConfigs[name]) && ruleConfigs[name].length > 1) {
+        desc.options = ruleConfigs[name].slice(1);
+      }
+
+      ruleDescriptions[name] = desc;
+    });
+
+    return ruleDescriptions;
+  },
+
+  /**
+   * context object Constructor to set read-only properties and provide additional functionality to the rules using it
+   * @returns {Object} rule Rule object containing function to execute rule, exported by the rule's file
+   */
+  get: function(name) {
+    if (name && typeof name === "string") {
+      return rules[name];
+    } else {
+      throw new Error(name + " is an invalid argument");
+    }
+  },
+
+  /**
+   * Get severity value for a rule from its given configuration description.
+   * @param {Integer|String|Array} ruleConfig configuration for the rule (picked up from soliumrc)
+   * @returns {Integer} severity Either 0 (rule turned off), 1 (warning) or 2 (error).
+   */
+  getRuleSeverity: function getRuleSeverity(ruleConfig) {
+    if (isValidSeverityInt(ruleConfig)) {
+      return ruleConfig;
+    }
+
+    if (isValidSeverityString(ruleConfig)) {
+      return {
+        off: 0,
+        warning: 1,
+        error: 2
+      }[ruleConfig];
+    }
+
+    if (isValidSeverityArray(ruleConfig)) {
+      return getRuleSeverity(ruleConfig[0]);
+    }
+
+    throw new Error("Invalid configuration value for rule.");
+  }
 };

--- a/lib/rules/arg-overflow.js
+++ b/lib/rules/arg-overflow.js
@@ -5,120 +5,136 @@
 
 "use strict";
 
-
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "In the case of 4 or more items in the same line, require they are instead put on a single line each"
-        },
-
-        schema: [{
-            type: "integer", minimum: 1
-        }]
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "In the case of 4 or more items in the same line, require they are instead put on a single line each"
     },
 
-    create: function(context) {
+    schema: [
+      {
+        type: "integer",
+        minimum: 1
+      }
+    ]
+  },
 
-        let MAX_IN_SINGLE_LINE = context.options ? context.options [0] : 3;
+  create: function(context) {
+    let MAX_IN_SINGLE_LINE = context.options ? context.options[0] : 3;
 
-        let sourceCode = context.getSourceCode();
+    let sourceCode = context.getSourceCode();
 
-        function inspectArrayExpression(emitted) {
-            let node = emitted.node, elements = node.elements;
-            let endingLineNum = sourceCode.getEndingLine(node);
+    function inspectArrayExpression(emitted) {
+      let node = emitted.node,
+        elements = node.elements;
+      let endingLineNum = sourceCode.getEndingLine(node);
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            if (sourceCode.getLine(node) === endingLineNum) {
-                if (elements.length > MAX_IN_SINGLE_LINE) {
-                    context.report({
-                        node: node,
-                        message: "In case of more than " + MAX_IN_SINGLE_LINE +
-							" elements, array expression needs to be spread over multiple lines with 1 element per line."
-                    });
-                }
-
-                return;
-            }
+      if (sourceCode.getLine(node) === endingLineNum) {
+        if (elements.length > MAX_IN_SINGLE_LINE) {
+          context.report({
+            node: node,
+            message:
+              "In case of more than " +
+              MAX_IN_SINGLE_LINE +
+              " elements, array expression needs to be spread over multiple lines with 1 element per line."
+          });
         }
 
-        function inspectStructDeclaration(emitted) {
-            let node = emitted.node,
-                body = node.body || [],
-                endingLineNum = sourceCode.getEndingLine(node);
-
-            if (emitted.exit) {
-                return;
-            }
-
-            //raise an error and stop linting if more than 3 attributes exist & declaration is on single line
-            if (sourceCode.getLine(node) === endingLineNum) {
-                if (body.length > MAX_IN_SINGLE_LINE) {
-                    context.report({
-                        node: node,
-                        message: "\"" + node.name + "\": In case of more than " + MAX_IN_SINGLE_LINE + " properties, struct declaration needs to be spread over multiple lines with 1 property per line."
-                    });
-                }
-                return;
-            }
-        }
-
-        //function params (if on multiple lines)
-        function inspectFunctionDeclaration(emitted) {
-            let node = emitted.node, params = node.params || [];
-
-            let startLine = sourceCode.getLine(node),
-                lastArgLine = params.length ? sourceCode.getEndingLine(params.slice(-1) [0]) : startLine;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            if (startLine === lastArgLine) {
-                if (params.length > MAX_IN_SINGLE_LINE) {
-                    context.report({
-                        node: node,
-                        message: "In case of more than " + MAX_IN_SINGLE_LINE + " parameters, drop each into its own line."
-                    });
-                }
-                return;
-            }
-        }
-
-        function inspectCallExpression(emitted) {
-
-            let node = emitted.node;
-            let endingLineNum = sourceCode.getEndingLine(node);
-
-            if (emitted.exit) {
-                return;
-            }
-
-            if (sourceCode.getLine(node) === endingLineNum) {
-                if (node.arguments.length > MAX_IN_SINGLE_LINE) {
-                    context.report({
-                        node: node,
-                        message: "Function \"" + node.callee.name + "\": in case of more than " + MAX_IN_SINGLE_LINE + " arguments, drop each into its own line."
-                    });
-                }
-                return;
-            }
-        }
-
-        return {
-            CallExpression: inspectCallExpression,
-            FunctionDeclaration: inspectFunctionDeclaration,
-            ConstructorDeclaration: inspectFunctionDeclaration,
-            StructDeclaration: inspectStructDeclaration,
-            ArrayExpression: inspectArrayExpression
-        };
-
+        return;
+      }
     }
+
+    function inspectStructDeclaration(emitted) {
+      let node = emitted.node,
+        body = node.body || [],
+        endingLineNum = sourceCode.getEndingLine(node);
+
+      if (emitted.exit) {
+        return;
+      }
+
+      //raise an error and stop linting if more than 3 attributes exist & declaration is on single line
+      if (sourceCode.getLine(node) === endingLineNum) {
+        if (body.length > MAX_IN_SINGLE_LINE) {
+          context.report({
+            node: node,
+            message:
+              '"' +
+              node.name +
+              '": In case of more than ' +
+              MAX_IN_SINGLE_LINE +
+              " properties, struct declaration needs to be spread over multiple lines with 1 property per line."
+          });
+        }
+        return;
+      }
+    }
+
+    //function params (if on multiple lines)
+    function inspectFunctionDeclaration(emitted) {
+      let node = emitted.node,
+        params = node.params || [];
+
+      let startLine = sourceCode.getLine(node),
+        lastArgLine = params.length
+          ? sourceCode.getEndingLine(params.slice(-1)[0])
+          : startLine;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      if (startLine === lastArgLine) {
+        if (params.length > MAX_IN_SINGLE_LINE) {
+          context.report({
+            node: node,
+            message:
+              "In case of more than " +
+              MAX_IN_SINGLE_LINE +
+              " parameters, drop each into its own line."
+          });
+        }
+        return;
+      }
+    }
+
+    function inspectCallExpression(emitted) {
+      let node = emitted.node;
+      let endingLineNum = sourceCode.getEndingLine(node);
+
+      if (emitted.exit) {
+        return;
+      }
+
+      if (sourceCode.getLine(node) === endingLineNum) {
+        if (node.arguments.length > MAX_IN_SINGLE_LINE) {
+          context.report({
+            node: node,
+            message:
+              'Function "' +
+              node.callee.name +
+              '": in case of more than ' +
+              MAX_IN_SINGLE_LINE +
+              " arguments, drop each into its own line."
+          });
+        }
+        return;
+      }
+    }
+
+    return {
+      CallExpression: inspectCallExpression,
+      FunctionDeclaration: inspectFunctionDeclaration,
+      ConstructorDeclaration: inspectFunctionDeclaration,
+      StructDeclaration: inspectStructDeclaration,
+      ArrayExpression: inspectArrayExpression
+    };
+  }
 };

--- a/lib/rules/array-declarations.js
+++ b/lib/rules/array-declarations.js
@@ -6,81 +6,93 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that array declarations don't have space between the type and brackets"
-        },
-
-        schema: [],
-
-        fixable: "whitespace"
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure that array declarations don't have space between the type and brackets"
     },
 
-    create: function(context) {
+    schema: [],
 
-        let sourceCode = context.getSourceCode();
+    fixable: "whitespace"
+  },
 
-        function inspectType(emitted) {
-            let node = emitted.node;
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
-            if (emitted.exit || !node.array_parts.length) {
-                return;
-            }
+    function inspectType(emitted) {
+      let node = emitted.node;
 
-            let code = sourceCode.getText(node), whitespaceDetector = /\s*(?=\[)/;
+      if (emitted.exit || !node.array_parts.length) {
+        return;
+      }
 
-            // First the regex must detect whitespace between literal and opening bracket
-            let scanned = whitespaceDetector.exec(code),
-                whitespaceString = scanned [0], index = scanned.index;
+      let code = sourceCode.getText(node),
+        whitespaceDetector = /\s*(?=\[)/;
 
-            whitespaceString !== "" && context.report({
-                node: node,
-                location: { column: index + 1 },
-                message: (
-                    "There should be no whitespace between \""
-					+ code.slice(0, index) + "\" and the opening square bracket."
-                ),
-                fix: function(fixer) {
-                    return [fixer.removeRange(
-                        [node.start + index, node.start + index + whitespaceString.length])];
-                }
-            });
+      // First the regex must detect whitespace between literal and opening bracket
+      let scanned = whitespaceDetector.exec(code),
+        whitespaceString = scanned[0],
+        index = scanned.index;
 
-            // Next, the regex must detect whitespace between opening & closing brackets
-            // Since this regex doesn't exclude the brackets themselves, we have to move positions to acquire
-            // the right info.
-            if (node.array_parts.length === 1 && node.array_parts [0] === null) {
-                let bracketString, indexWs;
+      whitespaceString !== "" &&
+        context.report({
+          node: node,
+          location: { column: index + 1 },
+          message:
+            'There should be no whitespace between "' +
+            code.slice(0, index) +
+            '" and the opening square bracket.',
+          fix: function(fixer) {
+            return [
+              fixer.removeRange([
+                node.start + index,
+                node.start + index + whitespaceString.length
+              ])
+            ];
+          }
+        });
 
-                whitespaceDetector = /\[(\s*)\]/;
-                scanned = whitespaceDetector.exec(code);
-                bracketString = scanned [0], whitespaceString = scanned [1], index = scanned.index, indexWs = index + 1;
+      // Next, the regex must detect whitespace between opening & closing brackets
+      // Since this regex doesn't exclude the brackets themselves, we have to move positions to acquire
+      // the right info.
+      if (node.array_parts.length === 1 && node.array_parts[0] === null) {
+        let bracketString, indexWs;
 
-                (whitespaceString !== "") && context.report({
+        whitespaceDetector = /\[(\s*)\]/;
+        scanned = whitespaceDetector.exec(code);
+        (bracketString = scanned[0]),
+          (whitespaceString = scanned[1]),
+          (index = scanned.index),
+          (indexWs = index + 1);
 
-                    node: node,
-                    location: { column: indexWs + 1 },
+        whitespaceString !== "" &&
+          context.report({
+            node: node,
+            location: { column: indexWs + 1 },
 
-                    fix: function(fixer) {
-                        return [fixer.replaceTextRange(
-                            [node.start + index, node.start + index + bracketString.length], "[]")];
-                    },
+            fix: function(fixer) {
+              return [
+                fixer.replaceTextRange(
+                  [
+                    node.start + index,
+                    node.start + index + bracketString.length
+                  ],
+                  "[]"
+                )
+              ];
+            },
 
-                    message: "There should be no whitespace between opening & closing square brackets. Use [] instead."
-
-                });
-            }
-        }
-
-        return {
-            Type: inspectType
-        };
-
+            message:
+              "There should be no whitespace between opening & closing square brackets. Use [] instead."
+          });
+      }
     }
 
+    return {
+      Type: inspectType
+    };
+  }
 };

--- a/lib/rules/blank-lines.js
+++ b/lib/rules/blank-lines.js
@@ -5,182 +5,201 @@
 
 "use strict";
 
-
 const eol = require("os").EOL;
 
-
 function hasNConsecutiveBlankLines(string, n) {
-    let pattern = `(\r?\n[ \t]*){${n},}\r?\n`;
-    return new RegExp(pattern).test(string);
+  let pattern = `(\r?\n[ \t]*){${n},}\r?\n`;
+  return new RegExp(pattern).test(string);
 }
-
 
 function getCorrectionString(string, n) {
-    let matches = string.match(/(\r?\n[ \t]*)/g);
-    if (!matches) {
-        return eol.repeat(n + 1);
-    }
-    let number = Math.max(0, n + 1 - matches.length);
-    return eol.repeat(number);
+  let matches = string.match(/(\r?\n[ \t]*)/g);
+  if (!matches) {
+    return eol.repeat(n + 1);
+  }
+  let number = Math.max(0, n + 1 - matches.length);
+  return eol.repeat(number);
 }
 
-
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that there is exactly a 2-line gap between Contract and Function declarations"
-        },
-
-        fixable: "whitespace",
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that there is exactly a 2-line gap between Contract and Function declarations"
     },
 
-    create(context) {
+    fixable: "whitespace",
 
-        const sourceCode = context.getSourceCode(),
-            noCodeRegExp = /^\s*$/,
-            isCommentRegExp = /\s*(\/\/*)|(\*\\*)|(\/\**)$/,
-            strictCommentRegExp = /^\s*(\/\/*)|(\*\\*)|(\/\**)$/; // Tests whether the entire line is a comment
-        const topLevelDeclarations = [ "ContractStatement", "LibraryStatement" ];
+    schema: []
+  },
 
-        function inspectProgram(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+  create(context) {
+    const sourceCode = context.getSourceCode(),
+      noCodeRegExp = /^\s*$/,
+      isCommentRegExp = /\s*(\/\/*)|(\*\\*)|(\/\**)$/,
+      strictCommentRegExp = /^\s*(\/\/*)|(\*\\*)|(\/\**)$/; // Tests whether the entire line is a comment
+    const topLevelDeclarations = ["ContractStatement", "LibraryStatement"];
 
-            function report(topLevelNode, spacing) {
-                const message = `${topLevelNode.type.replace("Statement", "")} '${topLevelNode.name}' `
-                    + "must be preceded by 2 blank lines.";
+    function inspectProgram(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-                context.report({
-                    node: topLevelNode, message,
-                    fix(fixer) {
-                        // The fix strategy is as follows:
-                        // - count lines going upwards (without going beyond the bounds of the spacing between this node and the previous one)
-                        // - Skip over any accompanying comments of the top level node
-                        // - Count the number of blank lines directly above the top-most accompanying comments iteratively
-                        // - Insert the desired number of line break characters right before the comment
+      function report(topLevelNode, spacing) {
+        const message =
+          `${topLevelNode.type.replace("Statement", "")} '${
+            topLevelNode.name
+          }' ` + "must be preceded by 2 blank lines.";
 
-                        let line = sourceCode.getLine(topLevelNode) - 1, // The line number
-                            maxLines = spacing.split(eol).length,
-                            bottomLine = sourceCode.getLine(topLevelNode),
-                            multipleLines = spacing.includes(eol), // Whether there are multiple lines
-                            insertAt = topLevelNode.start, // The point to insert the new line characters at
-                            numberOfBreaks = multipleLines ? 1 : 0; // The number of line breaks there are currently (default to 1 if there are multiple lines)
+        context.report({
+          node: topLevelNode,
+          message,
+          fix(fixer) {
+            // The fix strategy is as follows:
+            // - count lines going upwards (without going beyond the bounds of the spacing between this node and the previous one)
+            // - Skip over any accompanying comments of the top level node
+            // - Count the number of blank lines directly above the top-most accompanying comments iteratively
+            // - Insert the desired number of line break characters right before the comment
 
-                        // If there are multiple lines, manually count the number of lines (after skipping the accompanying comments)
-                        if (multipleLines) {
-                            // Subtract by the column number to preserve any indentation when inserting the newlines during the fix
-                            insertAt -= sourceCode.getColumn(topLevelNode);
+            let line = sourceCode.getLine(topLevelNode) - 1, // The line number
+              maxLines = spacing.split(eol).length,
+              bottomLine = sourceCode.getLine(topLevelNode),
+              multipleLines = spacing.includes(eol), // Whether there are multiple lines
+              insertAt = topLevelNode.start, // The point to insert the new line characters at
+              numberOfBreaks = multipleLines ? 1 : 0; // The number of line breaks there are currently (default to 1 if there are multiple lines)
 
-                            // Skip over all the node's accompanying comments
-                            while (strictCommentRegExp.test(sourceCode.getTextOnLine(line))) {
-                                insertAt -= sourceCode.getTextOnLine(line).length + 1;
+            // If there are multiple lines, manually count the number of lines (after skipping the accompanying comments)
+            if (multipleLines) {
+              // Subtract by the column number to preserve any indentation when inserting the newlines during the fix
+              insertAt -= sourceCode.getColumn(topLevelNode);
 
-                                let text = sourceCode.getTextOnLine(line);
+              // Skip over all the node's accompanying comments
+              while (strictCommentRegExp.test(sourceCode.getTextOnLine(line))) {
+                insertAt -= sourceCode.getTextOnLine(line).length + 1;
 
-                                // Multi line block comment, jump over the entire thing
-                                if (text.includes("*/") && !text.includes("/*")) {
-                                    let rest = sourceCode.getText().slice(0, insertAt);
-                                    let blockCommentStart = rest.lastIndexOf("/*");
+                let text = sourceCode.getTextOnLine(line);
 
-                                    // Decrement the line number by the number of lines the block comment takes up
-                                    line -= sourceCode.getText().slice(blockCommentStart, insertAt).split(eol).length;
-                                    // Set the endpoint to the end of the line above the block comment
-                                    insertAt = sourceCode.getText().slice(0, blockCommentStart).lastIndexOf(eol) + 1;
-                                } else {
-                                    // If it's just a regular comment, decrement the line number
-                                    line--;
-                                }
-                            }
+                // Multi line block comment, jump over the entire thing
+                if (text.includes("*/") && !text.includes("/*")) {
+                  let rest = sourceCode.getText().slice(0, insertAt);
+                  let blockCommentStart = rest.lastIndexOf("/*");
 
-                            // Count how many blank lines there are currently
-                            while (bottomLine - line < maxLines && line > 0 && noCodeRegExp.test(sourceCode.getTextOnLine(line--))) {
-                                numberOfBreaks++;
-                            }
-                        }
-
-                        // Repeat the end-of-line string to ensure there are 2 blank lines
-                        const correction = Math.max(0, 3 - numberOfBreaks);
-                        return [fixer.insertTextAt(insertAt, eol.repeat(correction))];
-                    }
-                });
-            }
-
-            const {node} = emitted, programBody = node.body;
-
-            for (let i = 1; i < programBody.length; i++) {
-                const currNode = programBody [i], prevNode = programBody [i-1];
-
-                if (!topLevelDeclarations.includes(currNode.type)) {
-                    continue;
+                  // Decrement the line number by the number of lines the block comment takes up
+                  line -= sourceCode
+                    .getText()
+                    .slice(blockCommentStart, insertAt)
+                    .split(eol).length;
+                  // Set the endpoint to the end of the line above the block comment
+                  insertAt =
+                    sourceCode
+                      .getText()
+                      .slice(0, blockCommentStart)
+                      .lastIndexOf(eol) + 1;
+                } else {
+                  // If it's just a regular comment, decrement the line number
+                  line--;
                 }
+              }
 
-                const spacing = sourceCode.getStringBetweenNodes(prevNode, currNode);
-                if (!hasNConsecutiveBlankLines(spacing, 2)) {
-                    report(currNode, spacing);
-                }
-            }
-        }
-
-
-        function inspectChild(emitted) {
-            let node = emitted.node, body = node.body || [];
-
-            function report(node, spacing) {
-                context.report({
-                    node: node,
-                    message: node.type + " must be succeeded by 1 blank line",
-                    fix(fixer) {
-                        // Add the correct number of line breaks at the after the node
-                        return [fixer.insertTextAfter(node, getCorrectionString(spacing, 1))];
-                    }
-                });
+              // Count how many blank lines there are currently
+              while (
+                bottomLine - line < maxLines &&
+                line > 0 &&
+                noCodeRegExp.test(sourceCode.getTextOnLine(line--))
+              ) {
+                numberOfBreaks++;
+              }
             }
 
-            if (emitted.exit) {
-                return;
-            }
-
-            for (let i = 0; i < body.length-1; i++) {
-                let endingLineNumber = sourceCode.getEndingLine(body [i]),
-                    a, b, c;
-
-                try {
-                    a = sourceCode.getTextOnLine(endingLineNumber+1);
-                    b = sourceCode.getTextOnLine(endingLineNumber+2);
-                    c = sourceCode.getTextOnLine(endingLineNumber);
-                } catch (e) { /* ignore */ }
-
-                if (
-                    ["FunctionDeclaration", "ConstructorDeclaration"].includes(body [i].type) &&
-                    sourceCode.getLine(body [i]) !== endingLineNumber &&
-                    !isCommentRegExp.test(c) &&
-                    ((!noCodeRegExp.test(a)) || noCodeRegExp.test(b) || endingLineNumber === sourceCode.getLine(body [i+1]))
-                ) {
-                    const spacing = sourceCode.getStringBetweenNodes(body[i], body[i + 1]);
-                    report(body [i], spacing);
-                }
-            }
-        }
-
-
-        let listeners = {
-            Program: inspectProgram
-        };
-
-        topLevelDeclarations.forEach(function(node) {
-            listeners [node] = inspectChild;
+            // Repeat the end-of-line string to ensure there are 2 blank lines
+            const correction = Math.max(0, 3 - numberOfBreaks);
+            return [fixer.insertTextAt(insertAt, eol.repeat(correction))];
+          }
         });
+      }
 
-        return listeners;
+      const { node } = emitted,
+        programBody = node.body;
 
+      for (let i = 1; i < programBody.length; i++) {
+        const currNode = programBody[i],
+          prevNode = programBody[i - 1];
+
+        if (!topLevelDeclarations.includes(currNode.type)) {
+          continue;
+        }
+
+        const spacing = sourceCode.getStringBetweenNodes(prevNode, currNode);
+        if (!hasNConsecutiveBlankLines(spacing, 2)) {
+          report(currNode, spacing);
+        }
+      }
     }
 
+    function inspectChild(emitted) {
+      let node = emitted.node,
+        body = node.body || [];
+
+      function report(node, spacing) {
+        context.report({
+          node: node,
+          message: node.type + " must be succeeded by 1 blank line",
+          fix(fixer) {
+            // Add the correct number of line breaks at the after the node
+            return [
+              fixer.insertTextAfter(node, getCorrectionString(spacing, 1))
+            ];
+          }
+        });
+      }
+
+      if (emitted.exit) {
+        return;
+      }
+
+      for (let i = 0; i < body.length - 1; i++) {
+        let endingLineNumber = sourceCode.getEndingLine(body[i]),
+          a,
+          b,
+          c;
+
+        try {
+          a = sourceCode.getTextOnLine(endingLineNumber + 1);
+          b = sourceCode.getTextOnLine(endingLineNumber + 2);
+          c = sourceCode.getTextOnLine(endingLineNumber);
+        } catch (e) {
+          /* ignore */
+        }
+
+        if (
+          ["FunctionDeclaration", "ConstructorDeclaration"].includes(
+            body[i].type
+          ) &&
+          sourceCode.getLine(body[i]) !== endingLineNumber &&
+          !isCommentRegExp.test(c) &&
+          (!noCodeRegExp.test(a) ||
+            noCodeRegExp.test(b) ||
+            endingLineNumber === sourceCode.getLine(body[i + 1]))
+        ) {
+          const spacing = sourceCode.getStringBetweenNodes(
+            body[i],
+            body[i + 1]
+          );
+          report(body[i], spacing);
+        }
+      }
+    }
+
+    let listeners = {
+      Program: inspectProgram
+    };
+
+    topLevelDeclarations.forEach(function(node) {
+      listeners[node] = inspectChild;
+    });
+
+    return listeners;
+  }
 };

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -6,53 +6,50 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that contract, library, modifier and struct names follow CamelCase notation"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that contract, library, modifier and struct names follow CamelCase notation"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let camelCaseRegEx = /^([A-Z][A-Za-z0-9]+)+$/;
-        let nodesToWatch = {
-            "ContractStatement": "Contract",
-            "LibraryStatement": "Library",
-            "StructDeclaration": "Struct",
-            "EventDeclaration": "Event"
-        };
+  create: function(context) {
+    let camelCaseRegEx = /^([A-Z][A-Za-z0-9]+)+$/;
+    let nodesToWatch = {
+      ContractStatement: "Contract",
+      LibraryStatement: "Library",
+      StructDeclaration: "Struct",
+      EventDeclaration: "Event"
+    };
 
-        function createInspector(nodeDesc) {
-            return (function inspect(emitted) {
-                let node = emitted.node;
+    function createInspector(nodeDesc) {
+      return function inspect(emitted) {
+        let node = emitted.node;
 
-                if (emitted.exit) {
-                    return;
-                }
-
-                if (!camelCaseRegEx.test(node.name)) {
-                    context.report({
-                        node: node,
-                        message: nodeDesc + " name '" + node.name + "' doesn't follow the CamelCase notation."
-                    });
-                }
-            });
+        if (emitted.exit) {
+          return;
         }
 
-        return Object.keys(nodesToWatch).reduce(function(listeners, nodeName) {
-
-            listeners [nodeName] = createInspector(nodesToWatch [nodeName]);
-            return listeners;
-
-        }, {});
-
+        if (!camelCaseRegEx.test(node.name)) {
+          context.report({
+            node: node,
+            message:
+              nodeDesc +
+              " name '" +
+              node.name +
+              "' doesn't follow the CamelCase notation."
+          });
+        }
+      };
     }
 
+    return Object.keys(nodesToWatch).reduce(function(listeners, nodeName) {
+      listeners[nodeName] = createInspector(nodesToWatch[nodeName]);
+      return listeners;
+    }, {});
+  }
 };

--- a/lib/rules/comma-whitespace.js
+++ b/lib/rules/comma-whitespace.js
@@ -6,124 +6,128 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that there is no whitespace or comments between comma delimited elements and commas"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure that there is no whitespace or comments between comma delimited elements and commas"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let sourceCode = context.getSourceCode();
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
+    function inspectCallExpression(emitted) {
+      let node = emitted.node,
+        callArgs = node.arguments;
 
-        function inspectCallExpression(emitted) {
-            let node = emitted.node,
-                callArgs = node.arguments;
+      function inspectCallArgForCommaWhitespace(arg) {
+        let charAfterArg = sourceCode.getNextChar(arg);
 
-            function inspectCallArgForCommaWhitespace(arg) {
-                let charAfterArg = sourceCode.getNextChar(arg);
+        charAfterArg !== "," &&
+          context.report({
+            node: arg,
+            location: {
+              column: sourceCode.getEndingColumn(arg) + 1
+            },
+            message:
+              "There should be no whitespace or comments between argument and the comma following it."
+          });
+      }
 
-                (charAfterArg !== ",") && context.report({
-                    node: arg,
-                    location: {
-                        column: sourceCode.getEndingColumn(arg) + 1
-                    },
-                    message: "There should be no whitespace or comments between argument and the comma following it."
-                });
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            if (emitted.exit) {
-                return;
-            }
-
-            //CHECKING FOR COMMA WHITESPACE
-            callArgs.slice(0, -1).forEach(inspectCallArgForCommaWhitespace);
-        }
-
-
-        function inspectArrayExpression(emitted) {
-            let node = emitted.node;
-
-            function inspectArrayElementForCommaWhitespace(elem) {
-                let charAfterElem = sourceCode.getNextChar(elem);
-
-                (charAfterElem !== ",") && context.report({
-                    node: elem,
-                    location: {
-                        column: sourceCode.getEndingColumn(elem) + 1
-                    },
-                    message: "There should be no whitespace or comments between Array element and the comma following it."
-                });
-            }
-
-            if (emitted.exit) {
-                return;
-            }
-
-            //need to test comma from starting to second last elem, since there's no comma after last element
-            node.elements.slice(0, -1).forEach(inspectArrayElementForCommaWhitespace);
-        }
-
-
-        function inspectSequenceExpression(emitted) {
-            let node = emitted.node, expressions = node.expressions || [];
-
-            function inspectExprForWhitespace(expr) {
-                let charAfterExpr = sourceCode.getNextChar(expr);
-
-                (charAfterExpr !== ",") && context.report({
-                    node: expr,
-                    location: {
-                        column: sourceCode.getEndingColumn(expr) + 1
-                    },
-                    message: "There should be no whitespace or comments between Tuple's element and the comma following it."
-                });
-            }
-
-            if (emitted.exit) {
-                return;
-            }
-
-            expressions.slice(0, -1).forEach(inspectExprForWhitespace);
-        }
-
-
-        function inspectVariableDeclarationTuple(emitted) {
-            let node = emitted.node, declarations = node.declarations;
-
-            function inspectVariableDeclaratorForWhitespace(vd) {
-                let charAfterExpr = sourceCode.getNextChar(vd);
-
-                (charAfterExpr !== ",") && context.report({
-                    node: vd,
-                    location: {
-                        column: sourceCode.getEndingColumn(vd) + 1
-                    },
-                    message: "'" + vd.id.name + "': identifier should be immediately followed by a comma without any whitespace in between."
-                });
-            }
-
-            if (emitted.exit) {
-                return;
-            }
-
-            declarations.slice(0, -1).forEach(inspectVariableDeclaratorForWhitespace);
-        }
-
-
-        return {
-            VariableDeclarationTuple: inspectVariableDeclarationTuple,
-            SequenceExpression: inspectSequenceExpression,
-            ArrayExpression: inspectArrayExpression,
-            CallExpression: inspectCallExpression
-        };
+      //CHECKING FOR COMMA WHITESPACE
+      callArgs.slice(0, -1).forEach(inspectCallArgForCommaWhitespace);
     }
+
+    function inspectArrayExpression(emitted) {
+      let node = emitted.node;
+
+      function inspectArrayElementForCommaWhitespace(elem) {
+        let charAfterElem = sourceCode.getNextChar(elem);
+
+        charAfterElem !== "," &&
+          context.report({
+            node: elem,
+            location: {
+              column: sourceCode.getEndingColumn(elem) + 1
+            },
+            message:
+              "There should be no whitespace or comments between Array element and the comma following it."
+          });
+      }
+
+      if (emitted.exit) {
+        return;
+      }
+
+      //need to test comma from starting to second last elem, since there's no comma after last element
+      node.elements.slice(0, -1).forEach(inspectArrayElementForCommaWhitespace);
+    }
+
+    function inspectSequenceExpression(emitted) {
+      let node = emitted.node,
+        expressions = node.expressions || [];
+
+      function inspectExprForWhitespace(expr) {
+        let charAfterExpr = sourceCode.getNextChar(expr);
+
+        charAfterExpr !== "," &&
+          context.report({
+            node: expr,
+            location: {
+              column: sourceCode.getEndingColumn(expr) + 1
+            },
+            message:
+              "There should be no whitespace or comments between Tuple's element and the comma following it."
+          });
+      }
+
+      if (emitted.exit) {
+        return;
+      }
+
+      expressions.slice(0, -1).forEach(inspectExprForWhitespace);
+    }
+
+    function inspectVariableDeclarationTuple(emitted) {
+      let node = emitted.node,
+        declarations = node.declarations;
+
+      function inspectVariableDeclaratorForWhitespace(vd) {
+        let charAfterExpr = sourceCode.getNextChar(vd);
+
+        charAfterExpr !== "," &&
+          context.report({
+            node: vd,
+            location: {
+              column: sourceCode.getEndingColumn(vd) + 1
+            },
+            message:
+              "'" +
+              vd.id.name +
+              "': identifier should be immediately followed by a comma without any whitespace in between."
+          });
+      }
+
+      if (emitted.exit) {
+        return;
+      }
+
+      declarations.slice(0, -1).forEach(inspectVariableDeclaratorForWhitespace);
+    }
+
+    return {
+      VariableDeclarationTuple: inspectVariableDeclarationTuple,
+      SequenceExpression: inspectSequenceExpression,
+      ArrayExpression: inspectArrayExpression,
+      CallExpression: inspectCallExpression
+    };
+  }
 };

--- a/lib/rules/conditionals-whitespace.js
+++ b/lib/rules/conditionals-whitespace.js
@@ -6,96 +6,102 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that there is exactly one space between conditional operators and parenthetic blocks"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure that there is exactly one space between conditional operators and parenthetic blocks"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let sourceCode = context.getSourceCode();
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
-        function inspectIfStatement(emitted) {
-            let node = emitted.node;
+    function inspectIfStatement(emitted) {
+      let node = emitted.node;
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            /**
-			 * Ensure a single space between 'if' token and the opening parenthesis 'if (...)'
-			 */
-            let ifTokenLength = "if".length,
-                nodeCode = sourceCode.getText(node).slice(ifTokenLength, ifTokenLength + 2);
+      /**
+       * Ensure a single space between 'if' token and the opening parenthesis 'if (...)'
+       */
+      let ifTokenLength = "if".length,
+        nodeCode = sourceCode
+          .getText(node)
+          .slice(ifTokenLength, ifTokenLength + 2);
 
-            (nodeCode !== " (") && context.report({
-                node: node,
-                location: {
-                    column: sourceCode.getColumn(node) + ifTokenLength
-                },
-                message: "There should be exactly a single space between the 'if' token and the parenthetic block representing the conditional."
-            });
-        }
-
-
-        function inspectWhileStatement(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            /**
-			 * Ensure a single space between 'while' token and the opening parenthesis 'while (...)'
-			 */
-            let whileTokenLength = "while".length,
-                nodeCode = sourceCode.getText(node).slice(whileTokenLength, whileTokenLength + 2);
-
-            (nodeCode !== " (") && context.report({
-                node: node,
-                location: {
-                    column: sourceCode.getColumn(node) + whileTokenLength
-                },
-                message: "There should be exactly a single space between the 'while' token and the parenthetic block representing the conditional."
-            });
-        }
-
-
-        function inspectForStatement(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            /**
-			 * Ensure a single space between 'for' token and the opening parenthesis 'for (...)'
-			 */
-            let forTokenLength = "for".length,
-                nodeCode = sourceCode.getText(node).slice(forTokenLength, forTokenLength + 2);
-
-            (nodeCode !== " (") && context.report({
-                node: node,
-                location: {
-                    column: sourceCode.getColumn(node) + forTokenLength
-                },
-                message: "There should be exactly a single space between the 'for' token and the parenthetic block representing the conditional."
-            });
-        }
-
-        return {
-            IfStatement: inspectIfStatement,
-            WhileStatement: inspectWhileStatement,
-            ForStatement: inspectForStatement
-        };
-
+      nodeCode !== " (" &&
+        context.report({
+          node: node,
+          location: {
+            column: sourceCode.getColumn(node) + ifTokenLength
+          },
+          message:
+            "There should be exactly a single space between the 'if' token and the parenthetic block representing the conditional."
+        });
     }
+
+    function inspectWhileStatement(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      /**
+       * Ensure a single space between 'while' token and the opening parenthesis 'while (...)'
+       */
+      let whileTokenLength = "while".length,
+        nodeCode = sourceCode
+          .getText(node)
+          .slice(whileTokenLength, whileTokenLength + 2);
+
+      nodeCode !== " (" &&
+        context.report({
+          node: node,
+          location: {
+            column: sourceCode.getColumn(node) + whileTokenLength
+          },
+          message:
+            "There should be exactly a single space between the 'while' token and the parenthetic block representing the conditional."
+        });
+    }
+
+    function inspectForStatement(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      /**
+       * Ensure a single space between 'for' token and the opening parenthesis 'for (...)'
+       */
+      let forTokenLength = "for".length,
+        nodeCode = sourceCode
+          .getText(node)
+          .slice(forTokenLength, forTokenLength + 2);
+
+      nodeCode !== " (" &&
+        context.report({
+          node: node,
+          location: {
+            column: sourceCode.getColumn(node) + forTokenLength
+          },
+          message:
+            "There should be exactly a single space between the 'for' token and the parenthetic block representing the conditional."
+        });
+    }
+
+    return {
+      IfStatement: inspectIfStatement,
+      WhileStatement: inspectWhileStatement,
+      ForStatement: inspectForStatement
+    };
+  }
 };

--- a/lib/rules/deprecated-suicide.js
+++ b/lib/rules/deprecated-suicide.js
@@ -5,51 +5,46 @@
 
 "use strict";
 
-
 function isSuicide(node) {
-    return node.type === "Identifier" && node.name === "suicide";
+  return node.type === "Identifier" && node.name === "suicide";
 }
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Suggest replacing deprecated 'suicide' for 'selfdestruct'"
-        },
-
-        schema: [],
-
-        fixable: "code"
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description: "Suggest replacing deprecated 'suicide' for 'selfdestruct'"
     },
 
-    create: function(context) {
-        function inspectCallExpression(emittedObject) {
-            if (!emittedObject.exit) {
-                return;
-            }
+    schema: [],
 
-            let callee = emittedObject.node.callee;
+    fixable: "code"
+  },
 
-            if (isSuicide(callee)) {
+  create: function(context) {
+    function inspectCallExpression(emittedObject) {
+      if (!emittedObject.exit) {
+        return;
+      }
 
-                context.report({
-                    node: emittedObject.node,
-                    fix: function(fixer) {
-                        return [fixer.replaceTextRange([callee.start, callee.end], "selfdestruct")];
-                    },
-                    message: "'suicide' is deprecated. Use 'selfdestruct' instead."
-                });
+      let callee = emittedObject.node.callee;
 
-            }
-        }
-
-        return {
-            CallExpression: inspectCallExpression
-        };
+      if (isSuicide(callee)) {
+        context.report({
+          node: emittedObject.node,
+          fix: function(fixer) {
+            return [
+              fixer.replaceTextRange([callee.start, callee.end], "selfdestruct")
+            ];
+          },
+          message: "'suicide' is deprecated. Use 'selfdestruct' instead."
+        });
+      }
     }
 
+    return {
+      CallExpression: inspectCallExpression
+    };
+  }
 };

--- a/lib/rules/double-quotes.js
+++ b/lib/rules/double-quotes.js
@@ -11,59 +11,58 @@
  * @returns {Boolean}
  */
 function isHex(literal) {
-    let reg = /^[0-9a-f]+$/i;
+  let reg = /^[0-9a-f]+$/i;
 
-    //test for '0x' separately because hex notation should not be a part of the standard RegExp
-    if (literal.slice(0, 2) !== "0x") {
-        return false;
-    }
+  //test for '0x' separately because hex notation should not be a part of the standard RegExp
+  if (literal.slice(0, 2) !== "0x") {
+    return false;
+  }
 
-    return reg.test(literal.slice(2));
+  return reg.test(literal.slice(2));
 }
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that string are quoted with double-quotes only",
-            replacedBy: ["quotes"]
-        },
-
-        schema: [],
-        deprecated: true
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description: "Ensure that string are quoted with double-quotes only",
+      replacedBy: ["quotes"]
     },
 
-    create: function(context) {
+    schema: [],
+    deprecated: true
+  },
 
-        let doubleQuotesLiteralRegExp = /^\".*\"$/,
-            sourceCode = context.getSourceCode();
+  create: function(context) {
+    let doubleQuotesLiteralRegExp = /^\".*\"$/,
+      sourceCode = context.getSourceCode();
 
-        function inspectLiteral(emitted) {
-            let node = emitted.node, nodeText = sourceCode.getText(node);
+    function inspectLiteral(emitted) {
+      let node = emitted.node,
+        nodeText = sourceCode.getText(node);
 
-            if (emitted.exit ||
-				typeof node.value !== "string" ||
-				(nodeText [0] !== "'" && nodeText [0] !== "\"" && isHex(node.value))
-            ) {
-                return;
-            }
+      if (
+        emitted.exit ||
+        typeof node.value !== "string" ||
+        (nodeText[0] !== "'" && nodeText[0] !== '"' && isHex(node.value))
+      ) {
+        return;
+      }
 
-            if (!doubleQuotesLiteralRegExp.test(nodeText)) {
-                context.report({
-                    node: node,
-                    message: "'" + node.value + "': String Literals must be quoted with \"double quotes\" only."
-                });
-            }
-        }
-
-        return {
-            Literal: inspectLiteral
-        };
-
+      if (!doubleQuotesLiteralRegExp.test(nodeText)) {
+        context.report({
+          node: node,
+          message:
+            "'" +
+            node.value +
+            '\': String Literals must be quoted with "double quotes" only.'
+        });
+      }
     }
 
+    return {
+      Literal: inspectLiteral
+    };
+  }
 };

--- a/lib/rules/emit.js
+++ b/lib/rules/emit.js
@@ -5,7 +5,6 @@
 
 "use strict";
 
-
 /**
  * While entering nodes, register all events and all call expressions that are not part of emit statement
  * While exiting, determine which of the registered call expressions is an event trigger and flag them
@@ -16,70 +15,72 @@
  * and whether they're being triggered using "emit".
  */
 function create(context) {
-    const events = [], callExpressions = [], sourceCode = context.getSourceCode();
+  const events = [],
+    callExpressions = [],
+    sourceCode = context.getSourceCode();
 
-    // Determines whether the given call name refers to an event declaration using scope resolution.
-    function isEvent(expr, eventDeclarations) {
-        for (let {node, enclosingContract} of eventDeclarations) {
-            if (expr.callee.name === node.name && sourceCode.isAChildOf(expr, enclosingContract)) {
-                return true;
-            }
-        }
-        return false;
+  // Determines whether the given call name refers to an event declaration using scope resolution.
+  function isEvent(expr, eventDeclarations) {
+    for (let { node, enclosingContract } of eventDeclarations) {
+      if (
+        expr.callee.name === node.name &&
+        sourceCode.isAChildOf(expr, enclosingContract)
+      ) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Stores each declared event in the file and its corresponding parent contract
+  function registerEventName(emitted) {
+    const { node } = emitted;
+    !emitted.exit &&
+      events.push({ node, enclosingContract: sourceCode.getParent(node) });
+  }
+
+  function registerNonEmittedCallExpression(emitted) {
+    const { node } = emitted;
+
+    if (!emitted.exit && sourceCode.getParent(node).type !== "EmitStatement") {
+      callExpressions.push(node);
+    }
+  }
+
+  function reportBadEventTriggers(emitted) {
+    if (!emitted.exit) {
+      return;
     }
 
-
-    // Stores each declared event in the file and its corresponding parent contract
-    function registerEventName(emitted) {
-        const { node } = emitted;
-        (!emitted.exit) && events.push({node, enclosingContract: sourceCode.getParent(node)});
-    }
-
-    function registerNonEmittedCallExpression(emitted) {
-        const { node } = emitted;
-
-        if (!emitted.exit && sourceCode.getParent(node).type !== "EmitStatement") {
-            callExpressions.push(node);
-        }
-    }
-
-    function reportBadEventTriggers(emitted) {
-        if (!emitted.exit) {
-            return;
-        }
-
-        callExpressions.forEach(node => {
-            isEvent(node, events) && context.report({
-                node,
-                fix(fixer) {
-                    return fixer.insertTextBefore(node, "emit ");
-                },
-                message: "Use emit statements for triggering events."
-            });
+    callExpressions.forEach(node => {
+      isEvent(node, events) &&
+        context.report({
+          node,
+          fix(fixer) {
+            return fixer.insertTextBefore(node, "emit ");
+          },
+          message: "Use emit statements for triggering events."
         });
-    }
+    });
+  }
 
-
-    return {
-        EventDeclaration: registerEventName,
-        CallExpression: registerNonEmittedCallExpression,
-        Program: reportBadEventTriggers
-    };
+  return {
+    EventDeclaration: registerEventName,
+    CallExpression: registerNonEmittedCallExpression,
+    Program: reportBadEventTriggers
+  };
 }
 
-
 module.exports = {
-
-    meta: {
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Use emit statement to trigger a solidity event"
-        },
-        schema: [],
-        fixable: "code"
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description: "Use emit statement to trigger a solidity event"
     },
+    schema: [],
+    fixable: "code"
+  },
 
-    create
-
+  create
 };

--- a/lib/rules/error-reason.js
+++ b/lib/rules/error-reason.js
@@ -6,58 +6,59 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that error message is provided for revert and require statements"
-        },
-
-        schema: [{
-            type: "object",
-            properties: {
-                revert: { type: "boolean" },
-                require: { type: "boolean" }
-            },
-            required: ["revert", "require"],
-            additionalProperties: false
-        }]
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that error message is provided for revert and require statements"
     },
 
-    create(context) {
+    schema: [
+      {
+        type: "object",
+        properties: {
+          revert: { type: "boolean" },
+          require: { type: "boolean" }
+        },
+        required: ["revert", "require"],
+        additionalProperties: false
+      }
+    ]
+  },
 
-        function inspectCallExpression(emitted) {
-            const { node } = emitted;
+  create(context) {
+    function inspectCallExpression(emitted) {
+      const { node } = emitted;
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            const { name } = node.callee, callArgs = node.arguments;
-            const options = context.options && context.options[0] || { revert: true, require: true };
+      const { name } = node.callee,
+        callArgs = node.arguments;
+      const options = (context.options && context.options[0]) || {
+        revert: true,
+        require: true
+      };
 
-            if (options.revert && name === "revert" && callArgs.length < 1) {
-                return context.report({
-                    node,
-                    message: "Provide an error message for revert()."
-                });
-            }
+      if (options.revert && name === "revert" && callArgs.length < 1) {
+        return context.report({
+          node,
+          message: "Provide an error message for revert()."
+        });
+      }
 
-            if (options.require && name === "require" && callArgs.length < 2) {
-                context.report({
-                    node,
-                    message: "Provide an error message for require()."
-                });
-            }
-        }
-
-        return {
-            CallExpression: inspectCallExpression
-        };
-
+      if (options.require && name === "require" && callArgs.length < 2) {
+        context.report({
+          node,
+          message: "Provide an error message for require()."
+        });
+      }
     }
 
+    return {
+      CallExpression: inspectCallExpression
+    };
+  }
 };

--- a/lib/rules/function-order.js
+++ b/lib/rules/function-order.js
@@ -5,102 +5,112 @@
 
 "use strict";
 
-
-const functionOrder = ["constructor", "fallback", "external", "public", "internal", "private"],
-    errorMessage = `Functions should be in order: ${functionOrder.join(", ")}`;
-
+const functionOrder = [
+    "constructor",
+    "fallback",
+    "external",
+    "public",
+    "internal",
+    "private"
+  ],
+  errorMessage = `Functions should be in order: ${functionOrder.join(", ")}`;
 
 function findFuncPosInOrder(contractNode, funcNode) {
-    // Account for both ways of defining a contract constructor
-    // 1. The old way (function with same name as contract)
-    // 2. New way ("constructor() {...}")
-    if (funcNode.name === contractNode.name || funcNode.type === "ConstructorDeclaration") {
-        return functionOrder.indexOf("constructor");
-    }
+  // Account for both ways of defining a contract constructor
+  // 1. The old way (function with same name as contract)
+  // 2. New way ("constructor() {...}")
+  if (
+    funcNode.name === contractNode.name ||
+    funcNode.type === "ConstructorDeclaration"
+  ) {
+    return functionOrder.indexOf("constructor");
+  }
 
-    if (funcNode.name === null) {
-        return functionOrder.indexOf("fallback");
-    }
+  if (funcNode.name === null) {
+    return functionOrder.indexOf("fallback");
+  }
 
-    // Default visibility of a function is public.
-    if (funcNode.modifiers === null) {
-        return functionOrder.indexOf("public");
-    }
-
-    // If we bypass all above cases, below logic is guranteed to return a valid position
-    const modifNames = funcNode.modifiers.map(m => { return m.name; });
-
-    for (let mName of modifNames) {
-        const i = functionOrder.indexOf(mName);
-
-        if (i > -1) {
-            return i;
-        }
-    }
-
-    // If we bypass above loop, it means modifiers exist for this func,
-    // but none of them was a visibility modif. This is equivalent to public vis. modif.
+  // Default visibility of a function is public.
+  if (funcNode.modifiers === null) {
     return functionOrder.indexOf("public");
+  }
+
+  // If we bypass all above cases, below logic is guranteed to return a valid position
+  const modifNames = funcNode.modifiers.map(m => {
+    return m.name;
+  });
+
+  for (let mName of modifNames) {
+    const i = functionOrder.indexOf(mName);
+
+    if (i > -1) {
+      return i;
+    }
+  }
+
+  // If we bypass above loop, it means modifiers exist for this func,
+  // but none of them was a visibility modif. This is equivalent to public vis. modif.
+  return functionOrder.indexOf("public");
 }
 
 function isFunctionVisibility(contractNode, funcNode, typeDescriptor) {
-    const funcPosInOrder = findFuncPosInOrder(contractNode, funcNode);
-    return typeDescriptor === functionOrder[funcPosInOrder];
+  const funcPosInOrder = findFuncPosInOrder(contractNode, funcNode);
+  return typeDescriptor === functionOrder[funcPosInOrder];
 }
 
-
-
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that functions in a contract are ordered according to their visibility"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that functions in a contract are ordered according to their visibility"
     },
 
-    create(context) {
-        /**
-         * Set cursor to point to first visibility in order of vis. array.
-         * For each function Fi inside contract, if Fi's vis is same as that pointed by cursor, ignore func.
-         * If not, check the pos in the order of Fi's vis. If ahead, simply move cursor forward to Fi's vis.'s
-         * position in array. If behind, report func.
-         */
-        function inspectFunctionsOfContract(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+    schema: []
+  },
 
-            const {node} = emitted, {body} = node;
-            let cursor = 0;
+  create(context) {
+    /**
+     * Set cursor to point to first visibility in order of vis. array.
+     * For each function Fi inside contract, if Fi's vis is same as that pointed by cursor, ignore func.
+     * If not, check the pos in the order of Fi's vis. If ahead, simply move cursor forward to Fi's vis.'s
+     * position in array. If behind, report func.
+     */
+    function inspectFunctionsOfContract(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-            // Filter out non-function nodes
-            body.filter(child => {
-                return ["FunctionDeclaration", "ConstructorDeclaration"].includes(child.type);
-            }).forEach(funcNode => {
-                if (isFunctionVisibility(node, funcNode, functionOrder[cursor])) {
-                    return;
-                }
+      const { node } = emitted,
+        { body } = node;
+      let cursor = 0;
 
-                const funcPosInOrder = findFuncPosInOrder(node, funcNode);
+      // Filter out non-function nodes
+      body
+        .filter(child => {
+          return ["FunctionDeclaration", "ConstructorDeclaration"].includes(
+            child.type
+          );
+        })
+        .forEach(funcNode => {
+          if (isFunctionVisibility(node, funcNode, functionOrder[cursor])) {
+            return;
+          }
 
-                if (funcPosInOrder > cursor) {
-                    cursor = funcPosInOrder;
-                    return;
-                }
+          const funcPosInOrder = findFuncPosInOrder(node, funcNode);
 
-                context.report({ node: funcNode, message: errorMessage });
-            });
-        }
+          if (funcPosInOrder > cursor) {
+            cursor = funcPosInOrder;
+            return;
+          }
 
-        return {
-            ContractStatement: inspectFunctionsOfContract
-        };
+          context.report({ node: funcNode, message: errorMessage });
+        });
     }
 
+    return {
+      ContractStatement: inspectFunctionsOfContract
+    };
+  }
 };

--- a/lib/rules/function-whitespace.js
+++ b/lib/rules/function-whitespace.js
@@ -6,133 +6,145 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure function calls and declaration have (or don't have) whitespace in appropriate locations"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure function calls and declaration have (or don't have) whitespace in appropriate locations"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let sourceCode = context.getSourceCode();
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
-        //If parameters are specified, ensure appropriate spacing surrounding commas
-        function inspectFunctionDeclaration(emitted) {
-            let node = emitted.node;
+    //If parameters are specified, ensure appropriate spacing surrounding commas
+    function inspectFunctionDeclaration(emitted) {
+      let node = emitted.node;
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            let params = node.params;
+      let params = node.params;
 
-            if (params && params.length > 1) {
-                params.slice(0, -1).forEach(function(arg) {
-                    sourceCode.getNextChar(arg) !== "," && context.report({
-                        node: arg,
-                        location: {
-                            column: sourceCode.getEndingColumn(arg) + 1
-                        },
-                        message: "All arguments (except the last one) must be immediately followed by a comma."
-                    });
-                });
-            }
-        }
-
-        // The InformalParameter nodes (params) in modifier declaration should follow the same spacing rules as function declarations
-        function inspectModifierDeclaration(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            //If parameters are specified, ensure appropriate spacing surrounding commas
-            let params = node.params;
-
-            if (params && params.length > 1) {
-                params.slice(0, -1).forEach(function(arg) {
-                    sourceCode.getNextChar(arg) !== "," && context.report({
-                        node: arg,
-                        location: {
-                            column: sourceCode.getEndingColumn(arg) + 1
-                        },
-                        message: "All arguments (except the last one) must be immediately followed by a comma."
-                    });
-                });
-            }
-        }
-
-        //same could potentially be applied to FunctionDeclaration
-        function inspectCallExpression(emitted) {
-            let node = emitted.node,
-                callArgs = node.arguments;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            let nodeCode = sourceCode.getText(node);
-
-            //for a 0-argument call, ensure that name is followed by '()'
-            if (!callArgs.length) {
-                for (let i = nodeCode.length; i > 0; i--) {
-                    if (nodeCode [i] === ")" && nodeCode [i-1] === "(") {
-                        return;
-                    }
-                    if (/[\s\(\)]/.test(nodeCode [i])) {
-                        break;
-                    }
-                }
-
-                return context.report({
-                    node: node,
-                    message: "\"" + nodeCode + "\": " +
-					"A call without arguments should have brackets without any whitespace between them, like 'functionName ()'."
-                });
-            }
-
-            let lastCallArg = callArgs.slice(-1) [0];
-
-            //if call spans over multiple lines (due to too many arguments), below rules don't apply
-            if (sourceCode.getLine(node) !== sourceCode.getEndingLine(lastCallArg)) {
-                return;
-            }
-
-            let charBeforeFirstArg = sourceCode.getPrevChar(callArgs [0]),
-                charAfterLastCallArg = sourceCode.getNextChar(lastCallArg);
-
-            (callArgs [0].type !== "NameValueAssignment" && charBeforeFirstArg !== "(") && context.report({
-                node: callArgs [0],
-                location: {
-                    column: sourceCode.getColumn(callArgs [0]) - 1
-                },
-                message: "'" + node.callee.name + "': The first argument must not be preceded by any whitespace or comments (only '(')."
+      if (params && params.length > 1) {
+        params.slice(0, -1).forEach(function(arg) {
+          sourceCode.getNextChar(arg) !== "," &&
+            context.report({
+              node: arg,
+              location: {
+                column: sourceCode.getEndingColumn(arg) + 1
+              },
+              message:
+                "All arguments (except the last one) must be immediately followed by a comma."
             });
-
-            (lastCallArg.type !== "NameValueAssignment" && charAfterLastCallArg !== ")") && context.report({
-                node: callArgs [0],
-                location: {
-                    column: sourceCode.getEndingColumn(lastCallArg) + 1
-                },
-                message: "'" + node.callee.name + "': The last argument must not be succeeded by any whitespace or comments (only ')')."
-            });
-        }
-
-        return {
-            CallExpression: inspectCallExpression,
-            ModifierDeclaration: inspectModifierDeclaration,
-            FunctionDeclaration: inspectFunctionDeclaration,
-            ConstructorDeclaration: inspectFunctionDeclaration
-        };
-
+        });
+      }
     }
 
+    // The InformalParameter nodes (params) in modifier declaration should follow the same spacing rules as function declarations
+    function inspectModifierDeclaration(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      //If parameters are specified, ensure appropriate spacing surrounding commas
+      let params = node.params;
+
+      if (params && params.length > 1) {
+        params.slice(0, -1).forEach(function(arg) {
+          sourceCode.getNextChar(arg) !== "," &&
+            context.report({
+              node: arg,
+              location: {
+                column: sourceCode.getEndingColumn(arg) + 1
+              },
+              message:
+                "All arguments (except the last one) must be immediately followed by a comma."
+            });
+        });
+      }
+    }
+
+    //same could potentially be applied to FunctionDeclaration
+    function inspectCallExpression(emitted) {
+      let node = emitted.node,
+        callArgs = node.arguments;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      let nodeCode = sourceCode.getText(node);
+
+      //for a 0-argument call, ensure that name is followed by '()'
+      if (!callArgs.length) {
+        for (let i = nodeCode.length; i > 0; i--) {
+          if (nodeCode[i] === ")" && nodeCode[i - 1] === "(") {
+            return;
+          }
+          if (/[\s\(\)]/.test(nodeCode[i])) {
+            break;
+          }
+        }
+
+        return context.report({
+          node: node,
+          message:
+            '"' +
+            nodeCode +
+            '": ' +
+            "A call without arguments should have brackets without any whitespace between them, like 'functionName ()'."
+        });
+      }
+
+      let lastCallArg = callArgs.slice(-1)[0];
+
+      //if call spans over multiple lines (due to too many arguments), below rules don't apply
+      if (sourceCode.getLine(node) !== sourceCode.getEndingLine(lastCallArg)) {
+        return;
+      }
+
+      let charBeforeFirstArg = sourceCode.getPrevChar(callArgs[0]),
+        charAfterLastCallArg = sourceCode.getNextChar(lastCallArg);
+
+      callArgs[0].type !== "NameValueAssignment" &&
+        charBeforeFirstArg !== "(" &&
+        context.report({
+          node: callArgs[0],
+          location: {
+            column: sourceCode.getColumn(callArgs[0]) - 1
+          },
+          message:
+            "'" +
+            node.callee.name +
+            "': The first argument must not be preceded by any whitespace or comments (only '(')."
+        });
+
+      lastCallArg.type !== "NameValueAssignment" &&
+        charAfterLastCallArg !== ")" &&
+        context.report({
+          node: callArgs[0],
+          location: {
+            column: sourceCode.getEndingColumn(lastCallArg) + 1
+          },
+          message:
+            "'" +
+            node.callee.name +
+            "': The last argument must not be succeeded by any whitespace or comments (only ')')."
+        });
+    }
+
+    return {
+      CallExpression: inspectCallExpression,
+      ModifierDeclaration: inspectModifierDeclaration,
+      FunctionDeclaration: inspectFunctionDeclaration,
+      ConstructorDeclaration: inspectFunctionDeclaration
+    };
+  }
 };

--- a/lib/rules/imports-on-top.js
+++ b/lib/rules/imports-on-top.js
@@ -8,89 +8,92 @@
 // Get platform specific newline character for applying fixes
 const eol = require("os").EOL;
 
-
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that all import statements are on top of the file"
-        },
-
-        fixable: "code",
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description: "Ensure that all import statements are on top of the file"
     },
 
-    create: function(context) {
+    fixable: "code",
 
-        /**
-         * If ImportStatement node is a direct child of Program node 'parent',
-         * then it is an element of parent.body array.
-         * The node should precede any other type of node in the array except for the pragma & pragma experimental directives
-         * and other import statements.
-         * The way the fix() algorithm currently works - it only fixes position of 1 import statement in a file in 1 iteration.
-         * This may be improved in future.
-         */
-        function inspectImportStatement(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+    schema: []
+  },
 
-            const {node} = emitted,
-                programNode = context.getSourceCode().getParent(node),
-                indexOfNode = programNode.body.indexOf(node),
-                nodesAllowedAbove = ["ExperimentalPragmaStatement", "PragmaStatement", "ImportStatement"];
+  create: function(context) {
+    /**
+     * If ImportStatement node is a direct child of Program node 'parent',
+     * then it is an element of parent.body array.
+     * The node should precede any other type of node in the array except for the pragma & pragma experimental directives
+     * and other import statements.
+     * The way the fix() algorithm currently works - it only fixes position of 1 import statement in a file in 1 iteration.
+     * This may be improved in future.
+     */
+    function inspectImportStatement(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-            let lastValidNode = programNode.body[0]; // the first node could very well be an unacceptable one, taking care of it below
+      const { node } = emitted,
+        programNode = context.getSourceCode().getParent(node),
+        indexOfNode = programNode.body.indexOf(node),
+        nodesAllowedAbove = [
+          "ExperimentalPragmaStatement",
+          "PragmaStatement",
+          "ImportStatement"
+        ];
 
-            // For every node preceding the import node check if it's one of the allowed types.
-            for (let childNode of programNode.body.slice(0, indexOfNode)) {
+      let lastValidNode = programNode.body[0]; // the first node could very well be an unacceptable one, taking care of it below
 
-                // The moment we find 1 node not allowed above import, report and exit.
-                //   - Remove import from current position
-                //   - Place it right before childNode.start
-                //   - The fix will place it right after the last valid import node
-                if (!nodesAllowedAbove.includes(childNode.type)) {
-                    return context.report({
-                        node,
-                        fix(fixer) {
-                            // Add the import statement after the last valid node and remove the import statement
-                            const sourceCode = context.getSourceCode();
-                            const importStatement = sourceCode.getText(node);
-                            let suffix;
+      // For every node preceding the import node check if it's one of the allowed types.
+      for (let childNode of programNode.body.slice(0, indexOfNode)) {
+        // The moment we find 1 node not allowed above import, report and exit.
+        //   - Remove import from current position
+        //   - Place it right before childNode.start
+        //   - The fix will place it right after the last valid import node
+        if (!nodesAllowedAbove.includes(childNode.type)) {
+          return context.report({
+            node,
+            fix(fixer) {
+              // Add the import statement after the last valid node and remove the import statement
+              const sourceCode = context.getSourceCode();
+              const importStatement = sourceCode.getText(node);
+              let suffix;
 
-                            // If the last valid node is import, we place the current import right below it.
-                            // If its a pragma directive (whether solidity or experimental), add current import after 3 EOLs
-                            if (lastValidNode.type === "ImportStatement") {
-                                suffix = eol;
-                            } else if (nodesAllowedAbove.includes(lastValidNode.type)) {
-                                // Because we've already explicitly checks for import st. above, this one basically
-                                // checks for the remaining, ie, pragma directives
-                                suffix = eol.repeat(3);
-                            } else {
-                                // If lastValidNode is not an allowed one, it means we have to insert the import ABOVE the lvn
-                                return [fixer.insertTextBefore(lastValidNode, importStatement + eol), fixer.remove(node)];
-                            }
+              // If the last valid node is import, we place the current import right below it.
+              // If its a pragma directive (whether solidity or experimental), add current import after 3 EOLs
+              if (lastValidNode.type === "ImportStatement") {
+                suffix = eol;
+              } else if (nodesAllowedAbove.includes(lastValidNode.type)) {
+                // Because we've already explicitly checks for import st. above, this one basically
+                // checks for the remaining, ie, pragma directives
+                suffix = eol.repeat(3);
+              } else {
+                // If lastValidNode is not an allowed one, it means we have to insert the import ABOVE the lvn
+                return [
+                  fixer.insertTextBefore(lastValidNode, importStatement + eol),
+                  fixer.remove(node)
+                ];
+              }
 
-                            return [fixer.insertTextAfter(lastValidNode, suffix + importStatement), fixer.remove(node)];
-                        },
-                        message: "Import Statement must precede everything except pragma directives."
-                    });
-                } else {
-                    // All nodes allowed above an import statement are considered valid nodes
-                    lastValidNode = childNode;
-                }
-            }
+              return [
+                fixer.insertTextAfter(lastValidNode, suffix + importStatement),
+                fixer.remove(node)
+              ];
+            },
+            message:
+              "Import Statement must precede everything except pragma directives."
+          });
+        } else {
+          // All nodes allowed above an import statement are considered valid nodes
+          lastValidNode = childNode;
         }
-
-        return {
-            ImportStatement: inspectImportStatement
-        };
-
+      }
     }
 
+    return {
+      ImportStatement: inspectImportStatement
+    };
+  }
 };

--- a/lib/rules/indentation.js
+++ b/lib/rules/indentation.js
@@ -5,481 +5,585 @@
 
 "use strict";
 
-
 // This func will receive either empty str (len = 0), str with N Spaces (N >= 1) or N Tabs (N >= 1)
 function getIndentDescription(indentStyle, level) {
-    // If either user has specified 0 indent or we're at level 0 (start), totalIndent becomes 0.
-    const totalIndent = indentStyle.length * level, s = totalIndent > 1 ? "s" : "";
+  // If either user has specified 0 indent or we're at level 0 (start), totalIndent becomes 0.
+  const totalIndent = indentStyle.length * level,
+    s = totalIndent > 1 ? "s" : "";
 
-    // If style is that there should be no indent for any level OR we're at base level
-    if (totalIndent === 0) {
-        return "0 whitespace";
-    }
+  // If style is that there should be no indent for any level OR we're at base level
+  if (totalIndent === 0) {
+    return "0 whitespace";
+  }
 
-    if (indentStyle [0] === " ") {
-        return `${totalIndent} space${s}`;
-    }
+  if (indentStyle[0] === " ") {
+    return `${totalIndent} space${s}`;
+  }
 
-    // If above 2 are bypassed, indent style must be tab(s)
-    return `${totalIndent} tab${s}`;
+  // If above 2 are bypassed, indent style must be tab(s)
+  return `${totalIndent} tab${s}`;
 }
 
 function getIndentString(indentStyle, level) {
-    return Array(level + 1).join(indentStyle);
+  return Array(level + 1).join(indentStyle);
 }
 
-
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure consistent indentation per level (4 spaces by default)"
-        },
-
-        schema: [{
-            oneOf: [
-                { type: "string", enum: ["tab"] },
-                { type: "integer", minimum: 0 }
-            ]
-        }]
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure consistent indentation per level (4 spaces by default)"
     },
 
-    create: function(context) {
-
-        // default configurations
-        let BASE_INDENTATION_STYLE = " ".repeat(4),
-            BASE_INDENTATION_STYLE_DESC = "4 spaces";
-
-        if (context.options) {
-            if (context.options [0] === "tab") {
-                BASE_INDENTATION_STYLE = "\t";
-                BASE_INDENTATION_STYLE_DESC = "1 tab";
-            } else {
-                let spCount = context.options [0];
-
-                BASE_INDENTATION_STYLE = " ".repeat(spCount);
-                BASE_INDENTATION_STYLE_DESC = spCount + " space" + (spCount === 1 ? "" : "s");
-            }
-        }
-
-        let BASE_INDENTATION_STYLE_REGEXP_GLOBAL = new RegExp(BASE_INDENTATION_STYLE, "g");
-
-
-        let sourceCode = context.getSourceCode();
-        let topLevelDeclarations = ["ContractStatement", "LibraryStatement"];
-
-        //Ensure NO indentation exists before top-level declarations (contract, library)
-        function inspectProgram(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            function inspectProgramChild(programChild) {
-                //if node's code starts at index 0, getPrevChar() returns null (meaning no errors), so change it to '\n'
-                let prevChar = sourceCode.getPrevChar(programChild) || "\n",
-                    childEndingLine = sourceCode.getEndingLine(programChild),
-                    childEndingLineText = sourceCode.getTextOnLine(childEndingLine);
-
-                function report(messageText) {
-                    context.report({
-                        node: programChild,
-                        message: (
-                            programChild.type.replace("Statement", "").toLowerCase() +
-							( programChild.name ? (" '" + programChild.name + "'") : " statement" ) +
-							": " + messageText
-                        )
-                    });
-                }
-
-                if (prevChar !== "\n") {
-                    //either indentation exists, or some other character - both are not allowed
-                    if (/\s/.test(prevChar)) {
-                        report("There should be no indentation before top-level declaration.");
-                    } else {
-                        report("There should be no character(s) before top-level declaration.");
-                    }
-                }
-
-                //if node starts and ends on different lines and its last line starts with a whitespace or multiline/natspec comment, report
-                if (
-                    sourceCode.getLine(programChild) !== childEndingLine &&
-					/^(\s+)|(\/\*[^*\/]*\*\/)/.test(childEndingLineText)
-                ) {
-                    context.report({
-                        node: programChild,
-                        location: {
-                            line: childEndingLine,
-                            column: 0
-                        },
-                        message: "Line shouln't have any indentation or comments at the beginning."
-                    });
-                }
-
-            }
-
-            node.body.forEach(inspectProgramChild);
-        }
-
-
-
-        //Ensure level 1 indentation before all immediate children of top-level declarations
-        function inspectTopLevelDeclaration(emitted) {
-            let body = emitted.node.body || [],
-                levelOneIndentRegExp = new RegExp("^\\n" + BASE_INDENTATION_STYLE + "$"),
-                endingLineRegExp = new RegExp("^" + BASE_INDENTATION_STYLE + "(\\S| \\*)$"),	//either a non-whitespace character or 1 extra whitespace followed by * (closing of multi-line comment)
-                endingLineExtraIndentRegExp = new RegExp("^" + BASE_INDENTATION_STYLE.repeat(2) + "(\\S| \\*)$");
-
-            if (emitted.exit) {
-                return;
-            }
-
-            function inspectChild(child) {
-                let prevChars = sourceCode.getPrevChars(child, BASE_INDENTATION_STYLE.length+1),
-                    endingLineNum = sourceCode.getEndingLine(child);
-
-                //if the start of node doesn't follow correct indentation
-                if (!levelOneIndentRegExp.test(prevChars)) {
-                    context.report({
-                        node: child,
-                        message: `Only use indent of ${BASE_INDENTATION_STYLE_DESC}.`
-                    });
-                }
-
-                // If the node starts & ends on same line, exit.
-                if (sourceCode.getLine(child) === endingLineNum) {
-                    return;
-                }
-
-                // If node starts & ends on diff lines, the ending line must also follow correct indentation.
-                // Exception to this is an abstract function whose declaration spans over multiple lines. Eg-
-                // function foo()
-                //     payable
-                //     returns (uint, string);
-
-                if (child.type === "FunctionDeclaration" && child.is_abstract) {
-
-                    if (!endingLineExtraIndentRegExp.test(
-                        sourceCode.getTextOnLine(endingLineNum).slice(0, BASE_INDENTATION_STYLE.repeat(2).length+1))) {
-                        context.report({
-                            node: child,
-                            location: {
-                                line: endingLineNum,
-                                column: 0
-                            },
-                            message: `Only use indent of ${BASE_INDENTATION_STYLE_DESC}.`
-                        });
-                    }
-
-                    return;
-                }
-
-                if (!endingLineRegExp.test(
-                    sourceCode.getTextOnLine(endingLineNum).slice(0, BASE_INDENTATION_STYLE.length+1))) {
-                    context.report({
-                        node: child,
-                        location: {
-                            line: endingLineNum,
-                            column: 0
-                        },
-                        message: `Only use indent of ${BASE_INDENTATION_STYLE_DESC}.`
-                    });
-                }
-            }
-
-            body.forEach(inspectChild);
-        }
-
-
-
-        //Ensure 1 extra indentation inside Block than before it
-        function inspectBlockStatement(emitted) {
-            let node = emitted.node;
-
-            //if the complete block resides on the same line, no need to check for indentation
-            if (emitted.exit || (sourceCode.getLine(node) === sourceCode.getEndingLine(node))) {
-                return;
-            }
-
-            let parent = sourceCode.getParent(node),
-                parentDeclarationLine = sourceCode.getLine(parent),
-                parentDeclarationLineText = sourceCode.getTextOnLine(parentDeclarationLine),
-                currentIndent, currentIndentLevel;
-
-            function inspectBlockItem(blockIndent, blockIndentDesc, blockItem) {
-                let prevChars = sourceCode.getPrevChars(blockItem, blockIndent.length+1),
-                    endingLineNum = sourceCode.getEndingLine(blockItem),
-                    endingLineRegExp = new RegExp("^" + blockIndent + "(" + BASE_INDENTATION_STYLE + ")?\\S.*$");
-
-                if (prevChars !== ("\n" + blockIndent)) {
-                    context.report({
-                        node: blockItem,
-                        message: `Only use indent of ${blockIndentDesc}.`
-                    });
-                }
-
-                /**
-				 * If the block item spans over multiple lines, make sure the ending line also follows the indent rule
-				 * An exception to this is the if-else statements when they don't have BlockStatement as their body
-				 * eg-
-				 * if (a)
-				 *     foo();
-				 * else
-				 *     bar();
-				 *
-				 * Another exception is chaining.
-				 * eg-
-				 * function() {
-				 *   myObject
-				 *     .funcA()
-				 *     .funcB()
-				 *     [0];
-				 * }
-				 * Ending line has 1 extra indentation but this is acceptable.
-				 */
-                if (
-                    blockItem.type !== "IfStatement" &&
-					sourceCode.getLine(blockItem) !== endingLineNum &&
-					!endingLineRegExp.test(sourceCode.getTextOnLine(endingLineNum))
-                ) {
-                    context.report({
-                        node: blockItem,
-                        location: {
-                            line: endingLineNum,
-                            column: 0
-                        },
-                        message: `Only use indent of ${blockIndentDesc}.`
-                    });
-                }
-            }
-
-            currentIndent = parentDeclarationLineText.slice(
-                0,
-                parentDeclarationLineText.indexOf(parentDeclarationLineText.trim())
-            );
-
-            //in case of no match, match() returns null. Return [] instead to avoid crash
-            currentIndentLevel = (currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []).length;
-
-            //ensure that there is only whitespace of correct level before the block's parent's code
-            if (getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !== currentIndent) {
-                return;	//exit now, we can' proceed further unless this is fixed
-            }
-
-            //indentation of items inside block should be 1 level greater than that of parent
-            const blockIndent = getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-            const blockIndentDesc = getIndentDescription(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-
-            node.body.forEach(inspectBlockItem.bind(null, blockIndent, blockIndentDesc));
-        }
-
-
-
-        function inspectStructDeclaration(emitted) {
-            let node = emitted.node,
-                body = node.body || [],
-                endingLineNum = sourceCode.getEndingLine(node);
-            let structDeclarationLineText, currentIndent, currentIndentLevel;
-
-            function inspectStructAttr(structIndent, structIndentDesc, attr) {
-                let indentRegExp = new RegExp("^" + structIndent + "[^\\s(\/\*)]"),
-                    attrLineText = sourceCode.getTextOnLine(sourceCode.getLine(attr));
-
-                //attribute declaration must be preceded by only correct level of indentation & no comments
-                !indentRegExp.test(attrLineText) && context.report({
-                    node: attr,
-                    message: `Only use indent of ${structIndentDesc}.`
-                });
-            }
-
-            // No need to lint further if entire struct declaration is on single line
-            if (emitted.exit || sourceCode.getLine(node) === endingLineNum) {
-                return;
-            }
-
-            structDeclarationLineText = sourceCode.getTextOnLine(sourceCode.getLine(node));
-
-            currentIndent = structDeclarationLineText.slice(
-                0,
-                structDeclarationLineText.indexOf(structDeclarationLineText.trim())
-            );
-
-            currentIndentLevel = (currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []).length;
-
-            //ensure that there is only whitespace of correct level on the line containing struct declaration
-            if (getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !== currentIndent) {
-                return;	//exit now, we can' proceed further unless this is fixed
-            }
-
-            const structIndent = getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-            const structIndentDesc = getIndentDescription(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-
-            body.forEach(inspectStructAttr.bind(null, structIndent, structIndentDesc));
-
-        }
-
-
-
-        function inspectArrayExpression(emitted) {
-            let node = emitted.node, elements = node.elements;
-            let endingLineNum = sourceCode.getEndingLine(node),
-                arrayExpressionLineText, currentIndent, currentIndentLevel;
-
-            function inspectElement(arrayIndent, arrayIndentDesc, elem) {
-                let indentRegExp = new RegExp("^" + arrayIndent + "[^\\s(\/\*)]"),
-                    elemLineText = sourceCode.getTextOnLine(sourceCode.getLine(elem));
-
-                //element declaration must be preceded by only correct level of indentation & no comments
-                !indentRegExp.test(elemLineText) && context.report({
-                    node: elem,
-                    message: `Only use indent of ${arrayIndentDesc}.`
-                });
-            }
-
-            // No need to lint further if entire arary declaration is on single line
-            if (emitted.exit || sourceCode.getLine(node) === endingLineNum) {
-                return;
-            }
-
-            arrayExpressionLineText = sourceCode.getTextOnLine(sourceCode.getLine(node));
-
-            currentIndent = arrayExpressionLineText.slice(
-                0,
-                arrayExpressionLineText.indexOf(arrayExpressionLineText.trim())
-            );
-
-            currentIndentLevel = (currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []).length;
-
-            //ensure that there is only whitespace of correct level on the line containing array expression
-            if (getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !== currentIndent) {
-                return;	//exit now, we can' proceed further unless this is fixed
-            }
-
-            const arrayIndent = getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-            const arrayIndentDesc = getIndentDescription(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-
-            elements.forEach(inspectElement.bind(null, arrayIndent, arrayIndentDesc));
-        }
-
-
-        //function params (if on multiple lines)
-        function inspectFunctionDeclaration(emitted) {
-            let node = emitted.node, params = node.params || [];
-
-            let startLine = sourceCode.getLine(node),
-                lastArgLine = params.length ? sourceCode.getEndingLine(params.slice(-1) [0]) : startLine,
-                functionDeclarationLineText, currentIndent, currentIndentLevel;
-
-            function inspectParam(paramIndent, paramIndentDesc, param) {
-                let indentRegExp = new RegExp("^" + paramIndent + "[^\\s(\/\*)]"),
-                    paramLineText = sourceCode.getTextOnLine(sourceCode.getLine(param));
-
-                //parameter declaration must be preceded by only correct level of indentation & no comments
-                !indentRegExp.test(paramLineText) && context.report({
-                    node: param,
-                    message: `Only use indent of ${paramIndentDesc}.`
-                });
-            }
-
-            // If declaration args start & end on same line, exit now
-            if (emitted.exit || startLine === lastArgLine) {
-                return;
-            }
-
-            functionDeclarationLineText = sourceCode.getTextOnLine(startLine);
-
-            currentIndent = functionDeclarationLineText.slice(
-                0,
-                functionDeclarationLineText.indexOf(functionDeclarationLineText.trim())
-            );
-
-            currentIndentLevel = (currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []).length;
-
-            //ensure that there is only whitespace of correct level on the line containing parameter
-            if (getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !== currentIndent) {
-                return;	//exit now, we can' proceed further unless this is fixed
-            }
-
-            const paramIndent = getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-            const paramIndentDesc = getIndentDescription(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-
-            params.forEach(inspectParam.bind(null, paramIndent, paramIndentDesc));
-        }
-
-
-        function inspectCallExpression(emitted) {
-
-            let node = emitted.node;
-            let endingLineNum = sourceCode.getEndingLine(node),
-                callExpressionLineText, currentIndent, currentIndentLevel;
-
-            function inspectArgument(argIndent, argIndentDesc, argument) {
-                let indentRegExp = new RegExp("^" + argIndent + "[^\\s(\/\*)]"),
-                    argLineText = sourceCode.getTextOnLine(sourceCode.getLine(argument));
-
-                //parameter declaration must be preceded by only correct level of indentation & no comments
-                !indentRegExp.test(argLineText) && context.report({
-                    node: argument,
-                    message: `Only use indent of ${argIndentDesc}.`
-                });
-            }
-
-            // Return if the call starts & ends on same line
-            // Also return if the callee is NOT an identifier, else rule creates false positives
-            // eg-
-            // foo()
-            //     .bar(10, "hello");
-            //
-            // baz(10, "hello");
-            //
-            // In first eg, rule will lint at args for indent because it thinks the call spans over multiple lines
-            if (emitted.exit ||
-				sourceCode.getLine(node) === endingLineNum || node.callee.type !== "Identifier") {
-                return;
-            }
-
-            callExpressionLineText = sourceCode.getTextOnLine(sourceCode.getLine(node));
-
-            currentIndent = callExpressionLineText.slice(
-                0,
-                callExpressionLineText.indexOf(callExpressionLineText.trim())
-            );
-
-            currentIndentLevel = (currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []).length;
-
-            //ensure that there is only whitespace of correct level on the line containing parameter
-            if (getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !== currentIndent) {
-                return;	//exit now, we can' proceed further unless this is fixed
-            }
-
-            const argIndent = getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-            const argIndentDesc = getIndentDescription(BASE_INDENTATION_STYLE, currentIndentLevel + 1);
-
-            node.arguments.forEach(inspectArgument.bind(null, argIndent, argIndentDesc));
-
-        }
-
-
-        let response = {
-            CallExpression: inspectCallExpression,
-            FunctionDeclaration: inspectFunctionDeclaration,
-            ArrayExpression: inspectArrayExpression,
-            StructDeclaration: inspectStructDeclaration,
-            BlockStatement: inspectBlockStatement,
-            Program: inspectProgram
-        };
-
-        topLevelDeclarations.forEach(function(nodeName) {
-            response [nodeName] = inspectTopLevelDeclaration;
-        });
-
-        return response;
-
+    schema: [
+      {
+        oneOf: [
+          { type: "string", enum: ["tab"] },
+          { type: "integer", minimum: 0 }
+        ]
+      }
+    ]
+  },
+
+  create: function(context) {
+    // default configurations
+    let BASE_INDENTATION_STYLE = " ".repeat(4),
+      BASE_INDENTATION_STYLE_DESC = "4 spaces";
+
+    if (context.options) {
+      if (context.options[0] === "tab") {
+        BASE_INDENTATION_STYLE = "\t";
+        BASE_INDENTATION_STYLE_DESC = "1 tab";
+      } else {
+        let spCount = context.options[0];
+
+        BASE_INDENTATION_STYLE = " ".repeat(spCount);
+        BASE_INDENTATION_STYLE_DESC =
+          spCount + " space" + (spCount === 1 ? "" : "s");
+      }
     }
 
+    let BASE_INDENTATION_STYLE_REGEXP_GLOBAL = new RegExp(
+      BASE_INDENTATION_STYLE,
+      "g"
+    );
+
+    let sourceCode = context.getSourceCode();
+    let topLevelDeclarations = ["ContractStatement", "LibraryStatement"];
+
+    //Ensure NO indentation exists before top-level declarations (contract, library)
+    function inspectProgram(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      function inspectProgramChild(programChild) {
+        //if node's code starts at index 0, getPrevChar() returns null (meaning no errors), so change it to '\n'
+        let prevChar = sourceCode.getPrevChar(programChild) || "\n",
+          childEndingLine = sourceCode.getEndingLine(programChild),
+          childEndingLineText = sourceCode.getTextOnLine(childEndingLine);
+
+        function report(messageText) {
+          context.report({
+            node: programChild,
+            message:
+              programChild.type.replace("Statement", "").toLowerCase() +
+              (programChild.name
+                ? " '" + programChild.name + "'"
+                : " statement") +
+              ": " +
+              messageText
+          });
+        }
+
+        if (prevChar !== "\n") {
+          //either indentation exists, or some other character - both are not allowed
+          if (/\s/.test(prevChar)) {
+            report(
+              "There should be no indentation before top-level declaration."
+            );
+          } else {
+            report(
+              "There should be no character(s) before top-level declaration."
+            );
+          }
+        }
+
+        //if node starts and ends on different lines and its last line starts with a whitespace or multiline/natspec comment, report
+        if (
+          sourceCode.getLine(programChild) !== childEndingLine &&
+          /^(\s+)|(\/\*[^*\/]*\*\/)/.test(childEndingLineText)
+        ) {
+          context.report({
+            node: programChild,
+            location: {
+              line: childEndingLine,
+              column: 0
+            },
+            message:
+              "Line shouln't have any indentation or comments at the beginning."
+          });
+        }
+      }
+
+      node.body.forEach(inspectProgramChild);
+    }
+
+    //Ensure level 1 indentation before all immediate children of top-level declarations
+    function inspectTopLevelDeclaration(emitted) {
+      let body = emitted.node.body || [],
+        levelOneIndentRegExp = new RegExp(
+          "^\\n" + BASE_INDENTATION_STYLE + "$"
+        ),
+        endingLineRegExp = new RegExp(
+          "^" + BASE_INDENTATION_STYLE + "(\\S| \\*)$"
+        ), //either a non-whitespace character or 1 extra whitespace followed by * (closing of multi-line comment)
+        endingLineExtraIndentRegExp = new RegExp(
+          "^" + BASE_INDENTATION_STYLE.repeat(2) + "(\\S| \\*)$"
+        );
+
+      if (emitted.exit) {
+        return;
+      }
+
+      function inspectChild(child) {
+        let prevChars = sourceCode.getPrevChars(
+            child,
+            BASE_INDENTATION_STYLE.length + 1
+          ),
+          endingLineNum = sourceCode.getEndingLine(child);
+
+        //if the start of node doesn't follow correct indentation
+        if (!levelOneIndentRegExp.test(prevChars)) {
+          context.report({
+            node: child,
+            message: `Only use indent of ${BASE_INDENTATION_STYLE_DESC}.`
+          });
+        }
+
+        // If the node starts & ends on same line, exit.
+        if (sourceCode.getLine(child) === endingLineNum) {
+          return;
+        }
+
+        // If node starts & ends on diff lines, the ending line must also follow correct indentation.
+        // Exception to this is an abstract function whose declaration spans over multiple lines. Eg-
+        // function foo()
+        //     payable
+        //     returns (uint, string);
+
+        if (child.type === "FunctionDeclaration" && child.is_abstract) {
+          if (
+            !endingLineExtraIndentRegExp.test(
+              sourceCode
+                .getTextOnLine(endingLineNum)
+                .slice(0, BASE_INDENTATION_STYLE.repeat(2).length + 1)
+            )
+          ) {
+            context.report({
+              node: child,
+              location: {
+                line: endingLineNum,
+                column: 0
+              },
+              message: `Only use indent of ${BASE_INDENTATION_STYLE_DESC}.`
+            });
+          }
+
+          return;
+        }
+
+        if (
+          !endingLineRegExp.test(
+            sourceCode
+              .getTextOnLine(endingLineNum)
+              .slice(0, BASE_INDENTATION_STYLE.length + 1)
+          )
+        ) {
+          context.report({
+            node: child,
+            location: {
+              line: endingLineNum,
+              column: 0
+            },
+            message: `Only use indent of ${BASE_INDENTATION_STYLE_DESC}.`
+          });
+        }
+      }
+
+      body.forEach(inspectChild);
+    }
+
+    //Ensure 1 extra indentation inside Block than before it
+    function inspectBlockStatement(emitted) {
+      let node = emitted.node;
+
+      //if the complete block resides on the same line, no need to check for indentation
+      if (
+        emitted.exit ||
+        sourceCode.getLine(node) === sourceCode.getEndingLine(node)
+      ) {
+        return;
+      }
+
+      let parent = sourceCode.getParent(node),
+        parentDeclarationLine = sourceCode.getLine(parent),
+        parentDeclarationLineText = sourceCode.getTextOnLine(
+          parentDeclarationLine
+        ),
+        currentIndent,
+        currentIndentLevel;
+
+      function inspectBlockItem(blockIndent, blockIndentDesc, blockItem) {
+        let prevChars = sourceCode.getPrevChars(
+            blockItem,
+            blockIndent.length + 1
+          ),
+          endingLineNum = sourceCode.getEndingLine(blockItem),
+          endingLineRegExp = new RegExp(
+            "^" + blockIndent + "(" + BASE_INDENTATION_STYLE + ")?\\S.*$"
+          );
+
+        if (prevChars !== "\n" + blockIndent) {
+          context.report({
+            node: blockItem,
+            message: `Only use indent of ${blockIndentDesc}.`
+          });
+        }
+
+        /**
+         * If the block item spans over multiple lines, make sure the ending line also follows the indent rule
+         * An exception to this is the if-else statements when they don't have BlockStatement as their body
+         * eg-
+         * if (a)
+         *     foo();
+         * else
+         *     bar();
+         *
+         * Another exception is chaining.
+         * eg-
+         * function() {
+         *   myObject
+         *     .funcA()
+         *     .funcB()
+         *     [0];
+         * }
+         * Ending line has 1 extra indentation but this is acceptable.
+         */
+        if (
+          blockItem.type !== "IfStatement" &&
+          sourceCode.getLine(blockItem) !== endingLineNum &&
+          !endingLineRegExp.test(sourceCode.getTextOnLine(endingLineNum))
+        ) {
+          context.report({
+            node: blockItem,
+            location: {
+              line: endingLineNum,
+              column: 0
+            },
+            message: `Only use indent of ${blockIndentDesc}.`
+          });
+        }
+      }
+
+      currentIndent = parentDeclarationLineText.slice(
+        0,
+        parentDeclarationLineText.indexOf(parentDeclarationLineText.trim())
+      );
+
+      //in case of no match, match() returns null. Return [] instead to avoid crash
+      currentIndentLevel = (
+        currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []
+      ).length;
+
+      //ensure that there is only whitespace of correct level before the block's parent's code
+      if (
+        getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !==
+        currentIndent
+      ) {
+        return; //exit now, we can' proceed further unless this is fixed
+      }
+
+      //indentation of items inside block should be 1 level greater than that of parent
+      const blockIndent = getIndentString(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+      const blockIndentDesc = getIndentDescription(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+
+      node.body.forEach(
+        inspectBlockItem.bind(null, blockIndent, blockIndentDesc)
+      );
+    }
+
+    function inspectStructDeclaration(emitted) {
+      let node = emitted.node,
+        body = node.body || [],
+        endingLineNum = sourceCode.getEndingLine(node);
+      let structDeclarationLineText, currentIndent, currentIndentLevel;
+
+      function inspectStructAttr(structIndent, structIndentDesc, attr) {
+        let indentRegExp = new RegExp("^" + structIndent + "[^\\s(/*)]"),
+          attrLineText = sourceCode.getTextOnLine(sourceCode.getLine(attr));
+
+        //attribute declaration must be preceded by only correct level of indentation & no comments
+        !indentRegExp.test(attrLineText) &&
+          context.report({
+            node: attr,
+            message: `Only use indent of ${structIndentDesc}.`
+          });
+      }
+
+      // No need to lint further if entire struct declaration is on single line
+      if (emitted.exit || sourceCode.getLine(node) === endingLineNum) {
+        return;
+      }
+
+      structDeclarationLineText = sourceCode.getTextOnLine(
+        sourceCode.getLine(node)
+      );
+
+      currentIndent = structDeclarationLineText.slice(
+        0,
+        structDeclarationLineText.indexOf(structDeclarationLineText.trim())
+      );
+
+      currentIndentLevel = (
+        currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []
+      ).length;
+
+      //ensure that there is only whitespace of correct level on the line containing struct declaration
+      if (
+        getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !==
+        currentIndent
+      ) {
+        return; //exit now, we can' proceed further unless this is fixed
+      }
+
+      const structIndent = getIndentString(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+      const structIndentDesc = getIndentDescription(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+
+      body.forEach(
+        inspectStructAttr.bind(null, structIndent, structIndentDesc)
+      );
+    }
+
+    function inspectArrayExpression(emitted) {
+      let node = emitted.node,
+        elements = node.elements;
+      let endingLineNum = sourceCode.getEndingLine(node),
+        arrayExpressionLineText,
+        currentIndent,
+        currentIndentLevel;
+
+      function inspectElement(arrayIndent, arrayIndentDesc, elem) {
+        let indentRegExp = new RegExp("^" + arrayIndent + "[^\\s(/*)]"),
+          elemLineText = sourceCode.getTextOnLine(sourceCode.getLine(elem));
+
+        //element declaration must be preceded by only correct level of indentation & no comments
+        !indentRegExp.test(elemLineText) &&
+          context.report({
+            node: elem,
+            message: `Only use indent of ${arrayIndentDesc}.`
+          });
+      }
+
+      // No need to lint further if entire arary declaration is on single line
+      if (emitted.exit || sourceCode.getLine(node) === endingLineNum) {
+        return;
+      }
+
+      arrayExpressionLineText = sourceCode.getTextOnLine(
+        sourceCode.getLine(node)
+      );
+
+      currentIndent = arrayExpressionLineText.slice(
+        0,
+        arrayExpressionLineText.indexOf(arrayExpressionLineText.trim())
+      );
+
+      currentIndentLevel = (
+        currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []
+      ).length;
+
+      //ensure that there is only whitespace of correct level on the line containing array expression
+      if (
+        getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !==
+        currentIndent
+      ) {
+        return; //exit now, we can' proceed further unless this is fixed
+      }
+
+      const arrayIndent = getIndentString(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+      const arrayIndentDesc = getIndentDescription(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+
+      elements.forEach(inspectElement.bind(null, arrayIndent, arrayIndentDesc));
+    }
+
+    //function params (if on multiple lines)
+    function inspectFunctionDeclaration(emitted) {
+      let node = emitted.node,
+        params = node.params || [];
+
+      let startLine = sourceCode.getLine(node),
+        lastArgLine = params.length
+          ? sourceCode.getEndingLine(params.slice(-1)[0])
+          : startLine,
+        functionDeclarationLineText,
+        currentIndent,
+        currentIndentLevel;
+
+      function inspectParam(paramIndent, paramIndentDesc, param) {
+        let indentRegExp = new RegExp("^" + paramIndent + "[^\\s(/*)]"),
+          paramLineText = sourceCode.getTextOnLine(sourceCode.getLine(param));
+
+        //parameter declaration must be preceded by only correct level of indentation & no comments
+        !indentRegExp.test(paramLineText) &&
+          context.report({
+            node: param,
+            message: `Only use indent of ${paramIndentDesc}.`
+          });
+      }
+
+      // If declaration args start & end on same line, exit now
+      if (emitted.exit || startLine === lastArgLine) {
+        return;
+      }
+
+      functionDeclarationLineText = sourceCode.getTextOnLine(startLine);
+
+      currentIndent = functionDeclarationLineText.slice(
+        0,
+        functionDeclarationLineText.indexOf(functionDeclarationLineText.trim())
+      );
+
+      currentIndentLevel = (
+        currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []
+      ).length;
+
+      //ensure that there is only whitespace of correct level on the line containing parameter
+      if (
+        getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !==
+        currentIndent
+      ) {
+        return; //exit now, we can' proceed further unless this is fixed
+      }
+
+      const paramIndent = getIndentString(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+      const paramIndentDesc = getIndentDescription(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+
+      params.forEach(inspectParam.bind(null, paramIndent, paramIndentDesc));
+    }
+
+    function inspectCallExpression(emitted) {
+      let node = emitted.node;
+      let endingLineNum = sourceCode.getEndingLine(node),
+        callExpressionLineText,
+        currentIndent,
+        currentIndentLevel;
+
+      function inspectArgument(argIndent, argIndentDesc, argument) {
+        let indentRegExp = new RegExp("^" + argIndent + "[^\\s(/*)]"),
+          argLineText = sourceCode.getTextOnLine(sourceCode.getLine(argument));
+
+        //parameter declaration must be preceded by only correct level of indentation & no comments
+        !indentRegExp.test(argLineText) &&
+          context.report({
+            node: argument,
+            message: `Only use indent of ${argIndentDesc}.`
+          });
+      }
+
+      // Return if the call starts & ends on same line
+      // Also return if the callee is NOT an identifier, else rule creates false positives
+      // eg-
+      // foo()
+      //     .bar(10, "hello");
+      //
+      // baz(10, "hello");
+      //
+      // In first eg, rule will lint at args for indent because it thinks the call spans over multiple lines
+      if (
+        emitted.exit ||
+        sourceCode.getLine(node) === endingLineNum ||
+        node.callee.type !== "Identifier"
+      ) {
+        return;
+      }
+
+      callExpressionLineText = sourceCode.getTextOnLine(
+        sourceCode.getLine(node)
+      );
+
+      currentIndent = callExpressionLineText.slice(
+        0,
+        callExpressionLineText.indexOf(callExpressionLineText.trim())
+      );
+
+      currentIndentLevel = (
+        currentIndent.match(BASE_INDENTATION_STYLE_REGEXP_GLOBAL) || []
+      ).length;
+
+      //ensure that there is only whitespace of correct level on the line containing parameter
+      if (
+        getIndentString(BASE_INDENTATION_STYLE, currentIndentLevel) !==
+        currentIndent
+      ) {
+        return; //exit now, we can' proceed further unless this is fixed
+      }
+
+      const argIndent = getIndentString(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+      const argIndentDesc = getIndentDescription(
+        BASE_INDENTATION_STYLE,
+        currentIndentLevel + 1
+      );
+
+      node.arguments.forEach(
+        inspectArgument.bind(null, argIndent, argIndentDesc)
+      );
+    }
+
+    let response = {
+      CallExpression: inspectCallExpression,
+      FunctionDeclaration: inspectFunctionDeclaration,
+      ArrayExpression: inspectArrayExpression,
+      StructDeclaration: inspectStructDeclaration,
+      BlockStatement: inspectBlockStatement,
+      Program: inspectProgram
+    };
+
+    topLevelDeclarations.forEach(function(nodeName) {
+      response[nodeName] = inspectTopLevelDeclaration;
+    });
+
+    return response;
+  }
 };

--- a/lib/rules/lbrace.js
+++ b/lib/rules/lbrace.js
@@ -6,418 +6,427 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure correct positioning of the opening brace '{'"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description: "Ensure correct positioning of the opening brace '{'"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let sourceCode = context.getSourceCode();
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
-        function inspectIfStatement(emitted) {
-            let node = emitted.node;
+    function inspectIfStatement(emitted) {
+      let node = emitted.node;
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            //rules for consequents of if/else if/else				
-            let ifConsequentType = node.consequent.type,
-                nodeStartingLine = sourceCode.getLine(node);
-            let consequentStartingLine = sourceCode.getLine(node.consequent),
-                consequentEndingLine = sourceCode.getEndingLine(node.consequent);
+      //rules for consequents of if/else if/else
+      let ifConsequentType = node.consequent.type,
+        nodeStartingLine = sourceCode.getLine(node);
+      let consequentStartingLine = sourceCode.getLine(node.consequent),
+        consequentEndingLine = sourceCode.getEndingLine(node.consequent);
 
-            if (ifConsequentType === "EmptyStatement") {
-
-                context.report({
-                    node: node.consequent,
-                    message: "Clause is followed by an empty statement."
-                });
-
-            } else if (ifConsequentType === "BlockStatement") {
-
-                //if the complete test lies on the same line as the 'if' token but the brace doesn't, report
-                if (nodeStartingLine === sourceCode.getEndingLine(node.test)) {
-                    if (sourceCode.getLine(node.consequent) !== nodeStartingLine) {
-
-                        context.report({
-                            node: node.consequent,
-                            message: "Opening brace must be on the same line as the 'if' token."
-                        });
-
-                    } else {
-
-                        //if the brace IS on the same line, ensure that only a single space exists between it and test
-                        (!/^[^\s\/] $/.test(sourceCode.getPrevChars(node.consequent, 2))) && context.report({
-                            node: node.consequent,
-                            message: "Only use single space between condition and opening brace."
-                        });
-
-                    }
-                }
-
-            } else {
-                /**
-				 * If consequent is a single item:
-				 *     1. It should be on the line immediately after the test
-				 *     2. It should completely reside on a single line
-				 */
-                if (consequentStartingLine !== sourceCode.getEndingLine(node.test) + 1) {
-                    context.report({
-                        node: node.consequent,
-                        message: "Consequent should exist exactly on the line after condition."
-                    });
-                } else if (consequentEndingLine !== consequentStartingLine) {
-                    context.report({
-                        node: node.consequent,
-                        message: "Consequent must reside on a single line only."
-                    });
-                }
-            }
-
-            let alternate = node.alternate;
-
-            if (!alternate) {
-                return;
-            }
-
-            let alternateLine = sourceCode.getLine(alternate);
-
-            /**
-			 * If consequent is a BlockStatement, then alternate & 'else' must begin on the same line as ending brace of consequent
-			 * Otherwise, 'else' must exist on the line immediately after the finishing line of the consequent
-			 */
-            if (ifConsequentType === "BlockStatement") {
-                if (
-                    (alternate.type === "BlockStatement" || alternate.type === "IfStatement") &&
-					alternateLine !== consequentEndingLine
-                ) {
-                    return context.report({
-                        node: alternate,
-                        message: "Alternate 'else' must begin on the same line as if's closing brace."
-                    });
-                }
-            } else {
-                let nextLineText;
-
-                try {
-                    nextLineText = sourceCode.getTextOnLine(consequentEndingLine + 1);
-                } catch (e) {
-                    //if next line doesn't exist, i.e., consequentEndingLine is the last line in the program
-                    nextLineText = "";
-                }
-
-                //ensure that consequent is followed by 'else' token on the next line
-                if (!/^\s*else/.test(nextLineText)) {
-                    return context.report({
-                        node: node.consequent,
-                        location: {
-                            line: consequentEndingLine
-                        },
-                        message: "'else' clause should start on the line after if consequent."
-                    });
-                }
-            }
-
-            //if alternate is another 'if' statement (,i.e., else if (..) {..}), below rules don't apply
-            if (alternate.type === "IfStatement") {
-                return;
-            }
-
-            if (alternate.type === "EmptyStatement") {
-                return context.report({
-                    node: alternate,
-                    message: "'else' is followed by an empty statement."
-                });
-            }
-
-            if (alternate.type === "BlockStatement") {
-                if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(alternate, 2))) {
-
-                    //if the brace IS on the same line, ensure that only a single space exists between it and test
-                    context.report({
-                        node: alternate,
-                        message: "Only use single space between 'else' and opening brace."
-                    });
-
-                }
-
-                return;
-            }
-
-            //ensure that 'else' token is followed by statement on the next line (when statement is neither EmptyStatement nor inside a block)
-            if (sourceCode.getLine(alternate) !== consequentEndingLine + 2) {
-                return context.report({
-                    node: alternate,
-                    message: "Alternate clause should exist on line after 'else'."
-                });
-            }
-
-            //if alternate is a single statement (not inside block), it must completely reside on a single line
-            (sourceCode.getLine(alternate) !== sourceCode.getEndingLine(alternate)) && context.report({
-                node: alternate,
-                message: "Entire statement must reside on a single line."
+      if (ifConsequentType === "EmptyStatement") {
+        context.report({
+          node: node.consequent,
+          message: "Clause is followed by an empty statement."
+        });
+      } else if (ifConsequentType === "BlockStatement") {
+        //if the complete test lies on the same line as the 'if' token but the brace doesn't, report
+        if (nodeStartingLine === sourceCode.getEndingLine(node.test)) {
+          if (sourceCode.getLine(node.consequent) !== nodeStartingLine) {
+            context.report({
+              node: node.consequent,
+              message:
+                "Opening brace must be on the same line as the 'if' token."
             });
+          } else {
+            //if the brace IS on the same line, ensure that only a single space exists between it and test
+            !/^[^\s\/] $/.test(sourceCode.getPrevChars(node.consequent, 2)) &&
+              context.report({
+                node: node.consequent,
+                message:
+                  "Only use single space between condition and opening brace."
+              });
+          }
+        }
+      } else {
+        /**
+         * If consequent is a single item:
+         *     1. It should be on the line immediately after the test
+         *     2. It should completely reside on a single line
+         */
+        if (
+          consequentStartingLine !==
+          sourceCode.getEndingLine(node.test) + 1
+        ) {
+          context.report({
+            node: node.consequent,
+            message:
+              "Consequent should exist exactly on the line after condition."
+          });
+        } else if (consequentEndingLine !== consequentStartingLine) {
+          context.report({
+            node: node.consequent,
+            message: "Consequent must reside on a single line only."
+          });
+        }
+      }
+
+      let alternate = node.alternate;
+
+      if (!alternate) {
+        return;
+      }
+
+      let alternateLine = sourceCode.getLine(alternate);
+
+      /**
+       * If consequent is a BlockStatement, then alternate & 'else' must begin on the same line as ending brace of consequent
+       * Otherwise, 'else' must exist on the line immediately after the finishing line of the consequent
+       */
+      if (ifConsequentType === "BlockStatement") {
+        if (
+          (alternate.type === "BlockStatement" ||
+            alternate.type === "IfStatement") &&
+          alternateLine !== consequentEndingLine
+        ) {
+          return context.report({
+            node: alternate,
+            message:
+              "Alternate 'else' must begin on the same line as if's closing brace."
+          });
+        }
+      } else {
+        let nextLineText;
+
+        try {
+          nextLineText = sourceCode.getTextOnLine(consequentEndingLine + 1);
+        } catch (e) {
+          //if next line doesn't exist, i.e., consequentEndingLine is the last line in the program
+          nextLineText = "";
         }
 
+        //ensure that consequent is followed by 'else' token on the next line
+        if (!/^\s*else/.test(nextLineText)) {
+          return context.report({
+            node: node.consequent,
+            location: {
+              line: consequentEndingLine
+            },
+            message:
+              "'else' clause should start on the line after if consequent."
+          });
+        }
+      }
 
-        function inspectForStatement(emitted) {
-            let node = emitted.node,
-                lastNodeOnStartingLine = node.update || node.test || node.init;
-            let startingLine = sourceCode.getLine(node);
+      //if alternate is another 'if' statement (,i.e., else if (..) {..}), below rules don't apply
+      if (alternate.type === "IfStatement") {
+        return;
+      }
 
-            if (emitted.exit) {
-                return;
-            }
+      if (alternate.type === "EmptyStatement") {
+        return context.report({
+          node: alternate,
+          message: "'else' is followed by an empty statement."
+        });
+      }
 
-            /**
-			 * If no BlockStatement found, report. Otherwise:
-			 * Check the last non-null node amongst 'init', 'test' and 'update'
-			 * If such a node doesn't exist and '{' is on diff line, report.
-			 * If such a node exists and it exists on the same line as 'for' and '{' is on diff line, report
-			 */
-            if (node.body.type !== "BlockStatement") {
-                return context.report({
-                    node: node,
-                    message: "Expected '{' after for statement."
-                });
-            }
-
-            if (
-                (
-                    !lastNodeOnStartingLine ||
-					startingLine === sourceCode.getEndingLine(lastNodeOnStartingLine)
-                ) &&
-				startingLine !== sourceCode.getLine(node.body)
-            ) {
-                return context.report({
-                    node: node.body,
-                    message: "Opening brace must be on the same line as the for statement."
-                });
-            }
-
-            if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(node.body, 2))) {
-                context.report({
-                    node: node.body,
-                    message: "Only use single space between for statement & opening brace."
-                });
-            }
+      if (alternate.type === "BlockStatement") {
+        if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(alternate, 2))) {
+          //if the brace IS on the same line, ensure that only a single space exists between it and test
+          context.report({
+            node: alternate,
+            message: "Only use single space between 'else' and opening brace."
+          });
         }
 
+        return;
+      }
 
-        function inspectWhileStatement(emitted) {
-            let node = emitted.node,
-                startingLine = sourceCode.getLine(node);
+      //ensure that 'else' token is followed by statement on the next line (when statement is neither EmptyStatement nor inside a block)
+      if (sourceCode.getLine(alternate) !== consequentEndingLine + 2) {
+        return context.report({
+          node: alternate,
+          message: "Alternate clause should exist on line after 'else'."
+        });
+      }
 
-            if (emitted.exit) {
-                return;
-            }
-
-            /**
-             * If no BlockStatement found, report. Otherwise:
-             * If 'while' and node.test exist on same line and '{' is on diff line, report
-             */
-            if (node.body.type !== "BlockStatement") {
-                return context.report({
-                    node: node,
-                    message: "Expected '{' after while statement."
-                });
-            }
-
-            if (
-                startingLine === sourceCode.getEndingLine(node.test) &&
-				startingLine !== sourceCode.getLine(node.body)
-            ) {
-                return context.report({
-                    node: node.body,
-                    message: "Opening brace must be on the same line as the while statement."
-                });
-            }
-
-            if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(node.body, 2))) {
-                context.report({
-                    node: node.body,
-                    message: "Only use single space between while declaration & opening brace."
-                });
-            }
-        }
-
-
-        function inspectDoWhileStatement(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            /**
-			 * If no BlockStatement found, report. Otherwise:
-			 * If 'while' and node.test exist on same line and '{' is on diff line, report
-			 */
-            if (node.body.type !== "BlockStatement") {
-                return context.report({
-                    node: node,
-                    message: "Expected '{' after do token."
-                });
-            }
-
-            if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(node.body, 2))) {
-                context.report({
-                    node: node.body,
-                    message: "Only use single space between 'do' & opening brace."
-                });
-            }
-        }
-
-
-        function inspectStructDeclaration(emitted) {
-            let node = emitted.node,
-                code = sourceCode.getText(node).replace("struct " + node.name, "");
-
-            if (emitted.exit) {
-                return;
-            }
-
-            (code.slice(0, 2) !== " {") && context.report({
-                node: node,
-                message: `'${node.name}': Declaration & opening brace must be separated by single space only.`
-            });
-        }
-
-
-        function inspectContractStatement(emitted) {
-            let node = emitted.node,
-                code = sourceCode.getTextOnLine(sourceCode.getLine(node));
-
-            if (emitted.exit) {
-                return;
-            }
-
-            (!/[^\s\/] {/.test(code)) && context.report({
-                node: node,
-                message: `'${node.name}': Declaration & opening brace must be separated by single space only.`
-            });
-        }
-
-
-        function inspectLibraryStatement(emitted) {
-            let node = emitted.node,
-                code = sourceCode.getTextOnLine(sourceCode.getLine(node));
-
-            if (emitted.exit) {
-                return;
-            }
-
-            (!/[^\s\/] {/.test(code)) && context.report({
-                node: node,
-                message: `'${node.name}': Declaration & opening brace must be separated by single space only.`
-            });
-        }
-
-
-        function inspectFunctionDeclaration(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit || node.is_abstract) {
-                return;
-            }
-
-            /**
-             * If entire (non-abstract) function's signature is on single line, then the opening brace of its body must be on the same line too.
-             * If signature is on multiple lines:
-             *     If sign contains only params (each on its own line), then brace must be on the same line as last param's ending line
-             *     If sign contains modifiers (each on its own line), then brace must be on the line immediately after ending line of last modifier
-             */
-            let declarationEndingLine,
-                declarationStartingLine = sourceCode.getLine(node),
-                bodyStartingLine = sourceCode.getLine(node.body);
-
-            //If the node just before function's body is on the start line itself, then the opening brace must too be on the start line
-            if (node.returnParams !== null) {
-                declarationEndingLine = sourceCode.getEndingLine(node.returnParams);
-            } else if (node.modifiers !== null) {
-                //if modifiers is non-null (,i.e., array), compare bodyStartingLine with ending line of the last modifier declaration (last array element)
-                declarationEndingLine = sourceCode.getEndingLine(node.modifiers.slice(-1) [0]);
-            } else if (node.params !== null) {
-                //if params is non-null (,i.e., array), compare bodyStartingLine with ending line of the last param declaration (last array element)
-                declarationEndingLine = sourceCode.getEndingLine(node.params.slice(-1) [0]);
-            } else {
-                //if none of the above is present, then opening brace must surely begin on the same line
-                declarationEndingLine = sourceCode.getLine(node);
-            }
-
-            let charsBeforeLBrace = sourceCode.getPrevChars(node.body, 2);
-
-            if (declarationEndingLine === declarationStartingLine) {
-				
-                if (bodyStartingLine !== declarationEndingLine) {
-                    context.report({
-                        node: node.body,
-                        message: "Opening brace must be on the same line as function's declaration."
-                    });
-                } else {
-                    (!/[^\s\/] /.test(charsBeforeLBrace)) && context.report({
-                        node: node.body,
-                        message: "Opening brace must be preceded by single space only."
-                    });
-                }
-
-                return;
-
-            }
-
-            if (node.returnParams) {
-                if (sourceCode.getLine(node.body) !== (sourceCode.getEndingLine(node.returnParams) + 1)) {
-                    context.report({
-                        node: node.body,
-                        message: "Opening brace must be on the line after returns declaration."
-                    });
-                }
-
-                return;
-            }
-
-            if (node.modifiers) {
-                const lbraceLine = sourceCode.getLine(node.body),
-                    lastModifEndLine = sourceCode.getEndingLine(node.modifiers.slice(-1) [0]);
-
-                if (lbraceLine !== lastModifEndLine+1) {
-                    context.report({
-                        node: node.body,
-                        message: "Opening brace must be on the line after last modifier."
-                    });
-                }
-
-                return;
-            }
-
-            (!/[^\s\/] /.test(charsBeforeLBrace)) && context.report({
-                node: node.body,
-                message: "Opening brace must be preceded by only a single space."
-            });
-        }
-
-
-        return {
-            FunctionDeclaration: inspectFunctionDeclaration,
-            LibraryStatement: inspectLibraryStatement,
-            ContractStatement: inspectContractStatement,
-            StructDeclaration: inspectStructDeclaration,
-            DoWhileStatement: inspectDoWhileStatement,
-            WhileStatement: inspectWhileStatement,
-            ForStatement: inspectForStatement,
-            IfStatement: inspectIfStatement
-        };
-		
+      //if alternate is a single statement (not inside block), it must completely reside on a single line
+      sourceCode.getLine(alternate) !== sourceCode.getEndingLine(alternate) &&
+        context.report({
+          node: alternate,
+          message: "Entire statement must reside on a single line."
+        });
     }
 
+    function inspectForStatement(emitted) {
+      let node = emitted.node,
+        lastNodeOnStartingLine = node.update || node.test || node.init;
+      let startingLine = sourceCode.getLine(node);
+
+      if (emitted.exit) {
+        return;
+      }
+
+      /**
+       * If no BlockStatement found, report. Otherwise:
+       * Check the last non-null node amongst 'init', 'test' and 'update'
+       * If such a node doesn't exist and '{' is on diff line, report.
+       * If such a node exists and it exists on the same line as 'for' and '{' is on diff line, report
+       */
+      if (node.body.type !== "BlockStatement") {
+        return context.report({
+          node: node,
+          message: "Expected '{' after for statement."
+        });
+      }
+
+      if (
+        (!lastNodeOnStartingLine ||
+          startingLine === sourceCode.getEndingLine(lastNodeOnStartingLine)) &&
+        startingLine !== sourceCode.getLine(node.body)
+      ) {
+        return context.report({
+          node: node.body,
+          message:
+            "Opening brace must be on the same line as the for statement."
+        });
+      }
+
+      if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(node.body, 2))) {
+        context.report({
+          node: node.body,
+          message:
+            "Only use single space between for statement & opening brace."
+        });
+      }
+    }
+
+    function inspectWhileStatement(emitted) {
+      let node = emitted.node,
+        startingLine = sourceCode.getLine(node);
+
+      if (emitted.exit) {
+        return;
+      }
+
+      /**
+       * If no BlockStatement found, report. Otherwise:
+       * If 'while' and node.test exist on same line and '{' is on diff line, report
+       */
+      if (node.body.type !== "BlockStatement") {
+        return context.report({
+          node: node,
+          message: "Expected '{' after while statement."
+        });
+      }
+
+      if (
+        startingLine === sourceCode.getEndingLine(node.test) &&
+        startingLine !== sourceCode.getLine(node.body)
+      ) {
+        return context.report({
+          node: node.body,
+          message:
+            "Opening brace must be on the same line as the while statement."
+        });
+      }
+
+      if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(node.body, 2))) {
+        context.report({
+          node: node.body,
+          message:
+            "Only use single space between while declaration & opening brace."
+        });
+      }
+    }
+
+    function inspectDoWhileStatement(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      /**
+       * If no BlockStatement found, report. Otherwise:
+       * If 'while' and node.test exist on same line and '{' is on diff line, report
+       */
+      if (node.body.type !== "BlockStatement") {
+        return context.report({
+          node: node,
+          message: "Expected '{' after do token."
+        });
+      }
+
+      if (!/^[^\s\/] $/.test(sourceCode.getPrevChars(node.body, 2))) {
+        context.report({
+          node: node.body,
+          message: "Only use single space between 'do' & opening brace."
+        });
+      }
+    }
+
+    function inspectStructDeclaration(emitted) {
+      let node = emitted.node,
+        code = sourceCode.getText(node).replace("struct " + node.name, "");
+
+      if (emitted.exit) {
+        return;
+      }
+
+      code.slice(0, 2) !== " {" &&
+        context.report({
+          node: node,
+          message: `'${
+            node.name
+          }': Declaration & opening brace must be separated by single space only.`
+        });
+    }
+
+    function inspectContractStatement(emitted) {
+      let node = emitted.node,
+        code = sourceCode.getTextOnLine(sourceCode.getLine(node));
+
+      if (emitted.exit) {
+        return;
+      }
+
+      !/[^\s\/] {/.test(code) &&
+        context.report({
+          node: node,
+          message: `'${
+            node.name
+          }': Declaration & opening brace must be separated by single space only.`
+        });
+    }
+
+    function inspectLibraryStatement(emitted) {
+      let node = emitted.node,
+        code = sourceCode.getTextOnLine(sourceCode.getLine(node));
+
+      if (emitted.exit) {
+        return;
+      }
+
+      !/[^\s\/] {/.test(code) &&
+        context.report({
+          node: node,
+          message: `'${
+            node.name
+          }': Declaration & opening brace must be separated by single space only.`
+        });
+    }
+
+    function inspectFunctionDeclaration(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit || node.is_abstract) {
+        return;
+      }
+
+      /**
+       * If entire (non-abstract) function's signature is on single line, then the opening brace of its body must be on the same line too.
+       * If signature is on multiple lines:
+       *     If sign contains only params (each on its own line), then brace must be on the same line as last param's ending line
+       *     If sign contains modifiers (each on its own line), then brace must be on the line immediately after ending line of last modifier
+       */
+      let declarationEndingLine,
+        declarationStartingLine = sourceCode.getLine(node),
+        bodyStartingLine = sourceCode.getLine(node.body);
+
+      //If the node just before function's body is on the start line itself, then the opening brace must too be on the start line
+      if (node.returnParams !== null) {
+        declarationEndingLine = sourceCode.getEndingLine(node.returnParams);
+      } else if (node.modifiers !== null) {
+        //if modifiers is non-null (,i.e., array), compare bodyStartingLine with ending line of the last modifier declaration (last array element)
+        declarationEndingLine = sourceCode.getEndingLine(
+          node.modifiers.slice(-1)[0]
+        );
+      } else if (node.params !== null) {
+        //if params is non-null (,i.e., array), compare bodyStartingLine with ending line of the last param declaration (last array element)
+        declarationEndingLine = sourceCode.getEndingLine(
+          node.params.slice(-1)[0]
+        );
+      } else {
+        //if none of the above is present, then opening brace must surely begin on the same line
+        declarationEndingLine = sourceCode.getLine(node);
+      }
+
+      let charsBeforeLBrace = sourceCode.getPrevChars(node.body, 2);
+
+      if (declarationEndingLine === declarationStartingLine) {
+        if (bodyStartingLine !== declarationEndingLine) {
+          context.report({
+            node: node.body,
+            message:
+              "Opening brace must be on the same line as function's declaration."
+          });
+        } else {
+          !/[^\s\/] /.test(charsBeforeLBrace) &&
+            context.report({
+              node: node.body,
+              message: "Opening brace must be preceded by single space only."
+            });
+        }
+
+        return;
+      }
+
+      if (node.returnParams) {
+        if (
+          sourceCode.getLine(node.body) !==
+          sourceCode.getEndingLine(node.returnParams) + 1
+        ) {
+          context.report({
+            node: node.body,
+            message:
+              "Opening brace must be on the line after returns declaration."
+          });
+        }
+
+        return;
+      }
+
+      if (node.modifiers) {
+        const lbraceLine = sourceCode.getLine(node.body),
+          lastModifEndLine = sourceCode.getEndingLine(
+            node.modifiers.slice(-1)[0]
+          );
+
+        if (lbraceLine !== lastModifEndLine + 1) {
+          context.report({
+            node: node.body,
+            message: "Opening brace must be on the line after last modifier."
+          });
+        }
+
+        return;
+      }
+
+      !/[^\s\/] /.test(charsBeforeLBrace) &&
+        context.report({
+          node: node.body,
+          message: "Opening brace must be preceded by only a single space."
+        });
+    }
+
+    return {
+      FunctionDeclaration: inspectFunctionDeclaration,
+      LibraryStatement: inspectLibraryStatement,
+      ContractStatement: inspectContractStatement,
+      StructDeclaration: inspectStructDeclaration,
+      DoWhileStatement: inspectDoWhileStatement,
+      WhileStatement: inspectWhileStatement,
+      ForStatement: inspectForStatement,
+      IfStatement: inspectIfStatement
+    };
+  }
 };

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -6,60 +6,64 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that a line of code doesn't exceed the specified number of characters"
-        },
-
-        schema: [{
-            type: "integer", minimum: 1
-        }]
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that a line of code doesn't exceed the specified number of characters"
     },
 
-    create(context) {
-        const maxLineLength = context.options ? context.options [0] : 145;
-        const sourceCode = context.getSourceCode();
+    schema: [
+      {
+        type: "integer",
+        minimum: 1
+      }
+    ]
+  },
 
-        function inspectProgram(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+  create(context) {
+    const maxLineLength = context.options ? context.options[0] : 145;
+    const sourceCode = context.getSourceCode();
 
-            let lines = sourceCode.text.split(/\r?\n/),
-                lastLine = -1;
+    function inspectProgram(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-            // Recursive function.
-            // --elopio - 20180421
-            function checkNodes(nodes) {
-                if (!Array.isArray(nodes)) {
-                    nodes = [nodes];
-                }
-                nodes.forEach(node => {
-                    let lineNumber = sourceCode.getLine(node) - 1;
+      let lines = sourceCode.text.split(/\r?\n/),
+        lastLine = -1;
 
-                    if (lineNumber > lastLine && lines[lineNumber].length > maxLineLength) {
-                        context.report({
-                            node,
-                            message: `Line exceeds the limit of ${maxLineLength} characters`
-                        });
-
-                        lastLine = lineNumber;
-                    }
-
-                    checkNodes(node.body || []);
-                });
-            }
-
-            checkNodes(emitted.node.body);
+      // Recursive function.
+      // --elopio - 20180421
+      function checkNodes(nodes) {
+        if (!Array.isArray(nodes)) {
+          nodes = [nodes];
         }
+        nodes.forEach(node => {
+          let lineNumber = sourceCode.getLine(node) - 1;
 
-        return {
-            Program: inspectProgram
-        };
+          if (
+            lineNumber > lastLine &&
+            lines[lineNumber].length > maxLineLength
+          ) {
+            context.report({
+              node,
+              message: `Line exceeds the limit of ${maxLineLength} characters`
+            });
 
+            lastLine = lineNumber;
+          }
+
+          checkNodes(node.body || []);
+        });
+      }
+
+      checkNodes(emitted.node.body);
     }
+
+    return {
+      Program: inspectProgram
+    };
+  }
 };

--- a/lib/rules/mixedcase.js
+++ b/lib/rules/mixedcase.js
@@ -6,111 +6,108 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that all variable, function and parameter names follow the mixedCase naming convention"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that all variable, function and parameter names follow the mixedCase naming convention"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let mixedCaseRegEx = /^_?[a-z][a-zA-Z0-9]*_?$/;
-        let similarNodes = [
-            "FunctionDeclaration",
-            "ModifierDeclaration"
-        ];
+  create: function(context) {
+    let mixedCaseRegEx = /^_?[a-z][a-zA-Z0-9]*_?$/;
+    let similarNodes = ["FunctionDeclaration", "ModifierDeclaration"];
 
-        function report(node, name) {
-            context.report({
-                node: node,
-                message: "'" + name + "' doesn't follow the mixedCase notation"
-            });
-        }
-
-        function inspectFuncOrModif(emitted) {
-            let node = emitted.node;
-
-            /**
-             * If node's parent is contract / library and node is either a modifier (which means Inheritance),
-             * do not apply mixedcase
-             */
-            if (emitted.exit ||
-                ((node.parent.type === "ContractStatement" || node.parent.type === "LibraryStatement") &&
-                (node.type === "FunctionDeclaration" && node.parent.name === node.name))
-            ) {
-                return;
-            }
-
-            if (!mixedCaseRegEx.test(node.name)) {
-                report(node, node.name);
-            }
-        }
-
-        function inspectVariableDeclarator(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            if (!mixedCaseRegEx.test(node.id.name)) {
-                context.report({
-                    node: node,
-                    message: "Identifier name '" + node.id.name + "' doesn't follow the mixedCase notation"
-                });
-            }
-        }
-
-        function inspectDeclaration(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            if (!node.is_constant && !mixedCaseRegEx.test(node.name)) {
-                report(node, node.name);
-            }
-        }
-
-        function inspectInformalParameter(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            /**
-			 * node.is could either be an object containing "name" or null.
-			 * It is null when there is no name (eg- `function foo() returns(bool) {}`)
-			 * Here, bool's node will have "literal" object but "id" as null.
-			 */
-            if (node.id && !mixedCaseRegEx.test(node.id)) {
-                report(node, node.id);
-            }
-        }
-
-
-        let response = {
-            InformalParameter: inspectInformalParameter,
-            StateVariableDeclaration: inspectDeclaration,
-            DeclarativeExpression: inspectDeclaration,
-            VariableDeclarator: inspectVariableDeclarator
-        };
-
-        similarNodes.forEach(function(nodeName) {
-            response [nodeName] = inspectFuncOrModif;
-        });
-
-        return response;
-
+    function report(node, name) {
+      context.report({
+        node: node,
+        message: "'" + name + "' doesn't follow the mixedCase notation"
+      });
     }
 
+    function inspectFuncOrModif(emitted) {
+      let node = emitted.node;
+
+      /**
+       * If node's parent is contract / library and node is either a modifier (which means Inheritance),
+       * do not apply mixedcase
+       */
+      if (
+        emitted.exit ||
+        ((node.parent.type === "ContractStatement" ||
+          node.parent.type === "LibraryStatement") &&
+          (node.type === "FunctionDeclaration" &&
+            node.parent.name === node.name))
+      ) {
+        return;
+      }
+
+      if (!mixedCaseRegEx.test(node.name)) {
+        report(node, node.name);
+      }
+    }
+
+    function inspectVariableDeclarator(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      if (!mixedCaseRegEx.test(node.id.name)) {
+        context.report({
+          node: node,
+          message:
+            "Identifier name '" +
+            node.id.name +
+            "' doesn't follow the mixedCase notation"
+        });
+      }
+    }
+
+    function inspectDeclaration(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      if (!node.is_constant && !mixedCaseRegEx.test(node.name)) {
+        report(node, node.name);
+      }
+    }
+
+    function inspectInformalParameter(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      /**
+       * node.is could either be an object containing "name" or null.
+       * It is null when there is no name (eg- `function foo() returns(bool) {}`)
+       * Here, bool's node will have "literal" object but "id" as null.
+       */
+      if (node.id && !mixedCaseRegEx.test(node.id)) {
+        report(node, node.id);
+      }
+    }
+
+    let response = {
+      InformalParameter: inspectInformalParameter,
+      StateVariableDeclaration: inspectDeclaration,
+      DeclarativeExpression: inspectDeclaration,
+      VariableDeclarator: inspectVariableDeclarator
+    };
+
+    similarNodes.forEach(function(nodeName) {
+      response[nodeName] = inspectFuncOrModif;
+    });
+
+    return response;
+  }
 };

--- a/lib/rules/no-constant.js
+++ b/lib/rules/no-constant.js
@@ -5,43 +5,44 @@
 
 "use strict";
 
-
 function create(context) {
-    function reportIfConstant(emitted) {
-        const { node } = emitted, enclosingFunction = context.getSourceCode().getParent(node);
- 
-        if (emitted.exit || node.name !== "constant" || enclosingFunction.type !== "FunctionDeclaration") {
-            return;
-        }
+  function reportIfConstant(emitted) {
+    const { node } = emitted,
+      enclosingFunction = context.getSourceCode().getParent(node);
 
-        // Only report this modifier if it is 'constant' and is being used in a function declaration.
-        context.report({
-            node,
-            fix(fixer) {
-                return fixer.replaceText(node, "view");
-            },
-            message: "Use 'view' instead of deprecated 'constant'."
-        });
+    if (
+      emitted.exit ||
+      node.name !== "constant" ||
+      enclosingFunction.type !== "FunctionDeclaration"
+    ) {
+      return;
     }
 
-    return {
-        ModifierArgument: reportIfConstant
-    };
+    // Only report this modifier if it is 'constant' and is being used in a function declaration.
+    context.report({
+      node,
+      fix(fixer) {
+        return fixer.replaceText(node, "view");
+      },
+      message: "Use 'view' instead of deprecated 'constant'."
+    });
+  }
+
+  return {
+    ModifierArgument: reportIfConstant
+  };
 }
 
-
 module.exports = {
-
-    meta: {
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Use view over deprecated constant in function declarations"
-        },
-        schema: [],
-        fixable: "code"
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description: "Use view over deprecated constant in function declarations"
     },
+    schema: [],
+    fixable: "code"
+  },
 
-    create
-
+  create
 };

--- a/lib/rules/no-empty-blocks.js
+++ b/lib/rules/no-empty-blocks.js
@@ -6,68 +6,72 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that no empty blocks exist"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description: "Ensure that no empty blocks exist"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        function report(node, loc) {
-            context.report({
-                node, message: "Code contains empty block", location: loc });
-        }
-
-        let similarNodeTypes = ["ContractStatement", "LibraryStatement", "InterfaceStatement"];
-
-        function inspectCLI(emitted) {
-            let node = emitted.node,
-                sourceCode = context.getSourceCode(), text = sourceCode.getText(node);
-
-            if (emitted.exit) {
-                return;
-            }
-
-            if (!node.body.length) {
-                report(node, { column: text.indexOf("{") });
-            }
-        }
-
-        function inspectBlockStatement(emitted) {
-            const { node } = emitted, { body } = node;
-
-            // Allow Function & Constructor declarations to have empty bodies.
-            if (
-                emitted.exit ||
-                ["FunctionDeclaration", "ConstructorDeclaration"].includes(context.getSourceCode().getParent(node).type)
-            ) {
-                return;
-            }
-
-            if (body && body.constructor.name === "Array" && !body.length) {
-                report(node);
-            }
-        }
-
-
-        let response = {
-            BlockStatement: inspectBlockStatement
-        };
-
-        similarNodeTypes.forEach(function(nodeName) {
-            response [nodeName] = inspectCLI;
-        });
-
-        return response;
-
+  create: function(context) {
+    function report(node, loc) {
+      context.report({
+        node,
+        message: "Code contains empty block",
+        location: loc
+      });
     }
 
+    let similarNodeTypes = [
+      "ContractStatement",
+      "LibraryStatement",
+      "InterfaceStatement"
+    ];
+
+    function inspectCLI(emitted) {
+      let node = emitted.node,
+        sourceCode = context.getSourceCode(),
+        text = sourceCode.getText(node);
+
+      if (emitted.exit) {
+        return;
+      }
+
+      if (!node.body.length) {
+        report(node, { column: text.indexOf("{") });
+      }
+    }
+
+    function inspectBlockStatement(emitted) {
+      const { node } = emitted,
+        { body } = node;
+
+      // Allow Function & Constructor declarations to have empty bodies.
+      if (
+        emitted.exit ||
+        ["FunctionDeclaration", "ConstructorDeclaration"].includes(
+          context.getSourceCode().getParent(node).type
+        )
+      ) {
+        return;
+      }
+
+      if (body && body.constructor.name === "Array" && !body.length) {
+        report(node);
+      }
+    }
+
+    let response = {
+      BlockStatement: inspectBlockStatement
+    };
+
+    similarNodeTypes.forEach(function(nodeName) {
+      response[nodeName] = inspectCLI;
+    });
+
+    return response;
+  }
 };

--- a/lib/rules/no-experimental.js
+++ b/lib/rules/no-experimental.js
@@ -6,33 +6,31 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that experimental features are not used in production"
-        },
-
-        schema: []
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that experimental features are not used in production"
     },
 
-    create(context) {
+    schema: []
+  },
 
-        function reportNode(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+  create(context) {
+    function reportNode(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-            return context.report({
-                node: emitted.node,
-                message: "Avoid using experimental features in production code"
-            });
-        }
-
-        return {
-            ExperimentalPragmaStatement: reportNode
-        };
+      return context.report({
+        node: emitted.node,
+        message: "Avoid using experimental features in production code"
+      });
     }
+
+    return {
+      ExperimentalPragmaStatement: reportNode
+    };
+  }
 };

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -6,78 +6,69 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Flag all the variables that were declared but never used"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description: "Flag all the variables that were declared but never used"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let allVariableDeclarations = {};
+  create: function(context) {
+    let allVariableDeclarations = {};
 
-        //collect all variable declarations from VariableDeclarators and DeclarativeExpressions
-        function inspectVariableDeclarator(emitted) {
-            let node = emitted.node;
+    //collect all variable declarations from VariableDeclarators and DeclarativeExpressions
+    function inspectVariableDeclarator(emitted) {
+      let node = emitted.node;
 
-            if (!emitted.exit) {
-                allVariableDeclarations [node.id.name] = node;
-            }
-        }
-
-        function inspectDeclarativeExpression(emitted) {
-            let node = emitted.node;
-
-            //do not examine if the declaration is part of a Struct definition
-            if (!emitted.exit && node.parent.type !== "StructDeclaration") {
-                allVariableDeclarations [node.name] = node;
-            }
-        }
-
-        //While exiting Progam Node, all the vars that haven't been used still exist inside VariableDeclarations. Report them
-        function inspectProgram(emitted) {
-
-            if (emitted.exit) {
-                Object.keys(allVariableDeclarations).forEach(function(name) {
-                    context.report({
-                        node: allVariableDeclarations [name],
-                        message: "Variable '" + name + "' is declared but never used."
-                    });
-                });
-            }
-
-        }
-
-        //As soon as the first use of a variable is encountered, delete that variable's node from allVariableDeclarations
-        function inspectIdentifier(emitted) {
-            if (!emitted.exit) {
-                let node = emitted.node,
-                    sourceCode = context.getSourceCode();
-
-                if (
-                    allVariableDeclarations [node.name] &&
-					sourceCode.getParent(node).type !== "VariableDeclarator"
-                ) {
-                    delete allVariableDeclarations [node.name];
-                }
-            }
-        }
-
-
-        return {
-            Identifier: inspectIdentifier,
-            Program: inspectProgram,
-            DeclarativeExpression: inspectDeclarativeExpression,
-            VariableDeclarator: inspectVariableDeclarator
-        };
-
+      if (!emitted.exit) {
+        allVariableDeclarations[node.id.name] = node;
+      }
     }
 
+    function inspectDeclarativeExpression(emitted) {
+      let node = emitted.node;
+
+      //do not examine if the declaration is part of a Struct definition
+      if (!emitted.exit && node.parent.type !== "StructDeclaration") {
+        allVariableDeclarations[node.name] = node;
+      }
+    }
+
+    //While exiting Progam Node, all the vars that haven't been used still exist inside VariableDeclarations. Report them
+    function inspectProgram(emitted) {
+      if (emitted.exit) {
+        Object.keys(allVariableDeclarations).forEach(function(name) {
+          context.report({
+            node: allVariableDeclarations[name],
+            message: "Variable '" + name + "' is declared but never used."
+          });
+        });
+      }
+    }
+
+    //As soon as the first use of a variable is encountered, delete that variable's node from allVariableDeclarations
+    function inspectIdentifier(emitted) {
+      if (!emitted.exit) {
+        let node = emitted.node,
+          sourceCode = context.getSourceCode();
+
+        if (
+          allVariableDeclarations[node.name] &&
+          sourceCode.getParent(node).type !== "VariableDeclarator"
+        ) {
+          delete allVariableDeclarations[node.name];
+        }
+      }
+    }
+
+    return {
+      Identifier: inspectIdentifier,
+      Program: inspectProgram,
+      DeclarativeExpression: inspectDeclarativeExpression,
+      VariableDeclarator: inspectVariableDeclarator
+    };
+  }
 };

--- a/lib/rules/no-with.js
+++ b/lib/rules/no-with.js
@@ -6,37 +6,31 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure no use of with statements in the code"
-        },
-
-        deprecated: true,
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description: "Ensure no use of with statements in the code"
     },
 
-    create: function(context) {
+    deprecated: true,
+    schema: []
+  },
 
-        function inspectWithStatement(emitted) {
-            if (emitted.exit) {
-                return;
-            }
-			
-            context.report({
-                node: emitted.node,
-                message: "Use of 'with' statement"
-            });
-        }
+  create: function(context) {
+    function inspectWithStatement(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-        return {
-            WithStatement: inspectWithStatement
-        };
-
+      context.report({
+        node: emitted.node,
+        message: "Use of 'with' statement"
+      });
     }
 
+    return {
+      WithStatement: inspectWithStatement
+    };
+  }
 };

--- a/lib/rules/operator-whitespace.js
+++ b/lib/rules/operator-whitespace.js
@@ -6,188 +6,238 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that operators are surrounded by a single space on either side"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure that operators are surrounded by a single space on either side"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let sourceCode = context.getSourceCode();
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
-        function inspectAssignmentExpression(emitted) {
-            /**
-			 * node.operator is refined here by adding backslash before all the 'special' characters.
-			 * 'special' chars are thos chars that are part of solidity assignment operators and, if used without backslash in JS RegExp,
-			 * behave as wildcard characters. So to make sure they're treated as simple strings, we add '\' before them.
-			 * As of today, these chars include: * / + | ^
-			 */
-            let node = emitted.node,
-                op = node.operator.replace(/([\+\*\/\|\^])/g, "\\$1"), opLength = node.operator.length;
+    function inspectAssignmentExpression(emitted) {
+      /**
+       * node.operator is refined here by adding backslash before all the 'special' characters.
+       * 'special' chars are thos chars that are part of solidity assignment operators and, if used without backslash in JS RegExp,
+       * behave as wildcard characters. So to make sure they're treated as simple strings, we add '\' before them.
+       * As of today, these chars include: * / + | ^
+       */
+      let node = emitted.node,
+        op = node.operator.replace(/([\+\*\/\|\^])/g, "\\$1"),
+        opLength = node.operator.length;
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            // If expression is 'abc *= def;', then charsAfterLeftNode will contain ' *= d'.
-            let charsAfterLeftNode = sourceCode.getNextChars(node.left, 3 + opLength),
-                validationRegexp = new RegExp("^ " + op + " [^\\s]$");
+      // If expression is 'abc *= def;', then charsAfterLeftNode will contain ' *= d'.
+      let charsAfterLeftNode = sourceCode.getNextChars(node.left, 3 + opLength),
+        validationRegexp = new RegExp("^ " + op + " [^\\s]$");
 
-            (!validationRegexp.test(charsAfterLeftNode)) && context.report({
-                node: node.left,
-                message: "Assignment operator must have exactly single space on both sides of it."
-            });
-        }
-
-        //statement like `var x = 10` doesn't come under AssignmentExpression, so needs to be checked separately
-        function inspectVariableDeclaration(emitted) {
-            let node = emitted.node, code = sourceCode.getText(node);
-
-            if (emitted.exit) {
-                return;
-            }
-
-            //if a particular character is '=', check its left and right for single space
-            for (let i = 2; i < code.length; i++) {
-                if (code [i] === "=") {
-                    (!/^[^\/\s] $/.test(code.slice(i-2, i))) && context.report({
-                        node: node,
-                        message: "There should be only a single space between assignment operator '=' and its left side." 
-                    });
-
-                    (!/^ [^\/\s]$/.test(code.slice(i+1, i+3))) && context.report({
-                        node: node,
-                        message: "There should be only a single space between assignment operator '=' and its right side." 
-                    });
-                }
-            }
-        }
-
-        function inspectBinaryExpression(emitted) {
-            let leftNode,
-                node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            /**
-			 * If the left & right side of expression span over multiple lines,
-			 * make sure that the operator resides on the same line as the left expression (ie, first line)
-			 */
-            // 1. take line no. of both left & right expr. Line no (right) = line (left) + 1
-            // Take string btw them, should be NO \n before operator. that's it
-
-            let rightNodeStartingLine = sourceCode.getLine(node.right),
-                leftNodeEndingLine = sourceCode.getEndingLine(node.left),
-                opRegExp = node.operator.replace(/([\+\*\/\|\^])/g, "\\$1");
-
-            if (rightNodeStartingLine > leftNodeEndingLine) {
-                let validationRegexOpOnSameLineAsLeftNodeEnd = new RegExp("^[^\\n]*" + opRegExp),
-                    strBetweenLeftAndRightNode = sourceCode.getStringBetweenNodes(node.left, node.right);
-
-                if (rightNodeStartingLine !== leftNodeEndingLine + 1) {
-                    context.report({
-                        node: node,
-                        location: {
-                            column: sourceCode.getColumn(node.right),
-                            line: sourceCode.getLine(node.right)
-                        },
-                        message: "In Binary Expressions that span over multiple lines, expression on the right side of the operator (" + node.operator + ") must be exactly 1 line below the line on which the left expression ends."
-                    });
-                }
-
-                if (!validationRegexOpOnSameLineAsLeftNodeEnd.test(strBetweenLeftAndRightNode)) {
-                    context.report({
-                        node: node,
-                        location: {
-                            column: sourceCode.getEndingColumn(node.left)
-                        },
-                        message: "Operator \"" + node.operator + "\" should be on the line where left side of the Binary expression ends." 
-                    });
-                }
-
-                return;
-            }
-
-            // Handle case where left node is a binary expression and right node may be a literal
-            if (sourceCode.isASTNode(node.left) && node.left.type === "BinaryExpression"){
-                leftNode = node.left.right;
-            } else {
-                leftNode = node.left;
-            }
-
-            let strBetweenLeftAndRight = sourceCode.getStringBetweenNodes(leftNode, node.right).split(node.operator),
-                onlyCharsRegExp = /^[^\s\/]$/;
-
-            if (strBetweenLeftAndRight [0].slice(-1) === " " || strBetweenLeftAndRight [1] [0] === " ") {
-                if (strBetweenLeftAndRight [0].slice(-1) !== strBetweenLeftAndRight [1] [0]) {
-                    context.report({
-                        node: node,
-                        location: {
-                            column: sourceCode.getEndingColumn(node.left) + 1
-                        },
-                        message: "Single space should be either on both sides of '" + node.operator + "' or not at all."
-                    });
-                } else {
-                    let secondLastCharOnLeft = strBetweenLeftAndRight [0].slice(-2, -1),
-                        secondCharOnRight = strBetweenLeftAndRight [1] [1];
-
-                    secondLastCharOnLeft && (!onlyCharsRegExp.test(secondLastCharOnLeft)) && context.report({
-                        node: node,
-                        location: {
-                            column: sourceCode.getEndingColumn(node.left)
-                        },
-                        message: "There should be a maximum of single space and no comments between left side and '" + node.operator + "'."
-                    });
-
-                    secondCharOnRight && (!onlyCharsRegExp.test(secondCharOnRight)) && context.report({
-                        node: node,
-                        location: {
-                            column: sourceCode.getColumn(node.right)
-                        },
-                        message: "There should be a maximum of single space and no comments between right side and '" + node.operator + "'."
-                    });
-                }
-
-                return;
-            }
-
-            let firstCharOnLeft = strBetweenLeftAndRight [0].slice(-1),
-                firstCharOnRight = strBetweenLeftAndRight [1] [0];
-
-            firstCharOnLeft && (!onlyCharsRegExp.test(firstCharOnLeft)) && context.report({
-                node: node,
-                location: {
-                    column: sourceCode.getEndingColumn(node.left)
-                },
-                message: "There should be no comments between left side and '" + node.operator + "'."
-            });
-
-            firstCharOnRight && (!onlyCharsRegExp.test(firstCharOnRight)) && context.report({
-                node: node,
-                location: {
-                    column: sourceCode.getColumn(node.right)
-                },
-                message: "There should be no comments between right side and '" + node.operator + "'."
-            });
-
-        }
-
-        return {
-            BinaryExpression: inspectBinaryExpression,
-            VariableDeclaration: inspectVariableDeclaration,
-            AssignmentExpression: inspectAssignmentExpression
-        };
-	
+      !validationRegexp.test(charsAfterLeftNode) &&
+        context.report({
+          node: node.left,
+          message:
+            "Assignment operator must have exactly single space on both sides of it."
+        });
     }
 
+    //statement like `var x = 10` doesn't come under AssignmentExpression, so needs to be checked separately
+    function inspectVariableDeclaration(emitted) {
+      let node = emitted.node,
+        code = sourceCode.getText(node);
+
+      if (emitted.exit) {
+        return;
+      }
+
+      //if a particular character is '=', check its left and right for single space
+      for (let i = 2; i < code.length; i++) {
+        if (code[i] === "=") {
+          !/^[^\/\s] $/.test(code.slice(i - 2, i)) &&
+            context.report({
+              node: node,
+              message:
+                "There should be only a single space between assignment operator '=' and its left side."
+            });
+
+          !/^ [^\/\s]$/.test(code.slice(i + 1, i + 3)) &&
+            context.report({
+              node: node,
+              message:
+                "There should be only a single space between assignment operator '=' and its right side."
+            });
+        }
+      }
+    }
+
+    function inspectBinaryExpression(emitted) {
+      let leftNode,
+        node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      /**
+       * If the left & right side of expression span over multiple lines,
+       * make sure that the operator resides on the same line as the left expression (ie, first line)
+       */
+      // 1. take line no. of both left & right expr. Line no (right) = line (left) + 1
+      // Take string btw them, should be NO \n before operator. that's it
+
+      let rightNodeStartingLine = sourceCode.getLine(node.right),
+        leftNodeEndingLine = sourceCode.getEndingLine(node.left),
+        opRegExp = node.operator.replace(/([\+\*\/\|\^])/g, "\\$1");
+
+      if (rightNodeStartingLine > leftNodeEndingLine) {
+        let validationRegexOpOnSameLineAsLeftNodeEnd = new RegExp(
+            "^[^\\n]*" + opRegExp
+          ),
+          strBetweenLeftAndRightNode = sourceCode.getStringBetweenNodes(
+            node.left,
+            node.right
+          );
+
+        if (rightNodeStartingLine !== leftNodeEndingLine + 1) {
+          context.report({
+            node: node,
+            location: {
+              column: sourceCode.getColumn(node.right),
+              line: sourceCode.getLine(node.right)
+            },
+            message:
+              "In Binary Expressions that span over multiple lines, expression on the right side of the operator (" +
+              node.operator +
+              ") must be exactly 1 line below the line on which the left expression ends."
+          });
+        }
+
+        if (
+          !validationRegexOpOnSameLineAsLeftNodeEnd.test(
+            strBetweenLeftAndRightNode
+          )
+        ) {
+          context.report({
+            node: node,
+            location: {
+              column: sourceCode.getEndingColumn(node.left)
+            },
+            message:
+              'Operator "' +
+              node.operator +
+              '" should be on the line where left side of the Binary expression ends.'
+          });
+        }
+
+        return;
+      }
+
+      // Handle case where left node is a binary expression and right node may be a literal
+      if (
+        sourceCode.isASTNode(node.left) &&
+        node.left.type === "BinaryExpression"
+      ) {
+        leftNode = node.left.right;
+      } else {
+        leftNode = node.left;
+      }
+
+      let strBetweenLeftAndRight = sourceCode
+          .getStringBetweenNodes(leftNode, node.right)
+          .split(node.operator),
+        onlyCharsRegExp = /^[^\s\/]$/;
+
+      if (
+        strBetweenLeftAndRight[0].slice(-1) === " " ||
+        strBetweenLeftAndRight[1][0] === " "
+      ) {
+        if (
+          strBetweenLeftAndRight[0].slice(-1) !== strBetweenLeftAndRight[1][0]
+        ) {
+          context.report({
+            node: node,
+            location: {
+              column: sourceCode.getEndingColumn(node.left) + 1
+            },
+            message:
+              "Single space should be either on both sides of '" +
+              node.operator +
+              "' or not at all."
+          });
+        } else {
+          let secondLastCharOnLeft = strBetweenLeftAndRight[0].slice(-2, -1),
+            secondCharOnRight = strBetweenLeftAndRight[1][1];
+
+          secondLastCharOnLeft &&
+            !onlyCharsRegExp.test(secondLastCharOnLeft) &&
+            context.report({
+              node: node,
+              location: {
+                column: sourceCode.getEndingColumn(node.left)
+              },
+              message:
+                "There should be a maximum of single space and no comments between left side and '" +
+                node.operator +
+                "'."
+            });
+
+          secondCharOnRight &&
+            !onlyCharsRegExp.test(secondCharOnRight) &&
+            context.report({
+              node: node,
+              location: {
+                column: sourceCode.getColumn(node.right)
+              },
+              message:
+                "There should be a maximum of single space and no comments between right side and '" +
+                node.operator +
+                "'."
+            });
+        }
+
+        return;
+      }
+
+      let firstCharOnLeft = strBetweenLeftAndRight[0].slice(-1),
+        firstCharOnRight = strBetweenLeftAndRight[1][0];
+
+      firstCharOnLeft &&
+        !onlyCharsRegExp.test(firstCharOnLeft) &&
+        context.report({
+          node: node,
+          location: {
+            column: sourceCode.getEndingColumn(node.left)
+          },
+          message:
+            "There should be no comments between left side and '" +
+            node.operator +
+            "'."
+        });
+
+      firstCharOnRight &&
+        !onlyCharsRegExp.test(firstCharOnRight) &&
+        context.report({
+          node: node,
+          location: {
+            column: sourceCode.getColumn(node.right)
+          },
+          message:
+            "There should be no comments between right side and '" +
+            node.operator +
+            "'."
+        });
+    }
+
+    return {
+      BinaryExpression: inspectBinaryExpression,
+      VariableDeclaration: inspectVariableDeclaration,
+      AssignmentExpression: inspectAssignmentExpression
+    };
+  }
 };

--- a/lib/rules/pragma-on-top.js
+++ b/lib/rules/pragma-on-top.js
@@ -8,110 +8,112 @@
 const { EOL } = require("os");
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure a) A PRAGMA directive exists and b) its on top of the file"
-        },
-
-        schema: [],
-
-        fixable: "code"
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure a) A PRAGMA directive exists and b) its on top of the file"
     },
 
-    create: function(context) {
+    schema: [],
 
-        let missingNodeOnTopErrorReported = false;
+    fixable: "code"
+  },
 
-        /**
-		 * This executes only when we're leaving the Program node. At that time,
-		 * we check whether the "missing pragma on top" error has already been reported or not.
-		 * If not, we proceed to report it here. This happens when there are no pragma statements in
-		 * the entire file. If there is one (but not on top of file), it gets reported by inspectPragmaStatement().
-		 * NOTE: A Pragma dir must exist at absolute top, even before pragma experimental.
-		 */
-        function inspectProgram(emitted) {
-            let node = emitted.node, body = node.body;
+  create: function(context) {
+    let missingNodeOnTopErrorReported = false;
 
-            if (!emitted.exit || missingNodeOnTopErrorReported) {
-                return;
-            }
+    /**
+     * This executes only when we're leaving the Program node. At that time,
+     * we check whether the "missing pragma on top" error has already been reported or not.
+     * If not, we proceed to report it here. This happens when there are no pragma statements in
+     * the entire file. If there is one (but not on top of file), it gets reported by inspectPragmaStatement().
+     * NOTE: A Pragma dir must exist at absolute top, even before pragma experimental.
+     */
+    function inspectProgram(emitted) {
+      let node = emitted.node,
+        body = node.body;
 
-            (body.length > 0) && (body [0].type !== "PragmaStatement") && context.report({
-                node: node,
-                message: "No Pragma directive found at the top of file."
-            });
-        }
+      if (!emitted.exit || missingNodeOnTopErrorReported) {
+        return;
+      }
 
-
-        function inspectPragmaStatement(emitted) {
-            let node = emitted.node,
-                sourceCode = context.getSourceCode(), pragmaParent = sourceCode.getParent(node);
-
-            // If pragma statement is on top, exit now. No further checks required.
-            if (emitted.exit || node.start === pragmaParent.body [0].start) {
-                return;
-            }
-
-            const pragmaCode = sourceCode.getText(node);
-
-            context.report({
-                node: node,
-                message: `"${pragmaCode}" should be at the top of the file.`,
-                fix: function(fixer) {
-                    return [fixer.remove(node),
-                        fixer.insertTextBefore(pragmaParent.body [0], `${pragmaCode}${EOL}`)];
-                }
-            });
-
-            missingNodeOnTopErrorReported = true;
-        }
-
-
-        // Experimental pragmas, if they exist, must be above everything EXCEPT pragma solidity & other experimental pragmas.
-        function inspectExperimentalPragmaStatement(emitted) {
-            if (emitted.exit) {
-                return;
-            }
-
-            const {node} = emitted,
-                nodesAllowedAbove = ["ExperimentalPragmaStatement", "PragmaStatement"],
-                programNode = context.getSourceCode().getParent(node);
-
-            for (let childNode of programNode.body) {
-                // If we've reached this exp. pragma while traversing body, it means its position is fine.
-                if (node.start === childNode.start) {
-                    return;
-                }
-
-                // We found the first node not allowed above experimental pragma, report and exit.
-                const pragmaCode = context.getSourceCode().getText(node);
-
-                if (nodesAllowedAbove.indexOf(childNode.type) < 0) {
-                    const errObject = {
-                        node,
-                        fix(fixer) {
-                            return [fixer.remove(node),
-                                fixer.insertTextBefore(childNode, `${pragmaCode}${EOL}`)];
-                        },
-                        message: "Experimental Pragma must precede everything except Solidity Pragma."
-                    };
-
-                    return context.report(errObject);
-                }
-            }
-        }
-
-        return {
-            Program: inspectProgram,
-            PragmaStatement: inspectPragmaStatement,
-            ExperimentalPragmaStatement: inspectExperimentalPragmaStatement
-        };
-
+      body.length > 0 &&
+        body[0].type !== "PragmaStatement" &&
+        context.report({
+          node: node,
+          message: "No Pragma directive found at the top of file."
+        });
     }
 
+    function inspectPragmaStatement(emitted) {
+      let node = emitted.node,
+        sourceCode = context.getSourceCode(),
+        pragmaParent = sourceCode.getParent(node);
+
+      // If pragma statement is on top, exit now. No further checks required.
+      if (emitted.exit || node.start === pragmaParent.body[0].start) {
+        return;
+      }
+
+      const pragmaCode = sourceCode.getText(node);
+
+      context.report({
+        node: node,
+        message: `"${pragmaCode}" should be at the top of the file.`,
+        fix: function(fixer) {
+          return [
+            fixer.remove(node),
+            fixer.insertTextBefore(pragmaParent.body[0], `${pragmaCode}${EOL}`)
+          ];
+        }
+      });
+
+      missingNodeOnTopErrorReported = true;
+    }
+
+    // Experimental pragmas, if they exist, must be above everything EXCEPT pragma solidity & other experimental pragmas.
+    function inspectExperimentalPragmaStatement(emitted) {
+      if (emitted.exit) {
+        return;
+      }
+
+      const { node } = emitted,
+        nodesAllowedAbove = ["ExperimentalPragmaStatement", "PragmaStatement"],
+        programNode = context.getSourceCode().getParent(node);
+
+      for (let childNode of programNode.body) {
+        // If we've reached this exp. pragma while traversing body, it means its position is fine.
+        if (node.start === childNode.start) {
+          return;
+        }
+
+        // We found the first node not allowed above experimental pragma, report and exit.
+        const pragmaCode = context.getSourceCode().getText(node);
+
+        if (nodesAllowedAbove.indexOf(childNode.type) < 0) {
+          const errObject = {
+            node,
+            fix(fixer) {
+              return [
+                fixer.remove(node),
+                fixer.insertTextBefore(childNode, `${pragmaCode}${EOL}`)
+              ];
+            },
+            message:
+              "Experimental Pragma must precede everything except Solidity Pragma."
+          };
+
+          return context.report(errObject);
+        }
+      }
+    }
+
+    return {
+      Program: inspectProgram,
+      PragmaStatement: inspectPragmaStatement,
+      ExperimentalPragmaStatement: inspectExperimentalPragmaStatement
+    };
+  }
 };

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -13,103 +13,112 @@ let jsStringEscape = require("js-string-escape");
  * @returns {Boolean}
  */
 function isHex(literal) {
-    const reg = /^[0-9a-f]+$/i;
+  const reg = /^[0-9a-f]+$/i;
 
-    //test for '0x' separately because hex notation should not be a part of the standard RegExp
-    if (literal.slice(0, 2) !== "0x") {
-        return false;
-    }
+  //test for '0x' separately because hex notation should not be a part of the standard RegExp
+  if (literal.slice(0, 2) !== "0x") {
+    return false;
+  }
 
-    return reg.test(literal.slice(2));
+  return reg.test(literal.slice(2));
 }
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that all strings use only 1 style - either double quotes or single quotes."
-        },
-
-        fixable: "code",
-
-        schema: [{
-            type: "string",
-            enum: ["double", "single"]
-        }]
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure that all strings use only 1 style - either double quotes or single quotes."
     },
 
-    create(context) {
-        let quote = "\"",
-            quoteStyle = "double", sourceCode = context.getSourceCode();
+    fixable: "code",
 
-        if (context.options && context.options [0] === "single") {
-            quote = "'";
-            quoteStyle = "single";
-        }
+    schema: [
+      {
+        type: "string",
+        enum: ["double", "single"]
+      }
+    ]
+  },
 
-        const selectedQuoteStyleLiteralRegExp = new RegExp("^\\" + quote + ".*\\" + quote + "$");
+  create(context) {
+    let quote = '"',
+      quoteStyle = "double",
+      sourceCode = context.getSourceCode();
 
-
-        function inspectLiteral(emitted) {
-            const node = emitted.node, nodeText = sourceCode.getText(node);
-
-            if (emitted.exit || typeof node.value !== "string" ||
-                (nodeText [0] !== "'" && nodeText [0] !== "\"" && isHex(node.value))) {
-                return;
-            }
-
-            if (!selectedQuoteStyleLiteralRegExp.test(nodeText)) {
-                let fixedString = quote + jsStringEscape(node.value) + quote;
-                const errorObject = {
-                    node,
-                    fix(fixer) {
-                        return fixer.replaceText(node, fixedString);
-                    },
-                    message: `'${node.value}': String literal must be quoted with ${quoteStyle} quotes.`
-                };
-
-                context.report(errorObject);
-            }
-        }
-
-
-        function inspectImportStatement(emitted) {
-            const {node} = emitted,
-                nodeText = sourceCode.getText(node), expectedString = `${quote}${node.from}${quote}`;
-
-            // If using the expected quote style, exit now.
-            if (emitted.exit || nodeText.indexOf(expectedString) > -1) {
-                return;
-            }
-
-            context.report({
-                node,
-                fix(fixer) {
-                    // TODO: escape string having quotes inside them, ie, use jsStringEscape()
-
-                    const start = nodeText.indexOf(node.from) - 1, // index of opening quote
-                        end = start + 1 + node.from.length; // index of closing quote
-                    let f = `${nodeText.slice(0, start)}${quote}${node.from}${quote}${nodeText.slice(end+1)}`;
-
-                    return fixer.replaceText(node, f);
-                },
-                location: {
-                    column: sourceCode.getColumn(node) + nodeText.indexOf(node.from) - 1
-                },
-                message: `"${node.from}": Import statements must use ${quoteStyle} quotes only.`
-            });
-
-        }
-
-
-        return {
-            Literal: inspectLiteral,
-            ImportStatement: inspectImportStatement
-        };
+    if (context.options && context.options[0] === "single") {
+      quote = "'";
+      quoteStyle = "single";
     }
 
+    const selectedQuoteStyleLiteralRegExp = new RegExp(
+      "^\\" + quote + ".*\\" + quote + "$"
+    );
+
+    function inspectLiteral(emitted) {
+      const node = emitted.node,
+        nodeText = sourceCode.getText(node);
+
+      if (
+        emitted.exit ||
+        typeof node.value !== "string" ||
+        (nodeText[0] !== "'" && nodeText[0] !== '"' && isHex(node.value))
+      ) {
+        return;
+      }
+
+      if (!selectedQuoteStyleLiteralRegExp.test(nodeText)) {
+        let fixedString = quote + jsStringEscape(node.value) + quote;
+        const errorObject = {
+          node,
+          fix(fixer) {
+            return fixer.replaceText(node, fixedString);
+          },
+          message: `'${
+            node.value
+          }': String literal must be quoted with ${quoteStyle} quotes.`
+        };
+
+        context.report(errorObject);
+      }
+    }
+
+    function inspectImportStatement(emitted) {
+      const { node } = emitted,
+        nodeText = sourceCode.getText(node),
+        expectedString = `${quote}${node.from}${quote}`;
+
+      // If using the expected quote style, exit now.
+      if (emitted.exit || nodeText.indexOf(expectedString) > -1) {
+        return;
+      }
+
+      context.report({
+        node,
+        fix(fixer) {
+          // TODO: escape string having quotes inside them, ie, use jsStringEscape()
+
+          const start = nodeText.indexOf(node.from) - 1, // index of opening quote
+            end = start + 1 + node.from.length; // index of closing quote
+          let f = `${nodeText.slice(0, start)}${quote}${
+            node.from
+          }${quote}${nodeText.slice(end + 1)}`;
+
+          return fixer.replaceText(node, f);
+        },
+        location: {
+          column: sourceCode.getColumn(node) + nodeText.indexOf(node.from) - 1
+        },
+        message: `"${
+          node.from
+        }": Import statements must use ${quoteStyle} quotes only.`
+      });
+    }
+
+    return {
+      Literal: inspectLiteral,
+      ImportStatement: inspectImportStatement
+    };
+  }
 };

--- a/lib/rules/semicolon-whitespace.js
+++ b/lib/rules/semicolon-whitespace.js
@@ -6,126 +6,136 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that there is no whitespace or comments before semicolons"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that there is no whitespace or comments before semicolons"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let sourceCode = context.getSourceCode();
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
-        function inspectExpressionStatement(emitted) {
-            let node = emitted.node;
+    function inspectExpressionStatement(emitted) {
+      let node = emitted.node;
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            let code = sourceCode.getText(node);
+      let code = sourceCode.getText(node);
 
-            //ensure there's no whitespace or comments before semicolon
-            (code [code.length - 1] === ";" && /(\s|\/)/.test(code [code.length - 2])) && context.report({
-                node: node,
-                location: {
-                    column: code.length - 2
-                },
-                message: "There should be no whitespace or comments before the semicolon."
-            });
-        }
-
-
-        function inspectUsingStatement(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            let code = sourceCode.getText(node);
-
-            //ensure there's no whitespace or comments before semicolon
-            (code [code.length - 1] === ";" && /(\s|\/)/.test(code [code.length - 2])) && context.report({
-                node: node,
-                location: {
-                    column: code.length - 2
-                },
-                message: "There should be no whitespace or comments before the semicolon."
-            });
-        }
-
-        function inspectVariableDeclaration(emitted) {
-            let node = emitted.node, code = sourceCode.getText(node);
-
-            if (emitted.exit) {
-                return;
-            }
-
-            //ensure there's no whitespace or comments before semicolon
-            (code [code.length - 1] === ";" && /(\s|\/)/.test(code [code.length - 2])) && context.report({
-                node: node,
-                location: {
-                    column: code.length - 2
-                },
-                message: "There should be no whitespace or comments before the semicolon."
-            });
-        }
-
-        //If we're dealing with abstract function declaration, we need to ensure no whitespce or comments before semicolon
-        function inspectFunctionDeclaration(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            let code = sourceCode.getText(node);
-
-            (node.is_abstract && code [code.length - 1] === ";" && /(\s|\/)/.test(code [code.length - 2])) &&
-            context.report({
-                node: node,
-                location: {
-                    column: code.length - 2
-                },
-                message: "There should be no whitespace or comments before the semicolon."
-            });
-        }
-
-        function inspectImportStatement(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            let code = sourceCode.getText(node);
-
-            //ensure there's no whitespace or comments before semicolon
-            (code [code.length - 1] === ";" && /(\s|\/)/.test(code [code.length - 2])) && context.report({
-                node: node,
-                location: {
-                    column: code.length - 2
-                },
-                message: "There should be no whitespace or comments before the semicolon."
-            });
-        }
-
-        return {
-            ImportStatement: inspectImportStatement,
-            FunctionDeclaration: inspectFunctionDeclaration,
-            VariableDeclaration: inspectVariableDeclaration,
-            UsingStatement: inspectUsingStatement,
-            ExpressionStatement: inspectExpressionStatement
-        };
-
+      //ensure there's no whitespace or comments before semicolon
+      code[code.length - 1] === ";" &&
+        /(\s|\/)/.test(code[code.length - 2]) &&
+        context.report({
+          node: node,
+          location: {
+            column: code.length - 2
+          },
+          message:
+            "There should be no whitespace or comments before the semicolon."
+        });
     }
 
+    function inspectUsingStatement(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      let code = sourceCode.getText(node);
+
+      //ensure there's no whitespace or comments before semicolon
+      code[code.length - 1] === ";" &&
+        /(\s|\/)/.test(code[code.length - 2]) &&
+        context.report({
+          node: node,
+          location: {
+            column: code.length - 2
+          },
+          message:
+            "There should be no whitespace or comments before the semicolon."
+        });
+    }
+
+    function inspectVariableDeclaration(emitted) {
+      let node = emitted.node,
+        code = sourceCode.getText(node);
+
+      if (emitted.exit) {
+        return;
+      }
+
+      //ensure there's no whitespace or comments before semicolon
+      code[code.length - 1] === ";" &&
+        /(\s|\/)/.test(code[code.length - 2]) &&
+        context.report({
+          node: node,
+          location: {
+            column: code.length - 2
+          },
+          message:
+            "There should be no whitespace or comments before the semicolon."
+        });
+    }
+
+    //If we're dealing with abstract function declaration, we need to ensure no whitespce or comments before semicolon
+    function inspectFunctionDeclaration(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      let code = sourceCode.getText(node);
+
+      node.is_abstract &&
+        code[code.length - 1] === ";" &&
+        /(\s|\/)/.test(code[code.length - 2]) &&
+        context.report({
+          node: node,
+          location: {
+            column: code.length - 2
+          },
+          message:
+            "There should be no whitespace or comments before the semicolon."
+        });
+    }
+
+    function inspectImportStatement(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      let code = sourceCode.getText(node);
+
+      //ensure there's no whitespace or comments before semicolon
+      code[code.length - 1] === ";" &&
+        /(\s|\/)/.test(code[code.length - 2]) &&
+        context.report({
+          node: node,
+          location: {
+            column: code.length - 2
+          },
+          message:
+            "There should be no whitespace or comments before the semicolon."
+        });
+    }
+
+    return {
+      ImportStatement: inspectImportStatement,
+      FunctionDeclaration: inspectFunctionDeclaration,
+      VariableDeclaration: inspectVariableDeclaration,
+      UsingStatement: inspectUsingStatement,
+      ExpressionStatement: inspectExpressionStatement
+    };
+  }
 };

--- a/lib/rules/uppercase.js
+++ b/lib/rules/uppercase.js
@@ -6,46 +6,42 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that all constants (and only constants) contain only upper case letters and underscore"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that all constants (and only constants) contain only upper case letters and underscore"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let upperCaseRegEx = /^[A-Z][A-Z_0-9]*[A-Z0-9]$/;
+  create: function(context) {
+    let upperCaseRegEx = /^[A-Z][A-Z_0-9]*[A-Z0-9]$/;
 
-        function reportNode(node) {
-            context.report({
-                node: node,
-                message: "Constant name '" + node.name + "' doesn't follow the UPPER_CASE notation"
-            });
-        }
-
-        function inspectStateVariableDeclaration(emitted) {
-            let node = emitted.node;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            node.is_constant &&
-			!upperCaseRegEx.test(node.name) &&
-			reportNode(node);
-        }
-
-        return {
-            StateVariableDeclaration: inspectStateVariableDeclaration
-        };
-
+    function reportNode(node) {
+      context.report({
+        node: node,
+        message:
+          "Constant name '" +
+          node.name +
+          "' doesn't follow the UPPER_CASE notation"
+      });
     }
 
+    function inspectStateVariableDeclaration(emitted) {
+      let node = emitted.node;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      node.is_constant && !upperCaseRegEx.test(node.name) && reportNode(node);
+    }
+
+    return {
+      StateVariableDeclaration: inspectStateVariableDeclaration
+    };
+  }
 };

--- a/lib/rules/value-in-payable.js
+++ b/lib/rules/value-in-payable.js
@@ -6,81 +6,81 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure 'msg.value' is only used in functions with the 'payable' modifier"
-        },
-
-        schema: []
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure 'msg.value' is only used in functions with the 'payable' modifier"
     },
 
-    create(context) {
+    schema: []
+  },
 
-        let currentFunctionDeclaration = null;
+  create(context) {
+    let currentFunctionDeclaration = null;
 
-        function inspectFunctionDeclaration(emitted) {
-            if (emitted.exit) {
-                currentFunctionDeclaration = null;
-                return;
-            }
+    function inspectFunctionDeclaration(emitted) {
+      if (emitted.exit) {
+        currentFunctionDeclaration = null;
+        return;
+      }
 
-            currentFunctionDeclaration = emitted.node;
-
-        }
-
-        function inspectMemberExpression(emitted) {
-            if (emitted.exit) {
-                return;
-            }
-
-            const { node } = emitted;
-
-            if (_isMsgValueAccess(node)
-                && _isInFunction()
-                && !_isPrivateFunction()
-                && !_isInPayableFunction()) {
-
-                context.report({
-                    node: emitted.node,
-                    message: `Function '${currentFunctionDeclaration.name}' must be declared payable if using 'msg.value'`
-                });
-            }
-        }
-
-        function _isMsgValueAccess(node) {
-            return node.object.name === "msg" && node.property.name === "value";
-        }
-
-        function _isInFunction() {
-            return currentFunctionDeclaration !== null;
-        }
-
-        function _isPrivateFunction() {
-            return (
-                _containsModifier(currentFunctionDeclaration, "private") ||
-                _containsModifier(currentFunctionDeclaration, "internal")
-            );
-        }
-
-        function _isInPayableFunction() {
-            return _containsModifier(currentFunctionDeclaration, "payable");
-        }
-
-        function _containsModifier(functionDeclaration, modifierName) {
-            return functionDeclaration.modifiers.map(modifier => {
-                return modifier.name;
-            }).includes(modifierName);
-        }
-
-        return {
-            FunctionDeclaration: inspectFunctionDeclaration,
-            MemberExpression: inspectMemberExpression
-        };
-
+      currentFunctionDeclaration = emitted.node;
     }
 
+    function inspectMemberExpression(emitted) {
+      if (emitted.exit) {
+        return;
+      }
+
+      const { node } = emitted;
+
+      if (
+        _isMsgValueAccess(node) &&
+        _isInFunction() &&
+        !_isPrivateFunction() &&
+        !_isInPayableFunction()
+      ) {
+        context.report({
+          node: emitted.node,
+          message: `Function '${
+            currentFunctionDeclaration.name
+          }' must be declared payable if using 'msg.value'`
+        });
+      }
+    }
+
+    function _isMsgValueAccess(node) {
+      return node.object.name === "msg" && node.property.name === "value";
+    }
+
+    function _isInFunction() {
+      return currentFunctionDeclaration !== null;
+    }
+
+    function _isPrivateFunction() {
+      return (
+        _containsModifier(currentFunctionDeclaration, "private") ||
+        _containsModifier(currentFunctionDeclaration, "internal")
+      );
+    }
+
+    function _isInPayableFunction() {
+      return _containsModifier(currentFunctionDeclaration, "payable");
+    }
+
+    function _containsModifier(functionDeclaration, modifierName) {
+      return functionDeclaration.modifiers
+        .map(modifier => {
+          return modifier.name;
+        })
+        .includes(modifierName);
+    }
+
+    return {
+      FunctionDeclaration: inspectFunctionDeclaration,
+      MemberExpression: inspectMemberExpression
+    };
+  }
 };

--- a/lib/rules/variable-declarations.js
+++ b/lib/rules/variable-declarations.js
@@ -6,71 +6,77 @@
 "use strict";
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that names \"l\", \"O\" & \"I\" are not used for variables"
-        },
-
-        schema: [{
-            type: "array",
-            items: { type: "string", minLength: 1 },
-            minItems: 1
-        }]
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "error",
+      description: 'Ensure that names "l", "O" & "I" are not used for variables'
     },
 
-    create: function(context) {
+    schema: [
+      {
+        type: "array",
+        items: { type: "string", minLength: 1 },
+        minItems: 1
+      }
+    ]
+  },
 
-        let disallowedNames = context.options ? context.options [0] : ["l", "O", "I"];
+  create: function(context) {
+    let disallowedNames = context.options
+      ? context.options[0]
+      : ["l", "O", "I"];
 
-        function inspectVariableDeclarator(emitted) {
-            let node = emitted.node, variableName = node.id.name;
+    function inspectVariableDeclarator(emitted) {
+      let node = emitted.node,
+        variableName = node.id.name;
 
-            if (emitted.exit) {
-                return;
-            }
+      if (emitted.exit) {
+        return;
+      }
 
-            disallowedNames.forEach(function(disallowedName) {
-                if (variableName === disallowedName) {
-                    context.report({
-                        node: node,
-                        message: "Using \"" + variableName + "\" for a variable name should be avoided."
-                    });
-                }
-            });
+      disallowedNames.forEach(function(disallowedName) {
+        if (variableName === disallowedName) {
+          context.report({
+            node: node,
+            message:
+              'Using "' +
+              variableName +
+              '" for a variable name should be avoided.'
+          });
         }
-
-        function inspectDeclarativeExpression(emitted) {
-            let node = emitted.node, variableName = node.name;
-
-            if (emitted.exit) {
-                return;
-            }
-
-            disallowedNames.forEach(function(disallowedName) {
-                if (variableName === disallowedName) {
-                    context.report({
-                        node: node,
-                        message: "Using '" + variableName + "' for a variable name should be avoided."
-                    });
-                }
-            });
-        }
-
-        // Aliased because both the inspect functions access the same property "name" of the node passed to them.
-        // So no need for 2 separate functions for now (will create separate when different attrs are accessed in future)
-        let inspectStateVariableDeclaration = inspectDeclarativeExpression;
-
-        return {
-            VariableDeclarator: inspectVariableDeclarator,
-            DeclarativeExpression: inspectDeclarativeExpression,
-            StateVariableDeclaration: inspectStateVariableDeclaration
-        };
-
+      });
     }
 
+    function inspectDeclarativeExpression(emitted) {
+      let node = emitted.node,
+        variableName = node.name;
+
+      if (emitted.exit) {
+        return;
+      }
+
+      disallowedNames.forEach(function(disallowedName) {
+        if (variableName === disallowedName) {
+          context.report({
+            node: node,
+            message:
+              "Using '" +
+              variableName +
+              "' for a variable name should be avoided."
+          });
+        }
+      });
+    }
+
+    // Aliased because both the inspect functions access the same property "name" of the node passed to them.
+    // So no need for 2 separate functions for now (will create separate when different attrs are accessed in future)
+    let inspectStateVariableDeclaration = inspectDeclarativeExpression;
+
+    return {
+      VariableDeclarator: inspectVariableDeclarator,
+      DeclarativeExpression: inspectDeclarativeExpression,
+      StateVariableDeclaration: inspectStateVariableDeclaration
+    };
+  }
 };

--- a/lib/rules/visibility-first.js
+++ b/lib/rules/visibility-first.js
@@ -6,45 +6,52 @@
 "use strict";
 
 module.exports = {
-    meta: {
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Ensure that the visibility modifier for a function should come before any custom modifiers"
-        },
-
-        schema: []
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description:
+        "Ensure that the visibility modifier for a function should come before any custom modifiers"
     },
 
-    create(context) {
-        // Find index of the first visibility modifier in declaration.
-        // Find the first non-VM before this first VM found above.
-        // If non-VM found, report the VM.
-        function inspectFD(emitted) {
-            const { node } = emitted,
-                visibilityModifiers = ["public", "external", "internal", "private"];
-            const modifiers = (node.modifiers || []),
-                firstVisibilityModifierIndex = modifiers.findIndex(m => visibilityModifiers.includes(m.name));
+    schema: []
+  },
 
-            // If no visibility modifiers exist in function declaration, exit now
-            if (emitted.exit || firstVisibilityModifierIndex === -1) {
-                return;
-            }
+  create(context) {
+    // Find index of the first visibility modifier in declaration.
+    // Find the first non-VM before this first VM found above.
+    // If non-VM found, report the VM.
+    function inspectFD(emitted) {
+      const { node } = emitted,
+        visibilityModifiers = ["public", "external", "internal", "private"];
+      const modifiers = node.modifiers || [],
+        firstVisibilityModifierIndex = modifiers.findIndex(m =>
+          visibilityModifiers.includes(m.name)
+        );
 
-            const firstNonVisModifBeforeFirstVisModif = modifiers.slice(0, firstVisibilityModifierIndex).find(m => !visibilityModifiers.includes(m.name));
+      // If no visibility modifiers exist in function declaration, exit now
+      if (emitted.exit || firstVisibilityModifierIndex === -1) {
+        return;
+      }
 
-            // TODO: Add fix() for this rule
-            if (firstNonVisModifBeforeFirstVisModif) {
-                const issue = {
-                    node: modifiers[firstVisibilityModifierIndex],
-                    message: `Visibility modifier "${modifiers[firstVisibilityModifierIndex].name}" should come before other modifiers.`
-                };
-                context.report(issue);
-            }
-        }
+      const firstNonVisModifBeforeFirstVisModif = modifiers
+        .slice(0, firstVisibilityModifierIndex)
+        .find(m => !visibilityModifiers.includes(m.name));
 
-        return {
-            FunctionDeclaration: inspectFD
+      // TODO: Add fix() for this rule
+      if (firstNonVisModifBeforeFirstVisModif) {
+        const issue = {
+          node: modifiers[firstVisibilityModifierIndex],
+          message: `Visibility modifier "${
+            modifiers[firstVisibilityModifierIndex].name
+          }" should come before other modifiers.`
         };
+        context.report(issue);
+      }
     }
+
+    return {
+      FunctionDeclaration: inspectFD
+    };
+  }
 };

--- a/lib/rules/whitespace.js
+++ b/lib/rules/whitespace.js
@@ -6,161 +6,185 @@
 "use strict";
 
 const { EOL } = require("os"),
-    jse = require("js-string-escape");
+  jse = require("js-string-escape");
 
 module.exports = {
-
-    meta: {
-
-        docs: {
-            recommended: true,
-            type: "warning",
-            description: "Specify where whitespace is suitable and where it isn't"
-        },
-
-        schema: []
-
+  meta: {
+    docs: {
+      recommended: true,
+      type: "warning",
+      description: "Specify where whitespace is suitable and where it isn't"
     },
 
-    create: function(context) {
+    schema: []
+  },
 
-        let sourceCode = context.getSourceCode();
+  create: function(context) {
+    let sourceCode = context.getSourceCode();
 
-        function inspectNameValueAssignment(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+    function inspectNameValueAssignment(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-            let node = emitted.node,
-                codeBetweenNameAndValue = sourceCode.getStringBetweenNodes(node.name, node.value);
-            let validationRegexp = /^((: )|(:)|( : ))$/;
+      let node = emitted.node,
+        codeBetweenNameAndValue = sourceCode.getStringBetweenNodes(
+          node.name,
+          node.value
+        );
+      let validationRegexp = /^((: )|(:)|( : ))$/;
 
-            (!validationRegexp.test(codeBetweenNameAndValue)) && context.report({
-                location: {
-                    column: sourceCode.getColumn(node.name) + 1
-                },
+      !validationRegexp.test(codeBetweenNameAndValue) &&
+        context.report({
+          location: {
+            column: sourceCode.getColumn(node.name) + 1
+          },
 
-                node: node,
-                message: ("Name '" + node.name.name +
-					"': Only \"N: V\", \"N : V\" or \"N:V\" spacing style should be used in Name-Value Mapping.")
-            });
+          node: node,
+          message:
+            "Name '" +
+            node.name.name +
+            '\': Only "N: V", "N : V" or "N:V" spacing style should be used in Name-Value Mapping.'
+        });
 
-            //If this is not the last node of its parent array, ensure the comma spacing is acceptable
-            let parentArray = node.parent.arguments;
+      //If this is not the last node of its parent array, ensure the comma spacing is acceptable
+      let parentArray = node.parent.arguments;
 
-            if (node.start === parentArray.slice(-1) [0].start) {
-                return;
-            }
+      if (node.start === parentArray.slice(-1)[0].start) {
+        return;
+      }
 
-            let escapedEOL = jse(EOL),
-                codeAfterCurrentAssignment = sourceCode.getNextChars(node.value, 3);
+      let escapedEOL = jse(EOL),
+        codeAfterCurrentAssignment = sourceCode.getNextChars(node.value, 3);
 
-            // thirdCharRegexp is used in validationRegExp if EOL is unix-style, ie, len(EOL) = 1.
-            // If len(EOL) is 2, then comma + EOL cover 3 chars, then thirdCharRegexp gets treated as a checked for 4th character,
-            // resulting in false positive.
-            const thirdCharRegexp = `[^${escapedEOL}\\/]`;
-            validationRegexp = new RegExp(
-                `^((,[^ ${escapedEOL}\\/].)|(, [^ ${escapedEOL}\\/])|(,${escapedEOL}${EOL.length === 1 ? thirdCharRegexp : ""}))$`
-            );
+      // thirdCharRegexp is used in validationRegExp if EOL is unix-style, ie, len(EOL) = 1.
+      // If len(EOL) is 2, then comma + EOL cover 3 chars, then thirdCharRegexp gets treated as a checked for 4th character,
+      // resulting in false positive.
+      const thirdCharRegexp = `[^${escapedEOL}\\/]`;
+      validationRegexp = new RegExp(
+        `^((,[^ ${escapedEOL}\\/].)|(, [^ ${escapedEOL}\\/])|(,${escapedEOL}${
+          EOL.length === 1 ? thirdCharRegexp : ""
+        }))$`
+      );
 
-            (!validationRegexp.test(codeAfterCurrentAssignment)) && context.report({
-                location: {
-                    column: sourceCode.getEndingColumn(node.value) + 1
-                },
+      !validationRegexp.test(codeAfterCurrentAssignment) &&
+        context.report({
+          location: {
+            column: sourceCode.getEndingColumn(node.value) + 1
+          },
 
-                node: node,
-                message: "\"" + sourceCode.getText(node.value) + "\" should be immediately followed by a comma, then an optional space."
-            });
-        }
-
-
-        function inspectMemberExpression(emitted) {
-            let node = emitted.node,
-                property = node.property;
-
-            /**
-			 * If expression spans over multiple lines, below rule doesn't apply
-			 * eg- myArray [
-			 *         fooBar ()
-			 *             .getIndex ()
-			 *             .toBase10 ()
-			 * 	   ];
-			 */
-            if (emitted.exit || (sourceCode.getLine(node) !== sourceCode.getEndingLine(property)) || !node.computed) {
-                return;
-            }
-
-            let charBeforeProperty = sourceCode.getPrevChar(property),
-                charAfterProperty = sourceCode.getNextChar(property);
-
-            (charBeforeProperty !== "[") && context.report({
-                node: property,
-                location: {
-                    column: sourceCode.getColumn(property) - 1
-                },
-                message: "There should be no whitespace or comments between '[' and property."
-            });
-
-            (charAfterProperty !== "]") && context.report({
-                node: property,
-                location: {
-                    column: sourceCode.getEndingColumn(property) + 1
-                },
-                message: "There should be no whitespace or comments between property and ']'."
-            });
-        }
-
-
-        function inspectBlockStatement(emitted) {
-            let node = emitted.node, blockBody = node.body,
-                lastBlockItem = blockBody.slice(-1) [0];	//if block is empty, this becomes undefined
-
-            //if block spans over multiple lines or is child of a function declaration, below rules don't apply
-            if (emitted.exit ||
-				(lastBlockItem && sourceCode.getLine(node) !== sourceCode.getEndingLine(lastBlockItem)) ||
-				["FunctionDeclaration", "ConstructorDeclaration"].includes(node.parent.type)
-            ) {
-                return;
-            }
-
-            //for a 0-item block, ensure that block node's code is simply '{}'
-            if (!blockBody.length) {
-                let nodeCode = sourceCode.getText(node);
-
-                (nodeCode !== "{}") && context.report({
-                    node: node,
-                    message: "An empty block shouldn't have any whitespace or comments between the braces, i.e., '{}'."
-                });
-
-                return;
-            }
-
-            let charBeforeFirstItem = sourceCode.getPrevChar(blockBody [0]),
-                charAfterLastItem = sourceCode.getNextChar(lastBlockItem);
-
-            (charBeforeFirstItem !== "{") && context.report({
-                node: blockBody [0],
-                location: {
-                    column: sourceCode.getColumn(blockBody [0]) - 1
-                },
-                message: "There should be no whitespace or comments between the opening brace '{' and first item."
-            });
-
-            (charAfterLastItem !== "}") && context.report({
-                node: lastBlockItem,
-                location: {
-                    column: sourceCode.getEndingColumn(lastBlockItem) + 1
-                },
-                message: "There should be no whitespace or comments between the last item and closing brace '}'."
-            });
-        }
-
-        return {
-            BlockStatement: inspectBlockStatement,
-            MemberExpression: inspectMemberExpression,
-            NameValueAssignment: inspectNameValueAssignment
-        };
-
+          node: node,
+          message:
+            '"' +
+            sourceCode.getText(node.value) +
+            '" should be immediately followed by a comma, then an optional space.'
+        });
     }
 
+    function inspectMemberExpression(emitted) {
+      let node = emitted.node,
+        property = node.property;
+
+      /**
+       * If expression spans over multiple lines, below rule doesn't apply
+       * eg- myArray [
+       *         fooBar ()
+       *             .getIndex ()
+       *             .toBase10 ()
+       * 	   ];
+       */
+      if (
+        emitted.exit ||
+        sourceCode.getLine(node) !== sourceCode.getEndingLine(property) ||
+        !node.computed
+      ) {
+        return;
+      }
+
+      let charBeforeProperty = sourceCode.getPrevChar(property),
+        charAfterProperty = sourceCode.getNextChar(property);
+
+      charBeforeProperty !== "[" &&
+        context.report({
+          node: property,
+          location: {
+            column: sourceCode.getColumn(property) - 1
+          },
+          message:
+            "There should be no whitespace or comments between '[' and property."
+        });
+
+      charAfterProperty !== "]" &&
+        context.report({
+          node: property,
+          location: {
+            column: sourceCode.getEndingColumn(property) + 1
+          },
+          message:
+            "There should be no whitespace or comments between property and ']'."
+        });
+    }
+
+    function inspectBlockStatement(emitted) {
+      let node = emitted.node,
+        blockBody = node.body,
+        lastBlockItem = blockBody.slice(-1)[0]; //if block is empty, this becomes undefined
+
+      //if block spans over multiple lines or is child of a function declaration, below rules don't apply
+      if (
+        emitted.exit ||
+        (lastBlockItem &&
+          sourceCode.getLine(node) !==
+            sourceCode.getEndingLine(lastBlockItem)) ||
+        ["FunctionDeclaration", "ConstructorDeclaration"].includes(
+          node.parent.type
+        )
+      ) {
+        return;
+      }
+
+      //for a 0-item block, ensure that block node's code is simply '{}'
+      if (!blockBody.length) {
+        let nodeCode = sourceCode.getText(node);
+
+        nodeCode !== "{}" &&
+          context.report({
+            node: node,
+            message:
+              "An empty block shouldn't have any whitespace or comments between the braces, i.e., '{}'."
+          });
+
+        return;
+      }
+
+      let charBeforeFirstItem = sourceCode.getPrevChar(blockBody[0]),
+        charAfterLastItem = sourceCode.getNextChar(lastBlockItem);
+
+      charBeforeFirstItem !== "{" &&
+        context.report({
+          node: blockBody[0],
+          location: {
+            column: sourceCode.getColumn(blockBody[0]) - 1
+          },
+          message:
+            "There should be no whitespace or comments between the opening brace '{' and first item."
+        });
+
+      charAfterLastItem !== "}" &&
+        context.report({
+          node: lastBlockItem,
+          location: {
+            column: sourceCode.getEndingColumn(lastBlockItem) + 1
+          },
+          message:
+            "There should be no whitespace or comments between the last item and closing brace '}'."
+        });
+    }
+
+    return {
+      BlockStatement: inspectBlockStatement,
+      MemberExpression: inspectMemberExpression,
+      NameValueAssignment: inspectNameValueAssignment
+    };
+  }
 };

--- a/lib/solium.js
+++ b/lib/solium.js
@@ -6,322 +6,377 @@
 "use strict";
 
 const solidityParser = require("solparse"),
-    solExplore = require("sol-explore"),
-    fs = require("fs"), path = require("path"),
-    util = require("util"),
-
-    EventEmitter = require("events").EventEmitter,
-    EventGenerator = require("./utils/node-event-generator"),
-    RuleContext = require("./rule-context"),
-    CommentDirectiveParser = require("./comment-directive-parser"),
-    SourceCode = require("./utils/source-code-utils"),
-
-    RuleFixer = require("./autofix/rule-fixer"),
-    SourceCodeFixer = require("./autofix/source-code-fixer"),
-
-    rules = require("./rules"),
-    astUtils = require("./utils/ast-utils"),
-    jsUtils = require("./utils/js-utils"),
-    configInspector = require("./utils/config-inspector"),
-    ruleInspector = require("./utils/rule-inspector"),
-
-    isErrObjectValid = require("../config/schemas/error-supplied-to-solium").validationFunc,
-    isValidFixerPacket = require("../config/schemas/fixer-packet").validationFunc,
-
-    soliumVersion = require("../package.json").version,
-    defaultSoliumrcJSON = require("./cli-utils/.default-soliumrc.json");
-
+  solExplore = require("sol-explore"),
+  fs = require("fs"),
+  path = require("path"),
+  util = require("util"),
+  EventEmitter = require("events").EventEmitter,
+  EventGenerator = require("./utils/node-event-generator"),
+  RuleContext = require("./rule-context"),
+  CommentDirectiveParser = require("./comment-directive-parser"),
+  SourceCode = require("./utils/source-code-utils"),
+  RuleFixer = require("./autofix/rule-fixer"),
+  SourceCodeFixer = require("./autofix/source-code-fixer"),
+  rules = require("./rules"),
+  astUtils = require("./utils/ast-utils"),
+  jsUtils = require("./utils/js-utils"),
+  configInspector = require("./utils/config-inspector"),
+  ruleInspector = require("./utils/rule-inspector"),
+  isErrObjectValid = require("../config/schemas/error-supplied-to-solium")
+    .validationFunc,
+  isValidFixerPacket = require("../config/schemas/fixer-packet").validationFunc,
+  soliumVersion = require("../package.json").version,
+  defaultSoliumrcJSON = require("./cli-utils/.default-soliumrc.json");
 
 module.exports = (function() {
+  let Solium = Object.create(new EventEmitter()),
+    messages = [],
+    sourceCodeText = "",
+    currentConfig = null,
+    commentDirectiveParser;
 
-    let Solium = Object.create(new EventEmitter()),
-        messages = [], sourceCodeText = "", currentConfig = null, commentDirectiveParser;
+  /**
+   * Initialize all global variables: ensure nothing from the previous lint() gets carried to the next lint()
+   * @returns {void}
+   */
+  Solium.reset = function reset() {
+    Solium.removeAllListeners();
+    messages = [];
+    sourceCodeText = "";
+    currentConfig = {};
+    commentDirectiveParser = null;
+  };
 
-    /**
-     * Initialize all global variables: ensure nothing from the previous lint() gets carried to the next lint()
-     * @returns {void}
-     */
-    Solium.reset = function reset() {
-        Solium.removeAllListeners();
-        messages = [];
-        sourceCodeText = "";
-        currentConfig = {};
-        commentDirectiveParser = null;
-    };
+  /**
+   * Function called for linting the code by external application(s) using the Solium object
+   * @param {(String|Buffer)} sourceCode The Source Code to lint
+   * @param {Object} config An object that specifies the rules to use and path of file containing custom rule definitions
+   * @returns {Array} errorObjects Array of objects, each containing lint error messages and supporting info, empty if no errors
+   */
+  Solium.lint = function lint(sourceCode, config, noReset) {
+    let nodeEventGenerator = new EventGenerator(Solium),
+      AST = {},
+      errorObjects;
 
-    /**
-     * Function called for linting the code by external application(s) using the Solium object
-     * @param {(String|Buffer)} sourceCode The Source Code to lint
-     * @param {Object} config An object that specifies the rules to use and path of file containing custom rule definitions
-     * @returns {Array} errorObjects Array of objects, each containing lint error messages and supporting info, empty if no errors
-     */
-    Solium.lint = function lint(sourceCode, config, noReset) {
-        let nodeEventGenerator = new EventGenerator(Solium), AST = {}, errorObjects;
+    if (
+      typeof sourceCode === "object" &&
+      sourceCode.constructor.name === "Buffer"
+    ) {
+      sourceCode = sourceCode.toString();
+    }
 
-        if (typeof sourceCode === "object" && sourceCode.constructor.name === "Buffer") {
-            sourceCode = sourceCode.toString();
-        }
+    if (!(sourceCode && typeof sourceCode === "string")) {
+      throw new Error("A valid source code string was not provided.");
+    }
 
-        if (!(sourceCode && typeof sourceCode === "string")) {
-            throw new Error("A valid source code string was not provided.");
-        }
+    if (!configInspector.isValid(config)) {
+      throw new Error(
+        "A valid configuration object was not passed." +
+          " Please see http://solium.readthedocs.io/en/latest/user-guide.html#configuring-the-linter" +
+          " for a valid config format."
+      );
+    }
 
-        if (!configInspector.isValid(config)) {
-            throw new Error(
-                "A valid configuration object was not passed." +
-                " Please see http://solium.readthedocs.io/en/latest/user-guide.html#configuring-the-linter" + 
-                " for a valid config format."
-            );
-        }
+    !noReset && Solium.reset();
 
-        !noReset && Solium.reset();
+    sourceCodeText = sourceCode;
+    astUtils.init(sourceCodeText);
+    currentConfig = JSON.parse(JSON.stringify(config)); // deep copy config object
+    currentConfig.options = currentConfig.options || {}; // ensure "options" attr always exists in config
 
-        sourceCodeText = sourceCode;
-        astUtils.init(sourceCodeText);
-        currentConfig = JSON.parse(JSON.stringify(config));	// deep copy config object
-        currentConfig.options = currentConfig.options || {};	// ensure "options" attr always exists in config
+    //load meta information of rules
+    if (configInspector.isFormatDeprecated(currentConfig)) {
+      let crf = currentConfig["custom-rules-filename"];
 
-        //load meta information of rules
-        if (configInspector.isFormatDeprecated(currentConfig)) {
-            let crf = currentConfig ["custom-rules-filename"];
+      Solium.reportInternal({
+        type: "warning",
+        message:
+          "[Deprecated] You are using a deprecated soliumrc configuration format. " +
+          "Please see http://solium.readthedocs.io/en/latest/user-guide.html#migrating-to-v1-0-0" +
+          " to migrate from Solium v0 to v1."
+      });
 
-            Solium.reportInternal({
-                type: "warning",
-                message: "[Deprecated] You are using a deprecated soliumrc configuration format. " +
-                    "Please see http://solium.readthedocs.io/en/latest/user-guide.html#migrating-to-v1-0-0" +
-                    " to migrate from Solium v0 to v1."
-            });
-
-            crf && Solium.reportInternal({
-                type: "warning",
-                message: "[Deprecated] Attribute \"custom-rules-filename\" is now deprecated. " +
-                    "Rules from " + crf + " were not loaded. Plugins are supported v1 onward. Please see " +
-                    "http://solium.readthedocs.io/en/latest/user-guide.html#custom-rule-injection-is-now-deprecated"
-            });
-
-            currentConfig.rules = rules.loadUsingDeprecatedConfigFormat(currentConfig.rules, crf);
-        } else {
-            currentConfig.rules = rules.load(currentConfig);
-        }
-
-        Object.keys(currentConfig.rules).forEach(function(name) {
-            let rule = rules.get(name), currentRuleConfig = currentConfig.rules [name];
-
-            // Check for validity of exposed rule object
-            if (!ruleInspector.isAValidRuleObject(rule)) {
-                throw new Error("A valid definition for rule \""
-                    + name + "\" was not provided. AJV message:\n" + util.inspect(ruleInspector.isAValidRuleObject.errors));
-            }
-
-            // Check for validity of options passed to the rule via soliumrc (if options were passed)
-            if (currentRuleConfig.options &&
-                !ruleInspector.areValidOptionsPassed(currentRuleConfig.options, rule.meta.schema)) {
-                throw new Error(`Invalid options were passed to rule "${name}".`);
-            }
-
-            // If rule contains deprecated tag & is set to true, display deprecation notice.
-            if (rule.meta.deprecated) {
-                let message = `[Deprecated] Rule "${name}" is deprecated.`;
-
-                if (rule.meta.docs.replacedBy) {
-                    message += " Please use " + rule.meta.docs.replacedBy.map(function(rn) {
-                        return "\"" + rn + "\"";
-                    }).join(", ") + " instead.";
-                }
-
-                Solium.reportInternal({ type: "warning", message });
-            }
-
-            // Call rule implementation's create() to retrieve the node names to listen for & their handlers
-            // and subscribe them to the event emitter.
-            let ruleNodeListeners = rule.create(new RuleContext(name, currentRuleConfig, rule.meta, Solium));
-
-            if (!ruleInspector.isAValidRuleResponseObject(ruleNodeListeners)) {
-                throw new Error(
-                    "A rule implementation's response must be an object whose keys "
-                    + "are AST Nodes to listen for and values their corresponding handler functions. AJV message:\n"
-                    + util.inspect(ruleInspector.isAValidRuleResponseObject.errors)
-                );
-            }
-
-            Object.keys(ruleNodeListeners).forEach(node => {
-                Solium.on(node, ruleNodeListeners [node]);
-            });
+      crf &&
+        Solium.reportInternal({
+          type: "warning",
+          message:
+            '[Deprecated] Attribute "custom-rules-filename" is now deprecated. ' +
+            "Rules from " +
+            crf +
+            " were not loaded. Plugins are supported v1 onward. Please see " +
+            "http://solium.readthedocs.io/en/latest/user-guide.html#custom-rule-injection-is-now-deprecated"
         });
 
-        try {
-            // Fetch AST with a top-level "comments" attribute
-            // In case of a parse error, catch the exception & re-throw with a modified message.
-            AST = solidityParser.parse(sourceCode, { comment: true });
-        } catch (e) {
-            e.message = `An error occured while parsing the source code: ${e.message}`;
-            throw(e);
+      currentConfig.rules = rules.loadUsingDeprecatedConfigFormat(
+        currentConfig.rules,
+        crf
+      );
+    } else {
+      currentConfig.rules = rules.load(currentConfig);
+    }
+
+    Object.keys(currentConfig.rules).forEach(function(name) {
+      let rule = rules.get(name),
+        currentRuleConfig = currentConfig.rules[name];
+
+      // Check for validity of exposed rule object
+      if (!ruleInspector.isAValidRuleObject(rule)) {
+        throw new Error(
+          'A valid definition for rule "' +
+            name +
+            '" was not provided. AJV message:\n' +
+            util.inspect(ruleInspector.isAValidRuleObject.errors)
+        );
+      }
+
+      // Check for validity of options passed to the rule via soliumrc (if options were passed)
+      if (
+        currentRuleConfig.options &&
+        !ruleInspector.areValidOptionsPassed(
+          currentRuleConfig.options,
+          rule.meta.schema
+        )
+      ) {
+        throw new Error(`Invalid options were passed to rule "${name}".`);
+      }
+
+      // If rule contains deprecated tag & is set to true, display deprecation notice.
+      if (rule.meta.deprecated) {
+        let message = `[Deprecated] Rule "${name}" is deprecated.`;
+
+        if (rule.meta.docs.replacedBy) {
+          message +=
+            " Please use " +
+            rule.meta.docs.replacedBy
+              .map(function(rn) {
+                return '"' + rn + '"';
+              })
+              .join(", ") +
+            " instead.";
         }
 
-        commentDirectiveParser = new CommentDirectiveParser(AST.comments, AST);
+        Solium.reportInternal({ type: "warning", message });
+      }
 
-        /**
-         * Perform depth-first traversal of the AST and notify rules upon entering & leaving nodes
-         * Each node has a type property which serves as the Event's name.
-         * This allows rules to listen to the type of node they wish to test.
-         */
-        solExplore.traverse(AST, {
-            enter(node, parent) {
-                node.parent = parent;	//allow the rules to access immediate parent of current node
-                nodeEventGenerator.enterNode(node);
-                delete node.parent;
-            },
+      // Call rule implementation's create() to retrieve the node names to listen for & their handlers
+      // and subscribe them to the event emitter.
+      let ruleNodeListeners = rule.create(
+        new RuleContext(name, currentRuleConfig, rule.meta, Solium)
+      );
 
-            leave(node) {
-                nodeEventGenerator.leaveNode(node);
-            }
+      if (!ruleInspector.isAValidRuleResponseObject(ruleNodeListeners)) {
+        throw new Error(
+          "A rule implementation's response must be an object whose keys " +
+            "are AST Nodes to listen for and values their corresponding handler functions. AJV message:\n" +
+            util.inspect(ruleInspector.isAValidRuleResponseObject.errors)
+        );
+      }
+
+      Object.keys(ruleNodeListeners).forEach(node => {
+        Solium.on(node, ruleNodeListeners[node]);
+      });
+    });
+
+    try {
+      // Fetch AST with a top-level "comments" attribute
+      // In case of a parse error, catch the exception & re-throw with a modified message.
+      AST = solidityParser.parse(sourceCode, { comment: true });
+    } catch (e) {
+      e.message = `An error occured while parsing the source code: ${
+        e.message
+      }`;
+      throw e;
+    }
+
+    commentDirectiveParser = new CommentDirectiveParser(AST.comments, AST);
+
+    /**
+     * Perform depth-first traversal of the AST and notify rules upon entering & leaving nodes
+     * Each node has a type property which serves as the Event's name.
+     * This allows rules to listen to the type of node they wish to test.
+     */
+    solExplore.traverse(AST, {
+      enter(node, parent) {
+        node.parent = parent; //allow the rules to access immediate parent of current node
+        nodeEventGenerator.enterNode(node);
+        delete node.parent;
+      },
+
+      leave(node) {
+        nodeEventGenerator.leaveNode(node);
+      }
+    });
+
+    // Remove all internal issues if user didn't ask for them.
+    if (!currentConfig.options.returnInternalIssues) {
+      messages = messages.filter(function(msg) {
+        return !msg.internal;
+      });
+    }
+
+    //sort errors by line (column if line is same)
+    messages.sort(function(a, b) {
+      let lineDiff = a.line - b.line;
+      return lineDiff ? lineDiff : a.column - b.column;
+    });
+
+    errorObjects = messages;
+    messages = []; //reset messages array to avoid carry-forward of error objects to other files
+
+    return errorObjects;
+  };
+
+  /**
+   * Lints, then applies fixes specified by rules and returns fixed code.
+   * @param {(String|Buffer)} sourceCode The Source Code to lint.
+   * @param {Object} config An object that specifies the rules to use and path of file containing custom rule definitions.
+   * @returns {Object} result Returns lint errors, errors that were fixed and final fixed code.
+   */
+  Solium.lintAndFix = function lintAndFix(sourceCode, config, noReset) {
+    if (
+      typeof sourceCode === "object" &&
+      sourceCode.constructor.name === "Buffer"
+    ) {
+      sourceCode = sourceCode.toString();
+    }
+
+    let errorObjects = Solium.lint(sourceCode, config, noReset);
+    let fixed = SourceCodeFixer.applyFixes(sourceCode, errorObjects);
+
+    return {
+      originalSourceCode: sourceCode,
+      fixesApplied: fixed.fixesApplied,
+      fixedSourceCode: fixed.fixedSourceCode,
+      errorMessages: fixed.remainingErrorMessages
+    };
+  };
+
+  /**
+   * Function called by any rule that wishes to send error message upon violation in source code
+   * @param {Object} error An object that contains sufficient information to describe the lint error
+   */
+  Solium.report = function report(error) {
+    if (!isErrObjectValid(error)) {
+      throw new Error(
+        util.inspect(error) +
+          " is not a valid error object. AJV message:\n" +
+          util.inspect(isErrObjectValid.errors)
+      );
+    }
+
+    error.location = error.location || {};
+
+    let message = {
+      ruleName: error.ruleName,
+      type: error.type, // either 'error' or 'warning'
+      node: error.node,
+      message: error.message,
+      line: error.location.line || astUtils.getLine(error.node),
+      column:
+        error.location.column === 0
+          ? 0
+          : error.location.column || astUtils.getColumn(error.node)
+    };
+
+    // First ensure that commentDirectiveParser is not null
+    // It will be undefined if Solium.report() is directly called without Solium.lint() and null after Solium.reset().
+    if (
+      commentDirectiveParser &&
+      !commentDirectiveParser.isRuleEnabledOnLine(
+        message.ruleName,
+        message.line
+      )
+    ) {
+      // If the line of code is configured to not be linted by Solium, do not report this lint issue.
+      return;
+    }
+
+    // If rule supplies a fix, it can be added to the message reported after validation.
+    if (error.fix) {
+      if (!error.ruleMeta.fixable) {
+        Solium.reportInternal({
+          type: "warning",
+          message:
+            '[Warning] The fixes supplied by rule "' +
+            error.ruleName +
+            '" will be ignored since its "meta" doesn\'t contain the "fixable" property.'
         });
-
-        // Remove all internal issues if user didn't ask for them.
-        if (!currentConfig.options.returnInternalIssues) {
-            messages = messages.filter(function(msg) {
-                return !msg.internal;
-            });
+      } else {
+        if (typeof error.fix !== "function") {
+          throw new Error(
+            `Rule "${error.ruleName}": ` +
+              `Attribute "fix" (reported as part of the error "${
+                error.message
+              }") must be a function.`
+          );
         }
 
-        //sort errors by line (column if line is same)
-        messages.sort(function(a, b) {
-            let lineDiff = a.line - b.line;
-            return (
-                lineDiff ? lineDiff : (a.column - b.column)
-            );
-        });
+        message.fix = error.fix(new RuleFixer(error.ruleMeta.fixable));
 
-        errorObjects = messages;
-        messages = [];	//reset messages array to avoid carry-forward of error objects to other files
-
-        return errorObjects;
-
-    };
-
-    /**
-     * Lints, then applies fixes specified by rules and returns fixed code.
-     * @param {(String|Buffer)} sourceCode The Source Code to lint.
-     * @param {Object} config An object that specifies the rules to use and path of file containing custom rule definitions.
-     * @returns {Object} result Returns lint errors, errors that were fixed and final fixed code. 
-     */
-    Solium.lintAndFix = function lintAndFix(sourceCode, config, noReset) {
-        if (typeof sourceCode === "object" && sourceCode.constructor.name === "Buffer") {
-            sourceCode = sourceCode.toString();
+        if (message.fix === null) {
+          // The rule's fix() was called but doesn't want to apply any fixes in this instance
+          delete message.fix;
+        } else if (!isValidFixerPacket(message.fix)) {
+          // Validate return value of the rule's error's fix() function
+          throw new Error(
+            'Rule "' +
+              error.ruleName +
+              '": the fix() method for rule error "' +
+              error.message +
+              '" returns an invalid value.'
+          );
         }
+      }
+    }
 
-        let errorObjects = Solium.lint(sourceCode, config, noReset);
-        let fixed = SourceCodeFixer.applyFixes(sourceCode, errorObjects);
+    messages.push(message);
+  };
 
-        return {
-            originalSourceCode: sourceCode,
-            fixesApplied: fixed.fixesApplied,
-            fixedSourceCode: fixed.fixedSourceCode,
-            errorMessages: fixed.remainingErrorMessages
-        };
+  /**
+   * Convenience wrapper for Solium modules to report internal issues. It adds the "internal: true" attr to error.
+   * @param {Object} issue Internal issue
+   */
+  Solium.reportInternal = function reportInternal(issue) {
+    if (!jsUtils.isStrictlyObject(issue)) {
+      throw new Error("Invalid error object");
+    }
+
+    // Assign line & column = -1 so messages.sort() brings the internal issues on top
+    messages.push(
+      Object.assign(issue, { internal: true, line: -1, column: -1 })
+    );
+  };
+
+  /**
+   * Provides the user with program source code wrapped inside a utility object that also provides functions to operate on the code
+   * @returns {Object} sourceCodeObject The SourceCode Object that provides source text & functionality
+   */
+  Solium.getSourceCode = function getSourceCode() {
+    return new SourceCode(sourceCodeText);
+  };
+
+  /**
+   * Get the default configuration dotfiles supplied by Solium
+   * @returns {Object} defaultConfig Object containing default .soliumrc.json & .soliumignore
+   */
+  Solium.getDefaultConfig = function getDefaultConfig() {
+    let sig = "node_modules";
+
+    // If unable to load soliumignore file, simply return node_modules string as soliumignore content
+    try {
+      sig = fs.readFileSync(
+        path.join(__dirname, "./cli-utils/.default-solium-ignore"),
+        "utf8"
+      );
+    } catch (e) {} // eslint-disable-line no-empty
+
+    return {
+      ".soliumignore": sig,
+      ".soliumrc.json": defaultSoliumrcJSON
     };
+  };
 
-    /**
-     * Function called by any rule that wishes to send error message upon violation in source code
-     * @param {Object} error An object that contains sufficient information to describe the lint error
-     */
-    Solium.report = function report(error) {
-        if (!isErrObjectValid(error)) {
-            throw new Error(util.inspect(error) +
-                " is not a valid error object. AJV message:\n" + util.inspect(isErrObjectValid.errors));
-        }
+  Solium.version = soliumVersion;
 
-        error.location = error.location || {};
-
-        let message = {
-
-            ruleName: error.ruleName,
-            type: error.type,	// either 'error' or 'warning'
-            node: error.node,
-            message: error.message,
-            line: error.location.line || astUtils.getLine(error.node),
-            column: (error.location.column === 0) ? 0 : (error.location.column || astUtils.getColumn(error.node))
-
-        };
-
-        // First ensure that commentDirectiveParser is not null
-        // It will be undefined if Solium.report() is directly called without Solium.lint() and null after Solium.reset().
-        if (commentDirectiveParser &&
-            !commentDirectiveParser.isRuleEnabledOnLine(message.ruleName, message.line)) {
-            // If the line of code is configured to not be linted by Solium, do not report this lint issue.
-            return;
-        }
-
-        // If rule supplies a fix, it can be added to the message reported after validation.
-        if (error.fix) {
-            if (!error.ruleMeta.fixable) {
-                Solium.reportInternal({
-                    type: "warning", message: "[Warning] The fixes supplied by rule \"" +
-                        error.ruleName + "\" will be ignored since its \"meta\" doesn't contain the \"fixable\" property."
-                });
-            } else {
-                if (typeof error.fix !== "function") {
-                    throw new Error(`Rule "${error.ruleName}": `
-                        + `Attribute "fix" (reported as part of the error "${error.message}") must be a function.`);
-                }
-
-                message.fix = error.fix(new RuleFixer(error.ruleMeta.fixable));
-
-                if (message.fix === null) {
-                    // The rule's fix() was called but doesn't want to apply any fixes in this instance
-                    delete message.fix;
-                } else if (!isValidFixerPacket(message.fix)) {
-                    // Validate return value of the rule's error's fix() function
-                    throw new Error("Rule \"" + error.ruleName +
-                        "\": the fix() method for rule error \"" + error.message + "\" returns an invalid value.");
-                }
-            }
-        }
-
-        messages.push(message);
-    };
-
-    /**
-     * Convenience wrapper for Solium modules to report internal issues. It adds the "internal: true" attr to error.
-     * @param {Object} issue Internal issue
-     */
-    Solium.reportInternal = function reportInternal(issue) {
-        if (!jsUtils.isStrictlyObject(issue)) {
-            throw new Error("Invalid error object");
-        }
-
-        // Assign line & column = -1 so messages.sort() brings the internal issues on top
-        messages.push(Object.assign(issue, { internal: true, line: -1, column: -1 }));
-    };
-
-    /**
-     * Provides the user with program source code wrapped inside a utility object that also provides functions to operate on the code
-     * @returns {Object} sourceCodeObject The SourceCode Object that provides source text & functionality
-     */
-    Solium.getSourceCode = function getSourceCode() {
-        return new SourceCode(sourceCodeText);
-    };
-
-    /**
-     * Get the default configuration dotfiles supplied by Solium
-     * @returns {Object} defaultConfig Object containing default .soliumrc.json & .soliumignore
-     */
-    Solium.getDefaultConfig = function getDefaultConfig() {
-        let sig = "node_modules";
-
-        // If unable to load soliumignore file, simply return node_modules string as soliumignore content
-        try {
-            sig = fs.readFileSync(path.join(__dirname, "./cli-utils/.default-solium-ignore"), "utf8");
-        } catch (e) {}  // eslint-disable-line no-empty
-
-        return {
-            ".soliumignore": sig,
-            ".soliumrc.json": defaultSoliumrcJSON
-        };
-    };
-
-    Solium.version = soliumVersion;
-
-    return Solium;
-
+  return Solium;
 })();

--- a/lib/utils/ast-utils.js
+++ b/lib/utils/ast-utils.js
@@ -6,26 +6,27 @@
 "use strict";
 
 let Ajv = require("ajv"),
-    util = require("util"),
-    astNodeSchema = require("../../config/schemas/ast-node");
+  util = require("util"),
+  astNodeSchema = require("../../config/schemas/ast-node");
 
-let nodeSchemaValidator = new Ajv({ allErrors: true }), sourceCodeText = "";
-
+let nodeSchemaValidator = new Ajv({ allErrors: true }),
+  sourceCodeText = "";
 
 // For internal use. Throws if is passed an invalid AST node, else does nothing.
 function throwIfInvalidNode(node, functionName) {
-    if (!exports.isASTNode(node)) {
-        throw new Error(functionName + "(): " + util.inspect(node) + " is not a valid AST node.");
-    }
+  if (!exports.isASTNode(node)) {
+    throw new Error(
+      functionName + "(): " + util.inspect(node) + " is not a valid AST node."
+    );
+  }
 }
-
 
 /**
  * Initialization method - provide all the necessary information astUtils functions could require in order to work
  * @param {String} sourceCodeText The source code being linted
  */
 exports.init = function(sourceCode) {
-    sourceCodeText = sourceCode;
+  sourceCodeText = sourceCode;
 };
 
 /**
@@ -41,16 +42,16 @@ exports.isASTNode = nodeSchemaValidator.compile(astNodeSchema);
  * @returns {Boolean} true if the given node is the right type
  */
 function isNodeType(node, name) {
-    throwIfInvalidNode(node, "isNodeType");
-    return node["type"] === name;
+  throwIfInvalidNode(node, "isNodeType");
+  return node["type"] === name;
 }
 
 /**
-  * @param {Object} node The node to check
-  * @returns {Boolean} true if the given node is an BlockStatement
-  */
+ * @param {Object} node The node to check
+ * @returns {Boolean} true if the given node is an BlockStatement
+ */
 exports.isBlockStatement = function(node) {
-    return isNodeType(node, "BlockStatement");
+  return isNodeType(node, "BlockStatement");
 };
 
 /**
@@ -58,7 +59,7 @@ exports.isBlockStatement = function(node) {
  * @returns {Boolean} true if the given node is an BreakStatement
  */
 exports.isBreakStatement = function(node) {
-    return isNodeType(node, "BreakStatement");
+  return isNodeType(node, "BreakStatement");
 };
 
 /**
@@ -66,7 +67,7 @@ exports.isBreakStatement = function(node) {
  * @returns {Boolean} true if the given node is an ExpressionStatement
  */
 exports.isExpression = function(node) {
-    return isNodeType(node, "ExpressionStatement");
+  return isNodeType(node, "ExpressionStatement");
 };
 
 /**
@@ -74,7 +75,7 @@ exports.isExpression = function(node) {
  * @returns {Boolean} true if the given node is an AssignmentStatement
  */
 exports.isAssignment = function(node) {
-    return isNodeType(node, "AssignmentExpression");
+  return isNodeType(node, "AssignmentExpression");
 };
 
 /**
@@ -82,7 +83,7 @@ exports.isAssignment = function(node) {
  * @returns {Boolean} true if the given node is an UpdateExpression
  */
 exports.isUpdate = function(node) {
-    return isNodeType(node, "UpdateExpression");
+  return isNodeType(node, "UpdateExpression");
 };
 
 /**
@@ -90,7 +91,7 @@ exports.isUpdate = function(node) {
  * @returns {Boolean} true if the given node is an MemberExpression
  */
 exports.isMember = function(node) {
-    return isNodeType(node, "MemberExpression");
+  return isNodeType(node, "MemberExpression");
 };
 
 /**
@@ -98,7 +99,7 @@ exports.isMember = function(node) {
  * @returns {Boolean} true if the given node is an IfStatement
  */
 exports.isIfStatement = function(node) {
-    return isNodeType(node, "IfStatement");
+  return isNodeType(node, "IfStatement");
 };
 
 /**
@@ -106,7 +107,11 @@ exports.isIfStatement = function(node) {
  * @returns {Boolean} true if the given node is a type of loop statement
  */
 exports.isLoopStatement = function(node) {
-    return ["ForStatement", "WhileStatement", "DoWhileStatement"].indexOf(node["type"]) >= 0;
+  return (
+    ["ForStatement", "WhileStatement", "DoWhileStatement"].indexOf(
+      node["type"]
+    ) >= 0
+  );
 };
 
 /**
@@ -115,8 +120,8 @@ exports.isLoopStatement = function(node) {
  * @returns {Object} nodeParent Parent node of the given node
  */
 exports.getParent = function(node) {
-    throwIfInvalidNode(node, "getParent");
-    return node.parent;
+  throwIfInvalidNode(node, "getParent");
+  return node.parent;
 };
 
 /**
@@ -125,15 +130,11 @@ exports.getParent = function(node) {
  * @returns {Integer} lineNumber Line number of code of the specified node. (LINES BEGIN FROM 1)
  */
 exports.getLine = function(node) {
-    throwIfInvalidNode(node, "getLine");
+  throwIfInvalidNode(node, "getLine");
 
-    let newLineCharsBefore = sourceCodeText
-        .slice(0, node.start)
-        .match(/\n/g);
+  let newLineCharsBefore = sourceCodeText.slice(0, node.start).match(/\n/g);
 
-    return (
-        (newLineCharsBefore ? newLineCharsBefore.length : 0) + 1
-    );
+  return (newLineCharsBefore ? newLineCharsBefore.length : 0) + 1;
 };
 
 /**
@@ -142,16 +143,16 @@ exports.getLine = function(node) {
  * @returns {Integer} columnNumber Column number of code of the specified node (COLUMNS BEGIN FROM 0)
  */
 exports.getColumn = function(node) {
-    throwIfInvalidNode(node, "getColumn");
+  throwIfInvalidNode(node, "getColumn");
 
-    //start looking from sourceCodeText [node.start] and stop upon encountering the first linebreak character
-    for (let i = node.start; i >= 0; i--) {
-        if (sourceCodeText [i] === "\n") {
-            return node.start - i - 1;
-        }
+  //start looking from sourceCodeText [node.start] and stop upon encountering the first linebreak character
+  for (let i = node.start; i >= 0; i--) {
+    if (sourceCodeText[i] === "\n") {
+      return node.start - i - 1;
     }
+  }
 
-    return node.start;
+  return node.start;
 };
 
 /**
@@ -160,15 +161,11 @@ exports.getColumn = function(node) {
  * @returns {Integer} lineNumber Line number of code ending of the specified node. (LINES BEGIN FROM 1)
  */
 exports.getEndingLine = function(node) {
-    throwIfInvalidNode(node, "getEndingLine");
+  throwIfInvalidNode(node, "getEndingLine");
 
-    let newLineCharsBefore = sourceCodeText
-        .slice(0, node.end)
-        .match(/\n/g);
+  let newLineCharsBefore = sourceCodeText.slice(0, node.end).match(/\n/g);
 
-    return (
-        (newLineCharsBefore ? newLineCharsBefore.length : 0) + 1
-    );
+  return (newLineCharsBefore ? newLineCharsBefore.length : 0) + 1;
 };
 
 /**
@@ -177,16 +174,16 @@ exports.getEndingLine = function(node) {
  * @returns {Integer} columnNumber Column number of last char of the specified node (COLUMNS BEGIN FROM 0)
  */
 exports.getEndingColumn = function(node) {
-    throwIfInvalidNode(node, "getEndingColumn");
+  throwIfInvalidNode(node, "getEndingColumn");
 
-    //start looking from 1 character before node.start and stop upon encountering the first linebreak character
-    for (let i = node.end - 1; i >= 0; i--) {
-        if (sourceCodeText [i] === "\n") {
-            return node.end - i - 2;
-        }
+  //start looking from 1 character before node.start and stop upon encountering the first linebreak character
+  for (let i = node.end - 1; i >= 0; i--) {
+    if (sourceCodeText[i] === "\n") {
+      return node.end - i - 2;
     }
+  }
 
-    return node.end - 1;
+  return node.end - 1;
 };
 
 /**
@@ -196,10 +193,13 @@ exports.getEndingColumn = function(node) {
  * @returns {Bool} true if potentialChild is indeed a child of potentialParent, false otherwise
  */
 exports.isAChildOf = (potentialChild, potentialParent) => {
-    throwIfInvalidNode(potentialChild, "isAChildOf");
-    throwIfInvalidNode(potentialParent, "isAChildOf");
+  throwIfInvalidNode(potentialChild, "isAChildOf");
+  throwIfInvalidNode(potentialParent, "isAChildOf");
 
-    // Note that if the start or end pos of both nodes is same,
-    // then they're considered to be the same node and DON'T have parent-child relationship.
-    return potentialChild.start > potentialParent.start && potentialChild.end < potentialParent.end;
+  // Note that if the start or end pos of both nodes is same,
+  // then they're considered to be the same node and DON'T have parent-child relationship.
+  return (
+    potentialChild.start > potentialParent.start &&
+    potentialChild.end < potentialParent.end
+  );
 };

--- a/lib/utils/config-inspector.js
+++ b/lib/utils/config-inspector.js
@@ -6,42 +6,39 @@
 "use strict";
 
 let Ajv = require("ajv"),
-    currentConfigSchema = require("../../config/schemas/config"),
-    deprecatedConfigSchema = require("../../config/schemas/deprecated/config-v0.5.5"),
-    sharableConfigSchema = require("../../config/schemas/sharable-config");
+  currentConfigSchema = require("../../config/schemas/config"),
+  deprecatedConfigSchema = require("../../config/schemas/deprecated/config-v0.5.5"),
+  sharableConfigSchema = require("../../config/schemas/sharable-config");
 
 let SchemaValidator = new Ajv({ allErrors: true }),
-    validateCurrentConfig = SchemaValidator.compile(currentConfigSchema),
-    validateDepConfig = SchemaValidator.compile(deprecatedConfigSchema),
-    validateSharableConfig = SchemaValidator.compile(sharableConfigSchema);
-
+  validateCurrentConfig = SchemaValidator.compile(currentConfigSchema),
+  validateDepConfig = SchemaValidator.compile(deprecatedConfigSchema),
+  validateSharableConfig = SchemaValidator.compile(sharableConfigSchema);
 
 module.exports = {
+  /**
+   * Determine whether a valid configuration object was passed by user.
+   * @param {Object} config The config object to examine.
+   * @returns {Boolean} decision True if config is valid, false otherwise.
+   */
+  isValid: function(config) {
+    return validateCurrentConfig(config) || validateDepConfig(config);
+  },
 
-    /**
-	 * Determine whether a valid configuration object was passed by user.
-	 * @param {Object} config The config object to examine.
-	 * @returns {Boolean} decision True if config is valid, false otherwise.
-	 */
-    isValid: function(config) {
-        return (validateCurrentConfig(config) || validateDepConfig(config));
-    },
+  /**
+   * Determine whether the configuration object passed by user is a current one or a deprecated one.
+   * @param {Object} config The config object to examine.
+   * @returns {Boolean} decision True if config is deprecated, false otherwise.
+   */
+  isFormatDeprecated: function(config) {
+    // This function assumes that a VALID config object is passed, ie, the object has passed isValid() test above.
+    return !validateCurrentConfig(config);
+  },
 
-    /**
-	 * Determine whether the configuration object passed by user is a current one or a deprecated one.
-	 * @param {Object} config The config object to examine.
-	 * @returns {Boolean} decision True if config is deprecated, false otherwise.
-	 */
-    isFormatDeprecated: function(config) {
-        // This function assumes that a VALID config object is passed, ie, the object has passed isValid() test above.
-        return !validateCurrentConfig(config);
-    },
-
-    /**
-	 * Determine whether the supplied config is a valid Sharable Config
-	 * @param {Object} config The config object to examine.
-	 * @returns {Boolean} decision True if config is valid, false otherwise.
-	 */
-    isAValidSharableConfig: validateSharableConfig
-
+  /**
+   * Determine whether the supplied config is a valid Sharable Config
+   * @param {Object} config The config object to examine.
+   * @returns {Boolean} decision True if config is valid, false otherwise.
+   */
+  isAValidSharableConfig: validateSharableConfig
 };

--- a/lib/utils/fs-utils.js
+++ b/lib/utils/fs-utils.js
@@ -8,27 +8,25 @@
 const fs = require("fs");
 
 module.exports = {
-
-    isDirectory(path) {
-        try  {
-            return fs.statSync(path).isDirectory();
-        } catch (e) {
-            if (e.code === "ENOENT") {
-                return false;
-            }
-            throw e;
-        }
-    },
-
-    isFile(path) {
-        try  {
-            return fs.statSync(path).isFile();
-        } catch (e) {
-            if (e.code === "ENOENT") {
-                return false;
-            }
-            throw e;
-        }
+  isDirectory(path) {
+    try {
+      return fs.statSync(path).isDirectory();
+    } catch (e) {
+      if (e.code === "ENOENT") {
+        return false;
+      }
+      throw e;
     }
+  },
 
+  isFile(path) {
+    try {
+      return fs.statSync(path).isFile();
+    } catch (e) {
+      if (e.code === "ENOENT") {
+        return false;
+      }
+      throw e;
+    }
+  }
 };

--- a/lib/utils/js-utils.js
+++ b/lib/utils/js-utils.js
@@ -6,17 +6,16 @@
 "use strict";
 
 module.exports = {
-
-    /**
-	 * Check if given argument is a non-null, non-Array javascript object
-	 * @param {Object} possibleObject Argument to check for validity
-	 * @returns {Boolean} isObject true if given argument is object, false otherwise
-	 */
-    isStrictlyObject: function(possibleObject) {
-        return (
-            possibleObject !== null &&	//because typeof null equals 'object', make sure the object is non-null
-			typeof possibleObject === "object" &&
-			possibleObject.constructor.name === "Object"
-        );
-    }
+  /**
+   * Check if given argument is a non-null, non-Array javascript object
+   * @param {Object} possibleObject Argument to check for validity
+   * @returns {Boolean} isObject true if given argument is object, false otherwise
+   */
+  isStrictlyObject: function(possibleObject) {
+    return (
+      possibleObject !== null && //because typeof null equals 'object', make sure the object is non-null
+      typeof possibleObject === "object" &&
+      possibleObject.constructor.name === "Object"
+    );
+  }
 };

--- a/lib/utils/node-event-generator.js
+++ b/lib/utils/node-event-generator.js
@@ -10,40 +10,37 @@
  * @param {Object} emitter EventEmitter object
  */
 function EventGenerator(emitter) {
-    this.emitter = emitter;
+  this.emitter = emitter;
 
-    // Increase limit on number of listeners to allow more rules to subscribe peacefully
-    // This limit may further be increased in future
-    this.emitter.setMaxListeners(35);
+  // Increase limit on number of listeners to allow more rules to subscribe peacefully
+  // This limit may further be increased in future
+  this.emitter.setMaxListeners(35);
 }
 
 EventGenerator.prototype = {
+  constructor: EventGenerator,
 
-    constructor: EventGenerator,
+  /**
+   * emit event that the node with type = node.type is being entered
+   * @param {Object} node The AST node being entered
+   */
+  enterNode(node) {
+    this.emitter.emit(node.type, {
+      node,
+      exit: false
+    });
+  },
 
-    /**
-	 * emit event that the node with type = node.type is being entered
-	 * @param {Object} node The AST node being entered
-	 */
-    enterNode(node) {
-        this.emitter.emit(node.type, {
-            node,
-            exit: false
-        });
-    },
-
-    /**
-	 * emit event that the node with type = node.type is being left
-	 * @param {Object} node The AST node being left
-	 */
-    leaveNode(node) {
-        this.emitter.emit(node.type, {
-            node,
-            exit: true
-        });
-    }
-
+  /**
+   * emit event that the node with type = node.type is being left
+   * @param {Object} node The AST node being left
+   */
+  leaveNode(node) {
+    this.emitter.emit(node.type, {
+      node,
+      exit: true
+    });
+  }
 };
-
 
 module.exports = EventGenerator;

--- a/lib/utils/rule-inspector.js
+++ b/lib/utils/rule-inspector.js
@@ -6,44 +6,44 @@
 "use strict";
 
 let coreRuleSchema = require("../../config/schemas/core-rule"),
-    coreRuleResponseSchema = require("../../config/schemas/core-rule-response");
+  coreRuleResponseSchema = require("../../config/schemas/core-rule-response");
 
 let SchemaValidator = coreRuleSchema.SchemaValidator,
-    validateCoreRule = SchemaValidator.compile(coreRuleSchema.Schema),
-    validateCoreRuleResponse = SchemaValidator.compile(coreRuleResponseSchema.Schema);
+  validateCoreRule = SchemaValidator.compile(coreRuleSchema.Schema),
+  validateCoreRuleResponse = SchemaValidator.compile(
+    coreRuleResponseSchema.Schema
+  );
 
 module.exports = {
+  /**
+   * Determine whether the supplied argument qualifies as a core rule object
+   * @param {Object} ruleObject The object to validate
+   * @returns {Boolean} isValid True if object is a valid core solium rule, false otherwise.
+   */
+  isAValidRuleObject: validateCoreRule,
 
-    /**
-	 * Determine whether the supplied argument qualifies as a core rule object
-	 * @param {Object} ruleObject The object to validate
-	 * @returns {Boolean} isValid True if object is a valid core solium rule, false otherwise.
-	 */
-    isAValidRuleObject: validateCoreRule,
+  /**
+   * Determine whether the response given by a rule's create() method is a set of valid
+   * node names (event listeners) with their corresponding handler functions.
+   * @param {Object} ruleResponseObject Object to validate
+   * @returns {Boolean} isValid True if object is a valid rule response, false otherwise.
+   */
+  isAValidRuleResponseObject: validateCoreRuleResponse,
 
-    /**
-	 * Determine whether the response given by a rule's create() method is a set of valid
-	 * node names (event listeners) with their corresponding handler functions.
-	 * @param {Object} ruleResponseObject Object to validate
-	 * @returns {Boolean} isValid True if object is a valid rule response, false otherwise.
-	 */
-    isAValidRuleResponseObject: validateCoreRuleResponse,
+  /**
+   * Determine whether the options object supplied is valid according to the schema passed.
+   * @param {Array} options List of options
+   * @param {Array} listItemsSchema A list of schema objects defining schema for every item in the options list.
+   * @returns {Boolean} isValid True if options list is valid, false otherwise.
+   */
+  areValidOptionsPassed: function(options, listItemsSchema) {
+    let validateOptionsList = SchemaValidator.compile({
+      type: "array",
+      minItems: listItemsSchema.length,
+      additionalItems: false,
+      items: listItemsSchema
+    });
 
-    /**
-	 * Determine whether the options object supplied is valid according to the schema passed.
-	 * @param {Array} options List of options
-	 * @param {Array} listItemsSchema A list of schema objects defining schema for every item in the options list.
-	 * @returns {Boolean} isValid True if options list is valid, false otherwise.
-	 */
-    areValidOptionsPassed: function(options, listItemsSchema) {
-        let validateOptionsList = SchemaValidator.compile({
-            type: "array",
-            minItems: listItemsSchema.length,
-            additionalItems: false,
-            items: listItemsSchema
-        });
-
-        return validateOptionsList(options);
-    }
-
+    return validateOptionsList(options);
+  }
 };

--- a/lib/utils/rule-loader.js
+++ b/lib/utils/rule-loader.js
@@ -5,19 +5,21 @@
 
 "use strict";
 
-let path = require("path"), util = require("util");
-let isAValidSharableConfig = require("./config-inspector").isAValidSharableConfig;
+let path = require("path"),
+  util = require("util");
+let isAValidSharableConfig = require("./config-inspector")
+  .isAValidSharableConfig;
 
 let constants = {
-    SOLIUM_RULESET_ALL: "solium:all",
-    SOLIUM_RULESET_RECOMMENDED: "solium:all",
-    SOLIUM_CORE_RULES_DIRNAME: "rules",
-    SOLIUM_PLUGIN_PREFIX: "solium-plugin-",
-    SOLIUM_SHARABLE_CONFIG_PREFIX: "solium-config-"
+  SOLIUM_RULESET_ALL: "solium:all",
+  SOLIUM_RULESET_RECOMMENDED: "solium:all",
+  SOLIUM_CORE_RULES_DIRNAME: "rules",
+  SOLIUM_PLUGIN_PREFIX: "solium-plugin-",
+  SOLIUM_SHARABLE_CONFIG_PREFIX: "solium-config-"
 };
 
-constants.SOLIUM_CORE_RULES_DIRPATH = "../" + constants.SOLIUM_CORE_RULES_DIRNAME;
-
+constants.SOLIUM_CORE_RULES_DIRPATH =
+  "../" + constants.SOLIUM_CORE_RULES_DIRNAME;
 
 /**
  * Given a ruleset name, determine whether its a core set or a sharable config and load the rule config accordingly.
@@ -25,44 +27,59 @@ constants.SOLIUM_CORE_RULES_DIRPATH = "../" + constants.SOLIUM_CORE_RULES_DIRNAM
  * @returns {Object} ruleConfigs Set of rule configs exported by the upstream ruleset.
  */
 function resolveUpstream(upstream) {
-    let coreRulesetRegExp = /^solium:[a-z_]+$/;
+  let coreRulesetRegExp = /^solium:[a-z_]+$/;
 
-    // Determine whether upstream is a solium core ruleset or a sharable config.
-    if (coreRulesetRegExp.test(upstream)) {
-        try {
-            return require("../../config/rulesets/solium-" + upstream.split(":") [1]).rules;
-        } catch (e) {
-            throw new Error("\"" + upstream + "\" is not a core ruleset.");
-        }
-    }
-
-    // If flow reaches here, it means upstream is a sharable config.
-    let configName = constants.SOLIUM_SHARABLE_CONFIG_PREFIX + upstream, config;
-
+  // Determine whether upstream is a solium core ruleset or a sharable config.
+  if (coreRulesetRegExp.test(upstream)) {
     try {
-        config = require(configName);
+      return require("../../config/rulesets/solium-" + upstream.split(":")[1])
+        .rules;
     } catch (e) {
-        if (e.code === "MODULE_NOT_FOUND") {
-            throw new Error(
-                "The sharable config \"" + configName + "\" is not installed. " +
-				"If Solium is installed globally, install the config globally using " +
-				"\"npm install -g " + configName + "\". Else install locally using " +
-				"\"npm install --save-dev " + configName + "\"."
-            );
-        }
+      throw new Error('"' + upstream + '" is not a core ruleset.');
+    }
+  }
 
-        throw new Error("The sharable config \"" + configName + "\" could not be loaded: " + e.message);
+  // If flow reaches here, it means upstream is a sharable config.
+  let configName = constants.SOLIUM_SHARABLE_CONFIG_PREFIX + upstream,
+    config;
+
+  try {
+    config = require(configName);
+  } catch (e) {
+    if (e.code === "MODULE_NOT_FOUND") {
+      throw new Error(
+        'The sharable config "' +
+          configName +
+          '" is not installed. ' +
+          "If Solium is installed globally, install the config globally using " +
+          '"npm install -g ' +
+          configName +
+          '". Else install locally using ' +
+          '"npm install --save-dev ' +
+          configName +
+          '".'
+      );
     }
 
-    if (isAValidSharableConfig(config)) {
-        return config.rules;
-    }
+    throw new Error(
+      'The sharable config "' +
+        configName +
+        '" could not be loaded: ' +
+        e.message
+    );
+  }
 
-    throw new Error("Invalid sharable config \"" +
-		configName + "\". AJV message:\n" + util.inspect(isAValidSharableConfig.errors));
+  if (isAValidSharableConfig(config)) {
+    return config.rules;
+  }
+
+  throw new Error(
+    'Invalid sharable config "' +
+      configName +
+      '". AJV message:\n' +
+      util.inspect(isAValidSharableConfig.errors)
+  );
 }
-
-
 
 /**
  * Create provided plugin's default rule configuration
@@ -71,16 +88,14 @@ function resolveUpstream(upstream) {
  * @returns {Object} config Rule configuration object for the given plugin
  */
 function resolvePluginConfig(name, plugin) {
-    let config = {};
+  let config = {};
 
-    Object.keys(plugin.rules).forEach(function(ruleName) {
-        config [name + "/" + ruleName] = plugin.rules [ruleName].meta.docs.type;
-    });
+  Object.keys(plugin.rules).forEach(function(ruleName) {
+    config[name + "/" + ruleName] = plugin.rules[ruleName].meta.docs.type;
+  });
 
-    return config;
+  return config;
 }
-
-
 
 /**
  * Load rule definitions (rule objects) from Solium's core rule directory & from pre-installed linter plugins.
@@ -88,44 +103,45 @@ function resolvePluginConfig(name, plugin) {
  * @returns {Object} ruleDefs Object of key: rule name & value: rule object exported by corresponding Solium rule definition.
  */
 function load(listOfRules) {
-    let ruleDefs = {};
+  let ruleDefs = {};
 
-    listOfRules.forEach(function(name) {
-        // If the rule is part of a plugin, first load the plugin assuming that it has already been installed
-        // in the same scope as Solium (global/project). Then return the appropriate rule from that plugin.
-        if (name.indexOf("/") > -1) {
-            let parts = name.split("/"),
-                pluginName = constants.SOLIUM_PLUGIN_PREFIX + parts [0], ruleName = parts [1], plugin;
+  listOfRules.forEach(function(name) {
+    // If the rule is part of a plugin, first load the plugin assuming that it has already been installed
+    // in the same scope as Solium (global/project). Then return the appropriate rule from that plugin.
+    if (name.indexOf("/") > -1) {
+      let parts = name.split("/"),
+        pluginName = constants.SOLIUM_PLUGIN_PREFIX + parts[0],
+        ruleName = parts[1],
+        plugin;
 
-            try {
-                plugin = require(pluginName);
-            } catch (e) {
-                throw new Error("Unable to load Plugin \"" + pluginName + "\".");
-            }
+      try {
+        plugin = require(pluginName);
+      } catch (e) {
+        throw new Error('Unable to load Plugin "' + pluginName + '".');
+      }
 
-            // No need to verify whether this rule's implementation exists & is valid or not.
-            // That is done at a later stage in solium.js itself using rule-inspector.
-            // TODO: Examine "peerDependencies" of the plugin to ensure its compatible with current version of Solium.
-            return ruleDefs [name] = plugin.rules [ruleName];
-        }
+      // No need to verify whether this rule's implementation exists & is valid or not.
+      // That is done at a later stage in solium.js itself using rule-inspector.
+      // TODO: Examine "peerDependencies" of the plugin to ensure its compatible with current version of Solium.
+      return (ruleDefs[name] = plugin.rules[ruleName]);
+    }
 
-        // If we're here, it means the rule is just a regular core rule :)
-        let ruleFile = path.join(constants.SOLIUM_CORE_RULES_DIRPATH, name);
+    // If we're here, it means the rule is just a regular core rule :)
+    let ruleFile = path.join(constants.SOLIUM_CORE_RULES_DIRPATH, name);
 
-        try {
-            ruleDefs [name] = require(ruleFile);
-        } catch (e) {
-            throw new Error("Unable to read " + ruleFile);
-        }
-    });
+    try {
+      ruleDefs[name] = require(ruleFile);
+    } catch (e) {
+      throw new Error("Unable to read " + ruleFile);
+    }
+  });
 
-    return ruleDefs;
+  return ruleDefs;
 }
 
-
 module.exports = {
-    load: load,
-    constants: constants,
-    resolveUpstream: resolveUpstream,
-    resolvePluginConfig: resolvePluginConfig
+  load: load,
+  constants: constants,
+  resolveUpstream: resolveUpstream,
+  resolvePluginConfig: resolvePluginConfig
 };

--- a/lib/utils/source-code-utils.js
+++ b/lib/utils/source-code-utils.js
@@ -5,23 +5,24 @@
 
 "use strict";
 
-const { EOL } = require("os"), astUtils = require("./ast-utils");
+const { EOL } = require("os"),
+  astUtils = require("./ast-utils");
 const INHERITABLE_METHODS = [
-    "isASTNode",
-    "getParent",
-    "getColumn",
-    "getEndingColumn",
-    "getLine",
-    "getEndingLine",
-    "isAChildOf",
-    "isBlockStatement",
-    "isBreakStatement",
-    "isExpression",
-    "isAssignment",
-    "isUpdate",
-    "isMember",
-    "isIfStatement",
-    "isLoopStatement"
+  "isASTNode",
+  "getParent",
+  "getColumn",
+  "getEndingColumn",
+  "getLine",
+  "getEndingLine",
+  "isAChildOf",
+  "isBlockStatement",
+  "isBreakStatement",
+  "isExpression",
+  "isAssignment",
+  "isUpdate",
+  "isMember",
+  "isIfStatement",
+  "isLoopStatement"
 ];
 
 /**
@@ -29,123 +30,120 @@ const INHERITABLE_METHODS = [
  * @param {String} sourceCodeText source code being linted
  */
 function SourceCode(sourceCodeText) {
-    this.text = sourceCodeText;
+  this.text = sourceCodeText;
 }
 
 SourceCode.prototype = {
+  constructor: SourceCode,
 
-    constructor: SourceCode,
+  /**
+   * Function to retrieve the source code text being linted. Returns the complete source code if no node specified
+   * @param {Object} node The AST node whose source code (specifically) is needed
+   * @param {Integer} beforeCount Include beforeCount number of characters prior to the node's code
+   * @param {Integer} afterCount Include afterCount number of characters following the node's code
+   * @returns {String} sourceCodeText source code of the specified node plus extra characters specified by beforeCount & afterCount
+   */
+  getText: function(node, beforeCount, afterCount) {
+    let sourceCodeText = this.text;
 
-    /**
-	 * Function to retrieve the source code text being linted. Returns the complete source code if no node specified
-	 * @param {Object} node The AST node whose source code (specifically) is needed
-	 * @param {Integer} beforeCount Include beforeCount number of characters prior to the node's code
-	 * @param {Integer} afterCount Include afterCount number of characters following the node's code
-	 * @returns {String} sourceCodeText source code of the specified node plus extra characters specified by beforeCount & afterCount
-	 */
-    getText: function(node, beforeCount, afterCount) {
-        let sourceCodeText = this.text;
+    if (node) {
+      if (astUtils.isASTNode(node)) {
+        return this.text.slice(
+          Math.max(0, node.start - (Math.abs(beforeCount) || 0)),
+          node.end + (Math.abs(afterCount) || 0)
+        );
+      }
 
-        if (node) {
-            if (astUtils.isASTNode(node)) {
-
-                return this.text.slice(
-                    Math.max(0, node.start - (Math.abs(beforeCount) || 0)),
-                    node.end + (Math.abs(afterCount) || 0)
-                );
-
-            }
-			
-            throw new Error("Invalid Node object");
-        }
-
-        return sourceCodeText;
-    },
-
-    getNextChar: function(node) {
-        if (node && astUtils.isASTNode(node)) {
-            //return null if node is the last node,i.e., no characters after this node's code
-            return this.text [node.end] || null;
-        }
-		
-        throw new Error("Invalid Node object");
-    },
-
-    getPrevChar: function(node) {
-        if (node && astUtils.isASTNode(node)) {
-            //return null if node.start is 0, i.e., node's code is the first thing in the source code text
-            return this.text [node.start - 1] || null;
-        }
-
-        throw new Error("Invalid Node object");
-    },
-
-    getNextChars: function(node, charCount) {
-        if (node && astUtils.isASTNode(node)) {
-            return this.text.slice(
-                node.end, node.end + (Math.abs(charCount) || 0)
-            );
-        }
-		
-        throw new Error("Invalid Node object");
-    },
-
-    getPrevChars: function(node, charCount) {
-        if (node && astUtils.isASTNode(node)) {
-            return this.text.slice(
-                Math.max(0, node.start - (Math.abs(charCount) || 0)),
-                node.start
-            );
-        }
-		
-        throw new Error("Invalid Node object");
-    },
-
-    /**
-	 * Get the entire string between 2 nodes - ranging from prevNode.end to currentNode.start (exclusive)
-	 * @param {ASTNode} prevNode The 1st AST Node
-	 * @param {ASTNode} currentNode The 2nd AST Node
-	 * @returns {String} charsBetweenNodes The entire string netween the 2 nodes
-	 */
-    getStringBetweenNodes: function(prevNode, currentNode) {
-        if (
-            prevNode && astUtils.isASTNode(prevNode) &&
-			currentNode && astUtils.isASTNode(currentNode) &&
-			prevNode.start <= currentNode.start
-        ) {
-            return this.text.slice(prevNode.end, currentNode.start);
-        }
-
-        throw new Error("Invalid argument for one or both nodes");
-    },
-
-    /**
-	 * Get the complete text on line lineNumber (excluding the EOL)
-	 * @param {Integer} lineNumber Line number whose text to get
-	 * @returns {String} code Source code text on the specified line
-	 */
-    getTextOnLine: function(lineNumber) {
-        //establish a cache the first time this function is called, so subsequent calls don't have to split the text again
-        if (!this.sourceCodeTextLines) {
-            this.sourceCodeTextLines = this.text.split(EOL);
-        }
-
-        if (
-            lineNumber && typeof lineNumber === "number" &&
-			parseInt(lineNumber) === lineNumber &&	//ensure that argument is an INTEGER
-			lineNumber >= 1 && lineNumber <= this.sourceCodeTextLines.length
-        ) {
-            return this.sourceCodeTextLines [lineNumber - 1];
-        }
-
-        throw new Error("Line number " + lineNumber + " invalid or out of bounds.");
+      throw new Error("Invalid Node object");
     }
 
+    return sourceCodeText;
+  },
+
+  getNextChar: function(node) {
+    if (node && astUtils.isASTNode(node)) {
+      //return null if node is the last node,i.e., no characters after this node's code
+      return this.text[node.end] || null;
+    }
+
+    throw new Error("Invalid Node object");
+  },
+
+  getPrevChar: function(node) {
+    if (node && astUtils.isASTNode(node)) {
+      //return null if node.start is 0, i.e., node's code is the first thing in the source code text
+      return this.text[node.start - 1] || null;
+    }
+
+    throw new Error("Invalid Node object");
+  },
+
+  getNextChars: function(node, charCount) {
+    if (node && astUtils.isASTNode(node)) {
+      return this.text.slice(node.end, node.end + (Math.abs(charCount) || 0));
+    }
+
+    throw new Error("Invalid Node object");
+  },
+
+  getPrevChars: function(node, charCount) {
+    if (node && astUtils.isASTNode(node)) {
+      return this.text.slice(
+        Math.max(0, node.start - (Math.abs(charCount) || 0)),
+        node.start
+      );
+    }
+
+    throw new Error("Invalid Node object");
+  },
+
+  /**
+   * Get the entire string between 2 nodes - ranging from prevNode.end to currentNode.start (exclusive)
+   * @param {ASTNode} prevNode The 1st AST Node
+   * @param {ASTNode} currentNode The 2nd AST Node
+   * @returns {String} charsBetweenNodes The entire string netween the 2 nodes
+   */
+  getStringBetweenNodes: function(prevNode, currentNode) {
+    if (
+      prevNode &&
+      astUtils.isASTNode(prevNode) &&
+      currentNode &&
+      astUtils.isASTNode(currentNode) &&
+      prevNode.start <= currentNode.start
+    ) {
+      return this.text.slice(prevNode.end, currentNode.start);
+    }
+
+    throw new Error("Invalid argument for one or both nodes");
+  },
+
+  /**
+   * Get the complete text on line lineNumber (excluding the EOL)
+   * @param {Integer} lineNumber Line number whose text to get
+   * @returns {String} code Source code text on the specified line
+   */
+  getTextOnLine: function(lineNumber) {
+    //establish a cache the first time this function is called, so subsequent calls don't have to split the text again
+    if (!this.sourceCodeTextLines) {
+      this.sourceCodeTextLines = this.text.split(EOL);
+    }
+
+    if (
+      lineNumber &&
+      typeof lineNumber === "number" &&
+      parseInt(lineNumber) === lineNumber && //ensure that argument is an INTEGER
+      lineNumber >= 1 &&
+      lineNumber <= this.sourceCodeTextLines.length
+    ) {
+      return this.sourceCodeTextLines[lineNumber - 1];
+    }
+
+    throw new Error("Line number " + lineNumber + " invalid or out of bounds.");
+  }
 };
 
 INHERITABLE_METHODS.forEach(function(methodName) {
-    SourceCode.prototype [methodName] = astUtils [methodName];
+  SourceCode.prototype[methodName] = astUtils[methodName];
 });
-
 
 module.exports = SourceCode;

--- a/package-lock.json
+++ b/package-lock.json
@@ -528,6 +528,16 @@
         }
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.6.0.tgz",
+      "integrity": "sha512-floiaI4F7hRkTrFe8V2ItOK97QYrX75DjmdzmVITZoAP6Cn06oEDPQRsO6MlHEP/u2SxI3xQ52Kpjw6j5WGfeQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
@@ -638,6 +648,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+    },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -1832,6 +1848,12 @@
       "requires": {
         "isarray": "1.0.0"
       }
+    },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
     },
     "js-string-escape": {
       "version": "1.0.1",
@@ -3973,6 +3995,12 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+    },
+    "prettier": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.5.tgz",
+      "integrity": "sha512-4M90mfvLz6yRf2Dhzd+xPIE6b4xkI8nHMJhsSm9IlfG17g6wujrrm7+H1X8x52tC4cSNm6HmuhCUSNe6Hd5wfw==",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -48,8 +48,10 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^4.13.0",
+    "eslint-plugin-prettier": "^2.6.0",
     "mocha": "^3.4.2",
     "nyc": "^11.2.1",
+    "prettier": "^1.13.5",
     "should": "^11.0.0",
     "solium-config-test": "0.0.1",
     "solium-config-test-invalid-schema": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   },
   "scripts": {
     "test": "nyc --reporter=text --reporter=html mocha --require should --reporter spec --recursive",
-    "lint": "eslint lib/ test/ bin/ config/"
+    "lint": "node_modules/prettier/bin-prettier.js --write \"lib/**/*.js\" --write \"test/**/*.js\" --write \"bin/**/*.js\" --write \"config/**/*.js\"",
+    "precommit": "pretty-quick --staged"
   },
   "keywords": [
     "lint",
@@ -49,9 +50,11 @@
     "chai": "^3.5.0",
     "eslint": "^4.13.0",
     "eslint-plugin-prettier": "^2.6.0",
+    "husky": "^0.14.3",
     "mocha": "^3.4.2",
     "nyc": "^11.2.1",
     "prettier": "^1.13.5",
+    "pretty-quick": "^1.6.0",
     "should": "^11.0.0",
     "solium-config-test": "0.0.1",
     "solium-config-test-invalid-schema": "0.0.0",

--- a/test/config/rulesets/solium-all.js
+++ b/test/config/rulesets/solium-all.js
@@ -5,30 +5,31 @@
 
 "use strict";
 
-let fs = require("fs"), path = require("path");
+let fs = require("fs"),
+  path = require("path");
 let rsSoliumAll = require("../../../config/rulesets/solium-all");
 let JS_EXT = ".js";
 
 describe("Tests for solium-all.js ruleset", function() {
+  it("should have a set of properties", function(done) {
+    rsSoliumAll.should.be.type("object");
+    rsSoliumAll.should.have.ownProperty("rules");
+    rsSoliumAll.rules.should.be.type("object");
 
-    it("should have a set of properties", function(done) {
-        rsSoliumAll.should.be.type("object");
-        rsSoliumAll.should.have.ownProperty("rules");
-        rsSoliumAll.rules.should.be.type("object");
+    done();
+  });
 
-        done();
+  it("should have an entry for every rule file in lib/rules directory", function(done) {
+    let listOfRuleFiles = fs.readdirSync(__dirname + "/../../../lib/rules/");
+
+    listOfRuleFiles.forEach(function(filename) {
+      if (path.extname(filename) === JS_EXT) {
+        rsSoliumAll.rules.should.have.ownProperty(
+          filename.slice(0, -JS_EXT.length)
+        );
+      }
     });
 
-    it("should have an entry for every rule file in lib/rules directory", function(done) {
-        let listOfRuleFiles = fs.readdirSync(__dirname + "/../../../lib/rules/");
-
-        listOfRuleFiles.forEach(function(filename) {
-            if (path.extname(filename) === JS_EXT) {
-                rsSoliumAll.rules.should.have.ownProperty(filename.slice(0, -JS_EXT.length));
-            }
-        });
-
-        done();
-    });
-
+    done();
+  });
 });

--- a/test/config/rulesets/solium-recommended.js
+++ b/test/config/rulesets/solium-recommended.js
@@ -5,30 +5,31 @@
 
 "use strict";
 
-let fs = require("fs"), path = require("path");
+let fs = require("fs"),
+  path = require("path");
 let rsSoliumAll = require("../../../config/rulesets/solium-recommended");
 let JS_EXT = ".js";
 
 describe("Tests for solium-recommended.js ruleset", function() {
+  it("should have a set of properties", function(done) {
+    rsSoliumAll.should.be.type("object");
+    rsSoliumAll.should.have.ownProperty("rules");
+    rsSoliumAll.rules.should.be.type("object");
 
-    it("should have a set of properties", function(done) {
-        rsSoliumAll.should.be.type("object");
-        rsSoliumAll.should.have.ownProperty("rules");
-        rsSoliumAll.rules.should.be.type("object");
+    done();
+  });
 
-        done();
+  it("should have an entry for every rule file in lib/rules directory", function(done) {
+    let listOfRuleFiles = fs.readdirSync(__dirname + "/../../../lib/rules/");
+
+    listOfRuleFiles.forEach(function(filename) {
+      if (path.extname(filename) === JS_EXT) {
+        rsSoliumAll.rules.should.have.ownProperty(
+          filename.slice(0, -JS_EXT.length)
+        );
+      }
     });
 
-    it("should have an entry for every rule file in lib/rules directory", function(done) {
-        let listOfRuleFiles = fs.readdirSync(__dirname + "/../../../lib/rules/");
-
-        listOfRuleFiles.forEach(function(filename) {
-            if (path.extname(filename) === JS_EXT) {
-                rsSoliumAll.rules.should.have.ownProperty(filename.slice(0, -JS_EXT.length));
-            }
-        });
-
-        done();
-    });
-
+    done();
+  });
 });

--- a/test/config/schemas/plugin.js
+++ b/test/config/schemas/plugin.js
@@ -5,201 +5,210 @@
 
 "use strict";
 
-let pluginSchema = require("../../../config/schemas/plugin.js"), isAValidPlugin = pluginSchema.validationFunc;
+let pluginSchema = require("../../../config/schemas/plugin.js"),
+  isAValidPlugin = pluginSchema.validationFunc;
 
 /* eslint-disable no-unused-vars */
 
 describe("Checking Plugin Schema", function() {
+  let sampleRule = {
+    meta: {
+      docs: {
+        recommended: true,
+        type: "error",
+        description: "This is a rule",
+        replacedBy: ["new-rule"]
+      },
+      schema: [],
+      fixable: "code",
+      deprecated: true
+    },
+    create: function(context) {}
+  };
 
-    let sampleRule = {
-        "meta": {
-            "docs": {
-                "recommended": true,
-                "type": "error",
-                "description": "This is a rule",
-                "replacedBy": ["new-rule"]
-            },
-            "schema": [],
-            "fixable": "code",
-            "deprecated": true
-        },
-        "create": function(context) {}
+  it("should expose a set of functions", function(done) {
+    pluginSchema.should.be.type("object");
+    pluginSchema.should.be.size(2);
+
+    pluginSchema.should.have.ownProperty("Schema");
+    pluginSchema.Schema.should.be.type("object");
+
+    pluginSchema.should.have.ownProperty("validationFunc");
+    pluginSchema.validationFunc.should.be.type("function");
+
+    done();
+  });
+
+  it("should accept valid plugin objects", function(done) {
+    let plugin = {
+      rules: {
+        "sample-rule-1": sampleRule,
+        "sample-rule-2": sampleRule
+      },
+      meta: {
+        description: "This is my badass plugin"
+      }
     };
 
+    isAValidPlugin(plugin).should.equal(true);
 
-    it("should expose a set of functions", function(done) {
-        pluginSchema.should.be.type("object");
-        pluginSchema.should.be.size(2);
+    plugin = {
+      rules: {
+        a: sampleRule,
+        b: sampleRule
+      },
+      meta: {
+        description: "c"
+      }
+    };
 
-        pluginSchema.should.have.ownProperty("Schema");
-        pluginSchema.Schema.should.be.type("object");
+    isAValidPlugin(plugin).should.equal(true);
 
-        pluginSchema.should.have.ownProperty("validationFunc");
-        pluginSchema.validationFunc.should.be.type("function");
+    plugin = {
+      rules: {},
+      meta: {
+        description: "c"
+      }
+    };
 
-        done();
+    isAValidPlugin(plugin).should.equal(true);
+
+    done();
+  });
+
+  it("should reject invalid plugin objects", function(done) {
+    let invalidPlugins = [
+      -1,
+      0,
+      1,
+      89.189,
+      "hello world",
+      null,
+      function() {},
+      undefined,
+      [],
+      true,
+      false
+    ];
+
+    // no 'rules'
+    invalidPlugins.push({
+      meta: {
+        description: "This is my badass plugin"
+      }
     });
 
-    it("should accept valid plugin objects", function(done) {
-
-        let plugin = {
-            "rules": {
-                "sample-rule-1": sampleRule,
-                "sample-rule-2": sampleRule
-            },
-            "meta": {
-                "description": "This is my badass plugin"
-            }
-        };
-
-        isAValidPlugin(plugin).should.equal(true);
-
-        plugin = {
-            "rules": {
-                "a": sampleRule,
-                "b": sampleRule
-            },
-            "meta": {
-                "description": "c"
-            }
-        };
-
-        isAValidPlugin(plugin).should.equal(true);
-
-        plugin = {
-            "rules": {},
-            "meta": {
-                "description": "c"
-            }
-        };
-
-        isAValidPlugin(plugin).should.equal(true);
-
-        done();
+    // no "meta"
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": sampleRule,
+        "sample-rule-2": sampleRule
+      }
     });
 
-    it("should reject invalid plugin objects", function(done) {
-        let invalidPlugins = [-1, 0, 1, 89.189, "hello world", null, function(){}, undefined, [], true, false];
-
-        // no 'rules'
-        invalidPlugins.push({
-            "meta": {
-                "description": "This is my badass plugin"
-            }
-        });
-
-        // no "meta"
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": sampleRule,
-                "sample-rule-2": sampleRule
-            }
-        });
-
-        // invalid rule
-        invalidPlugins.push({
-            "rules": "hello world",
-            "meta": {
-                "description": "This is my badass plugin"
-            }
-        });
-
-        // invalid meta
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": sampleRule
-            },
-            "meta": []
-        });
-
-        // invalid rule name
-        invalidPlugins.push({
-            "rules": {
-                "": sampleRule
-            },
-            "meta": {
-                "description": "This is my badass plugin"
-            }
-        });
-
-        // invalid rule definition
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": null
-            },
-            "meta": {
-                "description": "This is my badass plugin"
-            }
-        });
-
-        // no meta.description
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": sampleRule,
-                "sample-rule-2": sampleRule
-            },
-            "meta": {}
-        });
-
-        // empty meta.description
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": sampleRule,
-                "sample-rule-2": sampleRule
-            },
-            "meta": {
-                "description": ""
-            }
-        });
-
-        // invalid meta.description value
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": sampleRule,
-                "sample-rule-2": sampleRule
-            },
-            "meta": {
-                "description": 190828
-            }
-        });
-
-        // extra property
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": sampleRule,
-                "sample-rule-2": sampleRule
-            },
-            "meta": {
-                "description": "This is my badass plugin"
-            },
-            "randombullshit": {}
-        });
-
-        // extra property in meta
-        invalidPlugins.push({
-            "rules": {
-                "sample-rule-1": sampleRule,
-                "sample-rule-2": sampleRule
-            },
-            "meta": {
-                "description": "This is my badass plugin",
-                "morebullshit": true
-            }
-        });
-
-        // All the plugin definitions should be invalid because of precisely 1 error
-        // This forces us to test all possibilities separately.
-        invalidPlugins.forEach(function(p) {
-            isAValidPlugin(p).should.equal(false);
-            isAValidPlugin.errors.should.have.size(1);
-        });
-
-        isAValidPlugin({}).should.equal(false);
-        isAValidPlugin.errors.should.have.size(2);
-
-        done();
+    // invalid rule
+    invalidPlugins.push({
+      rules: "hello world",
+      meta: {
+        description: "This is my badass plugin"
+      }
     });
 
+    // invalid meta
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": sampleRule
+      },
+      meta: []
+    });
+
+    // invalid rule name
+    invalidPlugins.push({
+      rules: {
+        "": sampleRule
+      },
+      meta: {
+        description: "This is my badass plugin"
+      }
+    });
+
+    // invalid rule definition
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": null
+      },
+      meta: {
+        description: "This is my badass plugin"
+      }
+    });
+
+    // no meta.description
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": sampleRule,
+        "sample-rule-2": sampleRule
+      },
+      meta: {}
+    });
+
+    // empty meta.description
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": sampleRule,
+        "sample-rule-2": sampleRule
+      },
+      meta: {
+        description: ""
+      }
+    });
+
+    // invalid meta.description value
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": sampleRule,
+        "sample-rule-2": sampleRule
+      },
+      meta: {
+        description: 190828
+      }
+    });
+
+    // extra property
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": sampleRule,
+        "sample-rule-2": sampleRule
+      },
+      meta: {
+        description: "This is my badass plugin"
+      },
+      randombullshit: {}
+    });
+
+    // extra property in meta
+    invalidPlugins.push({
+      rules: {
+        "sample-rule-1": sampleRule,
+        "sample-rule-2": sampleRule
+      },
+      meta: {
+        description: "This is my badass plugin",
+        morebullshit: true
+      }
+    });
+
+    // All the plugin definitions should be invalid because of precisely 1 error
+    // This forces us to test all possibilities separately.
+    invalidPlugins.forEach(function(p) {
+      isAValidPlugin(p).should.equal(false);
+      isAValidPlugin.errors.should.have.size(1);
+    });
+
+    isAValidPlugin({}).should.equal(false);
+    isAValidPlugin.errors.should.have.size(2);
+
+    done();
+  });
 });
 
 /* eslint-enable no-unused-vars */

--- a/test/extras/custom-rules-file.js
+++ b/test/extras/custom-rules-file.js
@@ -1,46 +1,47 @@
 "use strict";
 
 module.exports = {
+  CUSTOM_RULE: function(context) {
+    context.on("IfStatement", function(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-    "CUSTOM_RULE": function(context) {
-        context.on("IfStatement", function(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+      context.report({
+        node: emitted.node,
+        message:
+          "*******************THIS IS MY CUSTOM RULE**********************"
+      });
+    });
+  },
 
-            context.report({
-                node: emitted.node,
-                message: "*******************THIS IS MY CUSTOM RULE**********************"
-            });
-        });
-    },
+  //this rule overlaps a built-in rule
+  lbrace: function(context) {
+    context.on("IfStatement", function(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-    //this rule overlaps a built-in rule
-    "lbrace": function(context) {
-        context.on("IfStatement", function(emitted) {
-            if (emitted.exit) {
-                return;
-            }
+      context.report({
+        node: emitted.node,
+        message:
+          "*******************THIS IS MY CUSTOM RULE**********************"
+      });
+    });
+  },
 
-            context.report({
-                node: emitted.node,
-                message: "*******************THIS IS MY CUSTOM RULE**********************"
-            });
-        });
-    },
+  //this rule is defined in this file, but shouldn't be included in rules because config.rules doesn't enable it
+  "not-included": function(context) {
+    context.on("IfStatement", function(emitted) {
+      if (emitted.exit) {
+        return;
+      }
 
-    //this rule is defined in this file, but shouldn't be included in rules because config.rules doesn't enable it
-    "not-included": function(context) {
-        context.on("IfStatement", function(emitted) {
-            if (emitted.exit) {
-                return;
-            }
-
-            context.report({
-                node: emitted.node,
-                message: "*******************THIS IS MY CUSTOM RULE**********************"
-            });
-        });
-    }
-
+      context.report({
+        node: emitted.node,
+        message:
+          "*******************THIS IS MY CUSTOM RULE**********************"
+      });
+    });
+  }
 };

--- a/test/lib/autofix/merge-fixer-packets.js
+++ b/test/lib/autofix/merge-fixer-packets.js
@@ -5,84 +5,84 @@
 
 "use strict";
 
-
 let mfp = require("../../../lib/autofix/merge-fixer-packets"),
-    ruleFixer = require("../../../lib/autofix/rule-fixer");
-
+  ruleFixer = require("../../../lib/autofix/rule-fixer");
 
 describe("check exposed API", function() {
+  it("should expose a single function", function(done) {
+    mfp.should.be.type("function");
+    done();
+  });
 
-    it("should expose a single function", function(done) {
-        mfp.should.be.type("function");
-        done();
-    });
+  it("should handle all valid inputs", function(done) {
+    let sourceCode = "abcdefghijklmnopqrstuvwxyz?<>,.!~",
+      codeModification = "123d@@@efgh+++lop===qr$$$stuvwz*###"; // 'abc' in start & '!~' in end are left out as-it-is
+    let rf = new ruleFixer("code");
 
-    it("should handle all valid inputs", function(done) {
-        let sourceCode = "abcdefghijklmnopqrstuvwxyz?<>,.!~",
-            codeModification = "123d@@@efgh+++lop===qr$$$stuvwz*###";	// 'abc' in start & '!~' in end are left out as-it-is
-        let rf = new ruleFixer("code");
+    // fixerPackets represent the outputs of the functions exposed by rule-fixer
+    // when a particular node & text are provided
+    let fixerPackets = [
+      rf.insertTextAfter({ type: "a", start: 0, end: 3 }, "123"),
+      rf.insertTextBefore({ type: "a", start: 4, end: 6 }, "@@@"),
+      rf.replaceText({ type: "a", start: 8, end: 11 }, "+++"),
+      rf.remove({ type: "a", start: 12, end: 14 }),
+      rf.insertTextAfterRange([15, 16], "==="),
+      rf.insertTextBeforeRange([18, 22], "$$$"),
+      rf.removeRange([23, 25]),
+      rf.replaceChar(26, "*"),
+      rf.replaceTextRange([27, 31], "###")
+    ];
 
-        // fixerPackets represent the outputs of the functions exposed by rule-fixer
-        // when a particular node & text are provided
-        let fixerPackets = [
-            rf.insertTextAfter({type: "a", start: 0, end: 3}, "123"),
-            rf.insertTextBefore({type: "a", start: 4, end: 6}, "@@@"),
-            rf.replaceText({type: "a", start: 8, end: 11}, "+++"),
-            rf.remove({type: "a", start: 12, end: 14}),
-            rf.insertTextAfterRange([15, 16], "==="),
-            rf.insertTextBeforeRange([18, 22], "$$$"),
-            rf.removeRange([23, 25]),
-            rf.replaceChar(26, "*"),
-            rf.replaceTextRange([27, 31], "###")
-        ];
+    // Send a single packet as object, should be returned as-it-is
+    let result = mfp(fixerPackets[0], sourceCode);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(fixerPackets[0].range[0]);
+    result.range[1].should.equal(fixerPackets[0].range[1]);
+    result.text.should.equal(fixerPackets[0].text);
 
-        // Send a single packet as object, should be returned as-it-is
-        let result = mfp(fixerPackets [0], sourceCode);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(fixerPackets [0].range [0]);
-        result.range [1].should.equal(fixerPackets [0].range [1]);
-        result.text.should.equal(fixerPackets [0].text);
+    // Send a single packet as item of array, should return the packet itself
+    result = mfp(fixerPackets.slice(0, 1), sourceCode);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(fixerPackets[0].range[0]);
+    result.range[1].should.equal(fixerPackets[0].range[1]);
+    result.text.should.equal(fixerPackets[0].text);
 
-        // Send a single packet as item of array, should return the packet itself
-        result = mfp(fixerPackets.slice(0, 1), sourceCode);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(fixerPackets [0].range [0]);
-        result.range [1].should.equal(fixerPackets [0].range [1]);
-        result.text.should.equal(fixerPackets [0].text);
+    // Send a list of (shuffled) packets, should return 1 final packet that
+    // ranges from start to end, accounting for all text changes
+    result = mfp(fixerPackets, sourceCode);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(fixerPackets[0].range[0]);
+    result.range[1].should.equal(fixerPackets.slice(-1)[0].range[1]);
+    result.text.should.equal(codeModification);
 
-        // Send a list of (shuffled) packets, should return 1 final packet that
-        // ranges from start to end, accounting for all text changes
-        result = mfp(fixerPackets, sourceCode);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(fixerPackets [0].range [0]);
-        result.range [1].should.equal(fixerPackets.slice(-1) [0].range [1]);
-        result.text.should.equal(codeModification);
+    done();
+  });
 
-        done();
-    });
+  it("should handle all logically invalid inputs", function(done) {
+    // Since merge-fixer-packets is a module called internally, it is guaranteed to receive a
+    // valid fixer packet or array of packets. Therefore we need not test it for all the fuzzy values.
 
-    it("should handle all logically invalid inputs", function(done) {
-        // Since merge-fixer-packets is a module called internally, it is guaranteed to receive a
-        // valid fixer packet or array of packets. Therefore we need not test it for all the fuzzy values.
-		
-        // overlapping ranges
-        mfp.bind(
-            mfp, [{range: [2, 5], text: ""}, {range: [4, 8], text: "%%%"}], "abcdefghijk"
-        ).should.throw();
+    // overlapping ranges
+    mfp
+      .bind(
+        mfp,
+        [{ range: [2, 5], text: "" }, { range: [4, 8], text: "%%%" }],
+        "abcdefghijk"
+      )
+      .should.throw();
 
-        done();
-    });
-
+    done();
+  });
 });

--- a/test/lib/autofix/rule-fixer.js
+++ b/test/lib/autofix/rule-fixer.js
@@ -6,297 +6,379 @@
 "use strict";
 
 let rf = require("../../../lib/autofix/rule-fixer");
-let RuleFixer, sampleRange = [5, 19];
+let RuleFixer,
+  sampleRange = [5, 19];
 
 // gets updated when a function is added/deleted in rulefixer API
 let listOfFunctions = [
-    "insertTextAfter", "insertTextBefore", "insertTextAt", "remove", "replaceText",
-    "insertTextAfterRange", "insertTextBeforeRange", "removeRange", "replaceChar", "replaceTextRange"
+  "insertTextAfter",
+  "insertTextBefore",
+  "insertTextAt",
+  "remove",
+  "replaceText",
+  "insertTextAfterRange",
+  "insertTextBeforeRange",
+  "removeRange",
+  "replaceChar",
+  "replaceTextRange"
 ];
 
 let node = {
-    type: "Literal",
-    start: 19,
-    end: 32
+  type: "Literal",
+  start: 19,
+  end: 32
 };
 
 describe("Test the rule-fixer API", function() {
+  it("should expose a constructor that creates a RuleFixer Object", function(done) {
+    rf.should.be.type("function");
 
-    it("should expose a constructor that creates a RuleFixer Object", function(done) {
-        rf.should.be.type("function");
+    RuleFixer = new rf("code");
 
-        RuleFixer = new rf("code");
+    RuleFixer.should.be.type("object");
+    RuleFixer.constructor.name.should.equal("RuleFixer");
+    Object.keys(RuleFixer).length.should.equal(10); // gets changed every time a function is added/deleted
 
-        RuleFixer.should.be.type("object");
-        RuleFixer.constructor.name.should.equal("RuleFixer");
-        Object.keys(RuleFixer).length.should.equal(10);	// gets changed every time a function is added/deleted
-
-        // Check methods exposed
-        listOfFunctions.forEach(function(fName) {
-            RuleFixer.should.have.ownProperty(fName);
-            RuleFixer [fName].should.be.type("function");
-        });
-
-        done();
+    // Check methods exposed
+    listOfFunctions.forEach(function(fName) {
+      RuleFixer.should.have.ownProperty(fName);
+      RuleFixer[fName].should.be.type("function");
     });
 
-    it("should handle all valid inputs for all the functions", function(done) {
-        let result, sampleText = "hello";
+    done();
+  });
 
-        // since RuleFixer.insertTextAt() is internally called by a lot of API functions,
-        // it gets tested with them. So no need to explicitly test it here.
+  it("should handle all valid inputs for all the functions", function(done) {
+    let result,
+      sampleText = "hello";
 
-        result = RuleFixer.insertTextAfter(node, sampleText);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(node.end);
-        result.range [1].should.equal(node.end);
-        result.text.should.equal(sampleText);
+    // since RuleFixer.insertTextAt() is internally called by a lot of API functions,
+    // it gets tested with them. So no need to explicitly test it here.
 
-        result = RuleFixer.insertTextBefore(node, sampleText);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(node.start);
-        result.range [1].should.equal(node.start);
-        result.text.should.equal(sampleText);
+    result = RuleFixer.insertTextAfter(node, sampleText);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(node.end);
+    result.range[1].should.equal(node.end);
+    result.text.should.equal(sampleText);
 
-        result = RuleFixer.remove(node);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(node.start);
-        result.range [1].should.equal(node.end);
-        result.text.should.be.empty();
+    result = RuleFixer.insertTextBefore(node, sampleText);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(node.start);
+    result.range[1].should.equal(node.start);
+    result.text.should.equal(sampleText);
 
-        result = RuleFixer.replaceText(node, sampleText);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(node.start);
-        result.range [1].should.equal(node.end);
-        result.text.should.equal(sampleText);
+    result = RuleFixer.remove(node);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(node.start);
+    result.range[1].should.equal(node.end);
+    result.text.should.be.empty();
 
-        result = RuleFixer.insertTextAfterRange(sampleRange, sampleText);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(sampleRange [1]);
-        result.range [1].should.equal(sampleRange [1]);
-        result.text.should.equal(sampleText);
+    result = RuleFixer.replaceText(node, sampleText);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(node.start);
+    result.range[1].should.equal(node.end);
+    result.text.should.equal(sampleText);
 
-        result = RuleFixer.insertTextBeforeRange(sampleRange, sampleText);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(sampleRange [0]);
-        result.range [1].should.equal(sampleRange [0]);
-        result.text.should.equal(sampleText);
+    result = RuleFixer.insertTextAfterRange(sampleRange, sampleText);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(sampleRange[1]);
+    result.range[1].should.equal(sampleRange[1]);
+    result.text.should.equal(sampleText);
 
-        result = RuleFixer.removeRange(sampleRange, sampleText);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(sampleRange [0]);
-        result.range [1].should.equal(sampleRange [1]);
-        result.text.should.be.empty();
+    result = RuleFixer.insertTextBeforeRange(sampleRange, sampleText);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(sampleRange[0]);
+    result.range[1].should.equal(sampleRange[0]);
+    result.text.should.equal(sampleText);
 
-        result = RuleFixer.replaceChar(sampleRange [0], sampleText [0]);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(sampleRange [0]);
-        result.range [1].should.equal(sampleRange [0] + 1);
-        result.text.should.equal(sampleText [0]);
+    result = RuleFixer.removeRange(sampleRange, sampleText);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(sampleRange[0]);
+    result.range[1].should.equal(sampleRange[1]);
+    result.text.should.be.empty();
 
-        result = RuleFixer.replaceTextRange(sampleRange, sampleText);
-        result.should.be.type("object");
-        result.should.have.ownProperty("range");
-        result.should.have.ownProperty("text");
-        result.range.should.be.Array();
-        result.range.length.should.equal(2);
-        result.range [0].should.equal(sampleRange [0]);
-        result.range [1].should.equal(sampleRange [1]);
-        result.text.should.equal(sampleText);
+    result = RuleFixer.replaceChar(sampleRange[0], sampleText[0]);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(sampleRange[0]);
+    result.range[1].should.equal(sampleRange[0] + 1);
+    result.text.should.equal(sampleText[0]);
 
-        done();
-    });
+    result = RuleFixer.replaceTextRange(sampleRange, sampleText);
+    result.should.be.type("object");
+    result.should.have.ownProperty("range");
+    result.should.have.ownProperty("text");
+    result.range.should.be.Array();
+    result.range.length.should.equal(2);
+    result.range[0].should.equal(sampleRange[0]);
+    result.range[1].should.equal(sampleRange[1]);
+    result.text.should.equal(sampleText);
 
-    it("should handle all invalid inputs for all the functions", function(done) {
-        RuleFixer.insertTextAfter.bind(RuleFixer, undefined, "hello").should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, null, "hello").should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, 109, "hello").should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, {}, "hello").should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, "node", "hello").should.throw();
+    done();
+  });
 
-        RuleFixer.insertTextAfter.bind(RuleFixer, node, undefined).should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, node, null).should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, node, 109).should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, node, {}).should.throw();
-        RuleFixer.insertTextAfter.bind(RuleFixer, node, node).should.throw();
+  it("should handle all invalid inputs for all the functions", function(done) {
+    RuleFixer.insertTextAfter
+      .bind(RuleFixer, undefined, "hello")
+      .should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, null, "hello").should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, 109, "hello").should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, {}, "hello").should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, "node", "hello").should.throw();
 
-        RuleFixer.insertTextAfter.bind(RuleFixer, node, "hello").should.not.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, node, undefined).should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, node, null).should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, node, 109).should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, node, {}).should.throw();
+    RuleFixer.insertTextAfter.bind(RuleFixer, node, node).should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.insertTextAfter.bind(RuleFixer, node, "hello").should.not.throw();
 
-        RuleFixer.insertTextBefore.bind(RuleFixer, undefined, "hello").should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, null, "hello").should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, 109, "hello").should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, {}, "hello").should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, "node", "hello").should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.insertTextBefore.bind(RuleFixer, node, undefined).should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, node, null).should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, node, 109).should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, node, {}).should.throw();
-        RuleFixer.insertTextBefore.bind(RuleFixer, node, node).should.throw();
+    RuleFixer.insertTextBefore
+      .bind(RuleFixer, undefined, "hello")
+      .should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, null, "hello").should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, 109, "hello").should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, {}, "hello").should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, "node", "hello").should.throw();
 
-        RuleFixer.insertTextBefore.bind(RuleFixer, node, "hello").should.not.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, node, undefined).should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, node, null).should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, node, 109).should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, node, {}).should.throw();
+    RuleFixer.insertTextBefore.bind(RuleFixer, node, node).should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.insertTextBefore
+      .bind(RuleFixer, node, "hello")
+      .should.not.throw();
 
-        RuleFixer.replaceText.bind(RuleFixer, undefined, "hello").should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, null, "hello").should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, 109, "hello").should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, {}, "hello").should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, "node", "hello").should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.replaceText.bind(RuleFixer, node, undefined).should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, node, null).should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, node, 109).should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, node, {}).should.throw();
-        RuleFixer.replaceText.bind(RuleFixer, node, node).should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, undefined, "hello").should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, null, "hello").should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, 109, "hello").should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, {}, "hello").should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, "node", "hello").should.throw();
 
-        RuleFixer.replaceText.bind(RuleFixer, node, "hello").should.not.throw();
+    RuleFixer.replaceText.bind(RuleFixer, node, undefined).should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, node, null).should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, node, 109).should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, node, {}).should.throw();
+    RuleFixer.replaceText.bind(RuleFixer, node, node).should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.replaceText.bind(RuleFixer, node, "hello").should.not.throw();
 
-        RuleFixer.remove.bind(RuleFixer, undefined).should.throw();
-        RuleFixer.remove.bind(RuleFixer, null).should.throw();
-        RuleFixer.remove.bind(RuleFixer, 109).should.throw();
-        RuleFixer.remove.bind(RuleFixer, {}).should.throw();
-        RuleFixer.remove.bind(RuleFixer, "node").should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.remove.bind(RuleFixer, node).should.not.throw();
+    RuleFixer.remove.bind(RuleFixer, undefined).should.throw();
+    RuleFixer.remove.bind(RuleFixer, null).should.throw();
+    RuleFixer.remove.bind(RuleFixer, 109).should.throw();
+    RuleFixer.remove.bind(RuleFixer, {}).should.throw();
+    RuleFixer.remove.bind(RuleFixer, "node").should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.remove.bind(RuleFixer, node).should.not.throw();
 
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, undefined, "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, null, "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, 109, "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, {}, "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, "range", "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, [], "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, [1], "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, [-1, -293], "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, [18.289, 8917.21], "hello").should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, [1, 2, 3], "hello").should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, sampleRange, undefined).should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, sampleRange, null).should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, sampleRange, 109).should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, sampleRange, {}).should.throw();
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, sampleRange, node).should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, undefined, "hello")
+      .should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, null, "hello")
+      .should.throw();
+    RuleFixer.insertTextAfterRange.bind(RuleFixer, 109, "hello").should.throw();
+    RuleFixer.insertTextAfterRange.bind(RuleFixer, {}, "hello").should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, "range", "hello")
+      .should.throw();
+    RuleFixer.insertTextAfterRange.bind(RuleFixer, [], "hello").should.throw();
+    RuleFixer.insertTextAfterRange.bind(RuleFixer, [1], "hello").should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, [-1, -293], "hello")
+      .should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, [18.289, 8917.21], "hello")
+      .should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, [1, 2, 3], "hello")
+      .should.throw();
 
-        RuleFixer.insertTextAfterRange.bind(RuleFixer, sampleRange, "hello").should.not.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, sampleRange, undefined)
+      .should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, sampleRange, null)
+      .should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, sampleRange, 109)
+      .should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, sampleRange, {})
+      .should.throw();
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, sampleRange, node)
+      .should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.insertTextAfterRange
+      .bind(RuleFixer, sampleRange, "hello")
+      .should.not.throw();
 
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, undefined, "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, null, "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, 109, "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, {}, "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, "range", "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, [], "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, [1], "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, [-1, -293], "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, [18.289, 8917.21], "hello").should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, [1, 2, 3], "hello").should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, sampleRange, undefined).should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, sampleRange, null).should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, sampleRange, 109).should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, sampleRange, {}).should.throw();
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, sampleRange, node).should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, undefined, "hello")
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, null, "hello")
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, 109, "hello")
+      .should.throw();
+    RuleFixer.insertTextBeforeRange.bind(RuleFixer, {}, "hello").should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, "range", "hello")
+      .should.throw();
+    RuleFixer.insertTextBeforeRange.bind(RuleFixer, [], "hello").should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, [1], "hello")
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, [-1, -293], "hello")
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, [18.289, 8917.21], "hello")
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, [1, 2, 3], "hello")
+      .should.throw();
 
-        RuleFixer.insertTextBeforeRange.bind(RuleFixer, sampleRange, "hello").should.not.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, sampleRange, undefined)
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, sampleRange, null)
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, sampleRange, 109)
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, sampleRange, {})
+      .should.throw();
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, sampleRange, node)
+      .should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.insertTextBeforeRange
+      .bind(RuleFixer, sampleRange, "hello")
+      .should.not.throw();
 
-        RuleFixer.replaceTextRange.bind(RuleFixer, undefined, "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, null, "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, 109, "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, {}, "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, "range", "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, [], "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, [1], "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, [-1, -293], "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, [18.289, 8917.21], "hello").should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, [1, 2, 3], "hello").should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, undefined).should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, null).should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, 109).should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, {}).should.throw();
-        RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, node).should.throw();
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, undefined, "hello")
+      .should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, null, "hello").should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, 109, "hello").should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, {}, "hello").should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, "range", "hello").should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, [], "hello").should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, [1], "hello").should.throw();
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, [-1, -293], "hello")
+      .should.throw();
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, [18.289, 8917.21], "hello")
+      .should.throw();
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, [1, 2, 3], "hello")
+      .should.throw();
 
-        RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, "hello").should.not.throw();
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, sampleRange, undefined)
+      .should.throw();
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, sampleRange, null)
+      .should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, 109).should.throw();
+    RuleFixer.replaceTextRange.bind(RuleFixer, sampleRange, {}).should.throw();
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, sampleRange, node)
+      .should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.replaceTextRange
+      .bind(RuleFixer, sampleRange, "hello")
+      .should.not.throw();
 
-        RuleFixer.removeRange.bind(RuleFixer, undefined).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, null).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, 109).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, {}).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, "range").should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, []).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, [1]).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, [-1, -293]).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, [18.289, 8917.21]).should.throw();
-        RuleFixer.removeRange.bind(RuleFixer, [1, 2, 3]).should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.removeRange.bind(RuleFixer, sampleRange).should.not.throw();
+    RuleFixer.removeRange.bind(RuleFixer, undefined).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, null).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, 109).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, {}).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, "range").should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, []).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, [1]).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, [-1, -293]).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, [18.289, 8917.21]).should.throw();
+    RuleFixer.removeRange.bind(RuleFixer, [1, 2, 3]).should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.removeRange.bind(RuleFixer, sampleRange).should.not.throw();
 
-        RuleFixer.replaceChar.bind(RuleFixer, undefined, "a").should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, null, "a").should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, 1.289, "a").should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, {}, "a").should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, "range", "a").should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, [], "a").should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, [1], "a").should.throw();
+    /*****************************************************************************/
 
-        RuleFixer.replaceChar.bind(RuleFixer, 2, undefined).should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, 2, null).should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, 2, 1.289).should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, 2, {}).should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, 2, "ch").should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, 2, []).should.throw();
-        RuleFixer.replaceChar.bind(RuleFixer, 2, [1]).should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, undefined, "a").should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, null, "a").should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 1.289, "a").should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, {}, "a").should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, "range", "a").should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, [], "a").should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, [1], "a").should.throw();
 
-        RuleFixer.replaceChar.bind(RuleFixer, 2, " ").should.not.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 2, undefined).should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 2, null).should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 2, 1.289).should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 2, {}).should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 2, "ch").should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 2, []).should.throw();
+    RuleFixer.replaceChar.bind(RuleFixer, 2, [1]).should.throw();
 
-        /*****************************************************************************/
+    RuleFixer.replaceChar.bind(RuleFixer, 2, " ").should.not.throw();
 
-        done();
-    });
+    /*****************************************************************************/
 
+    done();
+  });
 });

--- a/test/lib/autofix/source-code-fixer.js
+++ b/test/lib/autofix/source-code-fixer.js
@@ -9,235 +9,243 @@ let scf = require("../../../lib/autofix/source-code-fixer");
 
 // No need to check for fuzzy values in this module since it is only used internally, ensuring expected arguments
 describe("Test the source-code-fixer API", function() {
+  it("should expose a set of functions", function(done) {
+    scf.should.be.type("object");
+    scf.should.have.ownProperty("applyFixes");
+    scf.applyFixes.should.be.type("function");
+    done();
+  });
 
-    it("should expose a set of functions", function(done) {
-        scf.should.be.type("object");
-        scf.should.have.ownProperty("applyFixes");
-        scf.applyFixes.should.be.type("function");
-        done();
-    });
+  it("should not alter the errorMessages array when passed to applyFixes()", function(done) {
+    let msgsNoFixes = [
+      {
+        ruleName: "abc",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 }
+      }
+    ];
 
-    it("should not alter the errorMessages array when passed to applyFixes()", function(done) {
-        let msgsNoFixes = [{
-            ruleName: "abc",
-            message: "def",
-            type: "error",
-            line: 1,
-            column: 4,
-            node: {type: "Literal", start: 1, end: 9}
-        }];
+    let msgsWithFixes = [
+      {
+        ruleName: "abc",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 },
+        fix: { range: [1, 4], text: "" }
+      }
+    ];
 
-        let msgsWithFixes = [{
-            ruleName: "abc",
-            message: "def",
-            type: "error",
-            line: 1,
-            column: 4,
-            node: {type: "Literal", start: 1, end: 9},
-            fix: {range: [1, 4], text: ""}
-        }];
+    scf.applyFixes("", msgsNoFixes);
 
-        scf.applyFixes("", msgsNoFixes);
+    msgsNoFixes.should.be.Array();
+    msgsNoFixes.should.have.size(1);
+    msgsNoFixes[0].should.be.type("object");
+    msgsNoFixes[0].should.have.size(6);
+    msgsNoFixes[0].should.have.ownProperty("ruleName");
+    msgsNoFixes[0].ruleName.should.equal("abc");
+    msgsNoFixes[0].should.have.ownProperty("type");
+    msgsNoFixes[0].type.should.equal("error");
+    msgsNoFixes[0].should.have.ownProperty("node");
+    msgsNoFixes[0].node.should.be.type("object");
+    msgsNoFixes[0].should.have.ownProperty("line");
+    msgsNoFixes[0].line.should.equal(1);
+    msgsNoFixes[0].should.have.ownProperty("column");
+    msgsNoFixes[0].column.should.equal(4);
+    msgsNoFixes[0].should.have.ownProperty("message");
+    msgsNoFixes[0].message.should.equal("def");
+    msgsNoFixes[0].should.not.have.ownProperty("fix");
 
-        msgsNoFixes.should.be.Array();
-        msgsNoFixes.should.have.size(1);
-        msgsNoFixes [0].should.be.type("object");
-        msgsNoFixes [0].should.have.size(6);
-        msgsNoFixes [0].should.have.ownProperty("ruleName");
-        msgsNoFixes [0].ruleName.should.equal("abc");
-        msgsNoFixes [0].should.have.ownProperty("type");
-        msgsNoFixes [0].type.should.equal("error");
-        msgsNoFixes [0].should.have.ownProperty("node");
-        msgsNoFixes [0].node.should.be.type("object");
-        msgsNoFixes [0].should.have.ownProperty("line");
-        msgsNoFixes [0].line.should.equal(1);
-        msgsNoFixes [0].should.have.ownProperty("column");
-        msgsNoFixes [0].column.should.equal(4);
-        msgsNoFixes [0].should.have.ownProperty("message");
-        msgsNoFixes [0].message.should.equal("def");
-        msgsNoFixes [0].should.not.have.ownProperty("fix");
+    scf.applyFixes("abcd", msgsWithFixes);
 
-        scf.applyFixes("abcd", msgsWithFixes);
+    msgsWithFixes.should.be.Array();
+    msgsWithFixes.should.have.size(1);
+    msgsWithFixes[0].should.be.type("object");
+    msgsWithFixes[0].should.have.size(7);
+    msgsWithFixes[0].should.have.ownProperty("ruleName");
+    msgsWithFixes[0].ruleName.should.equal("abc");
+    msgsWithFixes[0].should.have.ownProperty("type");
+    msgsWithFixes[0].type.should.equal("error");
+    msgsWithFixes[0].should.have.ownProperty("node");
+    msgsWithFixes[0].node.should.be.type("object");
+    msgsWithFixes[0].should.have.ownProperty("line");
+    msgsWithFixes[0].line.should.equal(1);
+    msgsWithFixes[0].should.have.ownProperty("column");
+    msgsWithFixes[0].column.should.equal(4);
+    msgsWithFixes[0].should.have.ownProperty("message");
+    msgsWithFixes[0].message.should.equal("def");
+    msgsWithFixes[0].should.have.ownProperty("fix");
+    msgsWithFixes[0].fix.should.be.type("object");
 
-        msgsWithFixes.should.be.Array();
-        msgsWithFixes.should.have.size(1);
-        msgsWithFixes [0].should.be.type("object");
-        msgsWithFixes [0].should.have.size(7);
-        msgsWithFixes [0].should.have.ownProperty("ruleName");
-        msgsWithFixes [0].ruleName.should.equal("abc");
-        msgsWithFixes [0].should.have.ownProperty("type");
-        msgsWithFixes [0].type.should.equal("error");
-        msgsWithFixes [0].should.have.ownProperty("node");
-        msgsWithFixes [0].node.should.be.type("object");
-        msgsWithFixes [0].should.have.ownProperty("line");
-        msgsWithFixes [0].line.should.equal(1);
-        msgsWithFixes [0].should.have.ownProperty("column");
-        msgsWithFixes [0].column.should.equal(4);
-        msgsWithFixes [0].should.have.ownProperty("message");
-        msgsWithFixes [0].message.should.equal("def");
-        msgsWithFixes [0].should.have.ownProperty("fix");
-        msgsWithFixes [0].fix.should.be.type("object");
+    done();
+  });
 
-        done();
-    });
+  it("should return source code as-it-is if there are no fixes to apply", function(done) {
+    let msgsNoFixes = [
+      {
+        ruleName: "abc",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 }
+      }
+    ];
 
-    it("should return source code as-it-is if there are no fixes to apply", function(done) {
-        let msgsNoFixes = [{
-            ruleName: "abc",
-            message: "def",
-            type: "error",
-            line: 1,
-            column: 4,
-            node: {type: "Literal", start: 1, end: 9}
-        }];
+    let sourceCode = "abcd123@@@***&^###;;{}[]";
 
-        let sourceCode = "abcd123@@@***&^###;;{}[]";
+    let result = scf.applyFixes(sourceCode, []);
 
-        let result = scf.applyFixes(sourceCode, []);
+    result.should.be.type("object");
+    result.should.have.size(3);
+    result.should.have.ownProperty("fixesApplied");
+    result.should.have.ownProperty("remainingErrorMessages");
+    result.should.have.ownProperty("fixedSourceCode");
+    result.fixesApplied.should.be.Array();
+    result.fixesApplied.should.be.empty();
+    result.remainingErrorMessages.should.be.Array();
+    result.remainingErrorMessages.should.be.empty();
+    result.fixedSourceCode.should.equal(sourceCode);
 
-        result.should.be.type("object");
-        result.should.have.size(3);
-        result.should.have.ownProperty("fixesApplied");
-        result.should.have.ownProperty("remainingErrorMessages");
-        result.should.have.ownProperty("fixedSourceCode");
-        result.fixesApplied.should.be.Array();
-        result.fixesApplied.should.be.empty();
-        result.remainingErrorMessages.should.be.Array();
-        result.remainingErrorMessages.should.be.empty();
-        result.fixedSourceCode.should.equal(sourceCode);
+    result = scf.applyFixes(sourceCode, msgsNoFixes);
 
-        result = scf.applyFixes(sourceCode, msgsNoFixes);
+    result.should.be.type("object");
+    result.should.have.size(3);
+    result.should.have.ownProperty("fixesApplied");
+    result.should.have.ownProperty("remainingErrorMessages");
+    result.should.have.ownProperty("fixedSourceCode");
+    result.fixesApplied.should.be.Array();
+    result.fixesApplied.should.be.empty();
+    result.remainingErrorMessages.should.be.Array();
+    result.remainingErrorMessages.should.have.size(1);
+    result.fixedSourceCode.should.equal(sourceCode);
 
-        result.should.be.type("object");
-        result.should.have.size(3);
-        result.should.have.ownProperty("fixesApplied");
-        result.should.have.ownProperty("remainingErrorMessages");
-        result.should.have.ownProperty("fixedSourceCode");
-        result.fixesApplied.should.be.Array();
-        result.fixesApplied.should.be.empty();
-        result.remainingErrorMessages.should.be.Array();
-        result.remainingErrorMessages.should.have.size(1);
-        result.fixedSourceCode.should.equal(sourceCode);
-		
-        done();
-    });
+    done();
+  });
 
-    it("should fix as expected when valid args are passed to applyFixes()", function(done) {
-        // Also ensure that it correctly segregates all messages into either fixesApplied or remainingErrorMessages
-        let msgs = [
-            {
-                ruleName: "a",
-                message: "def",
-                type: "error",
-                line: 1,
-                column: 4,
-                node: {type: "Literal", start: 1, end: 9}
-            },
-            {
-                ruleName: "b",
-                message: "def",
-                type: "error",
-                line: 1,
-                column: 4,
-                node: {type: "Literal", start: 1, end: 9},
-                fix: {range: [3, 8], text: "***"}	// replace
-            },
-            {
-                ruleName: "c",
-                message: "def",
-                type: "error",
-                line: 1,
-                column: 4,
-                node: {type: "Literal", start: 1, end: 9}
-            },
-            {
-                ruleName: "d",
-                message: "def",
-                type: "error",
-                line: 1,
-                column: 4,
-                node: {type: "Literal", start: 1, end: 9},
-                fix: {range: [8, 24], text: ""}	// delete
-            }
-        ];
+  it("should fix as expected when valid args are passed to applyFixes()", function(done) {
+    // Also ensure that it correctly segregates all messages into either fixesApplied or remainingErrorMessages
+    let msgs = [
+      {
+        ruleName: "a",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 }
+      },
+      {
+        ruleName: "b",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 },
+        fix: { range: [3, 8], text: "***" } // replace
+      },
+      {
+        ruleName: "c",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 }
+      },
+      {
+        ruleName: "d",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 },
+        fix: { range: [8, 24], text: "" } // delete
+      }
+    ];
 
-        let sourceCode = "abcd123@@@***&^###;;{}[]",
-            fixedSourceCode = "abc***";
+    let sourceCode = "abcd123@@@***&^###;;{}[]",
+      fixedSourceCode = "abc***";
 
-        let result = scf.applyFixes(sourceCode, msgs);
+    let result = scf.applyFixes(sourceCode, msgs);
 
-        result.should.be.type("object");
-        result.should.have.size(3);
-        result.should.have.ownProperty("fixesApplied");
-        result.should.have.ownProperty("remainingErrorMessages");
-        result.should.have.ownProperty("fixedSourceCode");
+    result.should.be.type("object");
+    result.should.have.size(3);
+    result.should.have.ownProperty("fixesApplied");
+    result.should.have.ownProperty("remainingErrorMessages");
+    result.should.have.ownProperty("fixedSourceCode");
 
-        result.fixesApplied.should.be.Array();
-        result.fixesApplied.should.have.size(2);
-        result.fixesApplied [0].ruleName.should.equal("b");
-        result.fixesApplied [1].ruleName.should.equal("d");
-        result.remainingErrorMessages.should.be.Array();
-        result.remainingErrorMessages.should.have.size(2);
-        result.remainingErrorMessages [0].ruleName.should.equal("a");
-        result.remainingErrorMessages [1].ruleName.should.equal("c");
-        result.fixedSourceCode.should.equal(fixedSourceCode);
+    result.fixesApplied.should.be.Array();
+    result.fixesApplied.should.have.size(2);
+    result.fixesApplied[0].ruleName.should.equal("b");
+    result.fixesApplied[1].ruleName.should.equal("d");
+    result.remainingErrorMessages.should.be.Array();
+    result.remainingErrorMessages.should.have.size(2);
+    result.remainingErrorMessages[0].ruleName.should.equal("a");
+    result.remainingErrorMessages[1].ruleName.should.equal("c");
+    result.fixedSourceCode.should.equal(fixedSourceCode);
 
-        done();
-    });
+    done();
+  });
 
-    it("in case of overlapping fixes, the one that occurs before (row-wise then col-wise) should be applied", function(done) {
-        let msgs = [
-            {
-                ruleName: "a",
-                message: "def",
-                type: "error",
-                line: 1,
-                column: 4,
-                node: {type: "Literal", start: 1, end: 9},
-                fix: {range: [5, 10], text: "^_^"}	// shouldn't get applied
-            },
-            {
-                ruleName: "b",
-                message: "def",
-                type: "error",
-                line: 1,
-                column: 4,
-                node: {type: "Literal", start: 1, end: 9},
-                fix: {range: [3, 8], text: "***"}
-            }
-        ];
+  it("in case of overlapping fixes, the one that occurs before (row-wise then col-wise) should be applied", function(done) {
+    let msgs = [
+      {
+        ruleName: "a",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 },
+        fix: { range: [5, 10], text: "^_^" } // shouldn't get applied
+      },
+      {
+        ruleName: "b",
+        message: "def",
+        type: "error",
+        line: 1,
+        column: 4,
+        node: { type: "Literal", start: 1, end: 9 },
+        fix: { range: [3, 8], text: "***" }
+      }
+    ];
 
-        let sourceCode = "abcd123@@@***&^###;;{}[]",
-            fixedSourceCode = "abc***@@***&^###;;{}[]";
+    let sourceCode = "abcd123@@@***&^###;;{}[]",
+      fixedSourceCode = "abc***@@***&^###;;{}[]";
 
-        let result = scf.applyFixes(sourceCode, msgs);
+    let result = scf.applyFixes(sourceCode, msgs);
 
-        result.should.be.type("object");
-        result.should.have.size(3);
-        result.should.have.ownProperty("fixesApplied");
-        result.should.have.ownProperty("remainingErrorMessages");
-        result.should.have.ownProperty("fixedSourceCode");
+    result.should.be.type("object");
+    result.should.have.size(3);
+    result.should.have.ownProperty("fixesApplied");
+    result.should.have.ownProperty("remainingErrorMessages");
+    result.should.have.ownProperty("fixedSourceCode");
 
-        result.fixesApplied.should.be.Array();
-        result.fixesApplied.should.have.size(1);
-        result.fixesApplied [0].ruleName.should.equal("b");
-        result.remainingErrorMessages.should.be.Array();
-        result.remainingErrorMessages.should.have.size(1);
-        result.remainingErrorMessages [0].ruleName.should.equal("a");
-        result.fixedSourceCode.should.equal(fixedSourceCode);
+    result.fixesApplied.should.be.Array();
+    result.fixesApplied.should.have.size(1);
+    result.fixesApplied[0].ruleName.should.equal("b");
+    result.remainingErrorMessages.should.be.Array();
+    result.remainingErrorMessages.should.have.size(1);
+    result.remainingErrorMessages[0].ruleName.should.equal("a");
+    result.fixedSourceCode.should.equal(fixedSourceCode);
 
-        done();
-    });
+    done();
+  });
 
-    it("should throw when a fix reported by a rule contains overlapping fixer objects", function(done) {
-        // This is different from the overlapping being tested above. Here, we want to ensure that
-        // if rule ABC reports a fix inside an error object, and if that fix is an array of fixer packets,
-        // those packets must not have overlapping ranges.
-        scf.applyFixes.bind(scf,
-            [{range: [2, 5], text: ""}, {range: [4, 8], text: "%%%"}], "abcdefghijk"
-        ).should.throw();
+  it("should throw when a fix reported by a rule contains overlapping fixer objects", function(done) {
+    // This is different from the overlapping being tested above. Here, we want to ensure that
+    // if rule ABC reports a fix inside an error object, and if that fix is an array of fixer packets,
+    // those packets must not have overlapping ranges.
+    scf.applyFixes
+      .bind(
+        scf,
+        [{ range: [2, 5], text: "" }, { range: [4, 8], text: "%%%" }],
+        "abcdefghijk"
+      )
+      .should.throw();
 
-        done();
-    });
-
+    done();
+  });
 });

--- a/test/lib/comment-directive-parser.js
+++ b/test/lib/comment-directive-parser.js
@@ -6,7 +6,7 @@
 "use strict";
 
 const solidityParser = require("solparse"),
-    CommentDirectiveParser = require("../../lib/comment-directive-parser");
+  CommentDirectiveParser = require("../../lib/comment-directive-parser");
 
 const code = `
 // hello world
@@ -16,144 +16,231 @@ contract foo {
 `;
 const AST = solidityParser.parse(code, { comment: true });
 
-
 describe("comment-directive-parser", () => {
+  it("should expose a class to create CDP objects", done => {
+    function shouldThrow(f, msg) {
+      try {
+        f();
+      } catch (e) {
+        e.message.should.equal(msg);
+      }
+    }
 
-    it("should expose a class to create CDP objects", done => {
-        function shouldThrow(f, msg) {
-            try { f(); } catch (e) { e.message.should.equal(msg); }
-        }
+    CommentDirectiveParser.should.be.type("function");
 
-        CommentDirectiveParser.should.be.type("function");
+    const minimalAST = { type: "Program", start: 0, end: 1 };
+    const myCdp = new CommentDirectiveParser([], minimalAST);
+    const invalidArgError =
+      "First argument should be an array of comment tokens.";
 
-        const minimalAST = { type: "Program", start: 0, end: 1 };
-        const myCdp = new CommentDirectiveParser([], minimalAST);
-        const invalidArgError = "First argument should be an array of comment tokens.";
+    (myCdp instanceof CommentDirectiveParser).should.be.true();
+    myCdp.should.have.size(4); // changes when properties are added/removed
+    myCdp.should.have.ownProperty("lastLine");
+    myCdp.should.have.ownProperty("commentTokens");
+    myCdp.should.have.ownProperty("lineConfigurations");
+    myCdp.should.have.ownProperty("ALL_RULES");
 
-        (myCdp instanceof CommentDirectiveParser).should.be.true();
-        myCdp.should.have.size(4);  // changes when properties are added/removed
-        myCdp.should.have.ownProperty("lastLine");
-        myCdp.should.have.ownProperty("commentTokens");
-        myCdp.should.have.ownProperty("lineConfigurations");
-        myCdp.should.have.ownProperty("ALL_RULES");
+    const invalidTokens = [
+      ,
+      undefined,
+      null,
+      {},
+      1,
+      90,
+      "",
+      1.83,
+      0,
+      -1892,
+      true,
+      false,
+      () => {}
+    ];
 
-
-        const invalidTokens = [, undefined, null, {}, 1, 90, "", 1.83, 0, -1892, true, false, ()=>{}];
-
-        invalidTokens.forEach(t => {
-            shouldThrow(() => {new CommentDirectiveParser(t, minimalAST);}, invalidArgError);
-        });
-
-        // Just check that AST validation is working, no need for extensive testing
-        shouldThrow(() => {new CommentDirectiveParser([], null);}, "getEndingLine(): null is not a valid AST node.");
-
-        done();
+    invalidTokens.forEach(t => {
+      shouldThrow(() => {
+        new CommentDirectiveParser(t, minimalAST);
+      }, invalidArgError);
     });
 
-    it("should expose a set of methods via the CDP object", done => {
-        const cdp = new CommentDirectiveParser(AST.comments, AST);
+    // Just check that AST validation is working, no need for extensive testing
+    shouldThrow(() => {
+      new CommentDirectiveParser([], null);
+    }, "getEndingLine(): null is not a valid AST node.");
 
-        cdp.isRuleEnabledOnLine.should.be.type("function");
-        cdp._constructLineConfigurations.should.be.type("function");
-        cdp._addRulesToLineConfig.should.be.type("function");
-        cdp._constructLineConfigurationFromComment.should.be.type("function");
-        cdp._cleanCommentText.should.be.type("function");
-        cdp._parseRuleNames.should.be.type("function");
-        cdp._toEndOfFile.should.be.type("function");
+    done();
+  });
 
-        done();
+  it("should expose a set of methods via the CDP object", done => {
+    const cdp = new CommentDirectiveParser(AST.comments, AST);
+
+    cdp.isRuleEnabledOnLine.should.be.type("function");
+    cdp._constructLineConfigurations.should.be.type("function");
+    cdp._addRulesToLineConfig.should.be.type("function");
+    cdp._constructLineConfigurationFromComment.should.be.type("function");
+    cdp._cleanCommentText.should.be.type("function");
+    cdp._parseRuleNames.should.be.type("function");
+    cdp._toEndOfFile.should.be.type("function");
+
+    done();
+  });
+
+  it("should throw when calling isRuleEnabledOnLine() with invalid args", done => {
+    const cdp = new CommentDirectiveParser(AST.comments, AST);
+    const badRuleNames = [
+        ,
+        undefined,
+        null,
+        {},
+        [],
+        1,
+        90,
+        "",
+        1.83,
+        0,
+        -1892,
+        true,
+        false,
+        () => {}
+      ],
+      badLineNumbers = [
+        ,
+        undefined,
+        null,
+        {},
+        [],
+        "h",
+        "",
+        1.83,
+        0,
+        -1892,
+        true,
+        false,
+        () => {}
+      ];
+
+    badRuleNames.forEach(r => {
+      cdp.isRuleEnabledOnLine
+        .bind(cdp, r, 1)
+        .should.throw("Rule name should be a non-empty string string.");
     });
 
-    it("should throw when calling isRuleEnabledOnLine() with invalid args", done => {
-        const cdp = new CommentDirectiveParser(AST.comments, AST);
-        const badRuleNames = [, undefined, null, {}, [], 1, 90, "", 1.83, 0, -1892, true, false, ()=>{}],
-            badLineNumbers = [, undefined, null, {}, [], "h", "", 1.83, 0, -1892, true, false, ()=>{}];
-
-        badRuleNames.forEach(r => {
-            cdp.isRuleEnabledOnLine.bind(
-                cdp, r, 1).should.throw("Rule name should be a non-empty string string.");
-        });
-
-        badLineNumbers.forEach(l => {
-            cdp.isRuleEnabledOnLine.bind(
-                cdp, "rule", l).should.throw("Line number should be a positive integer.");
-        });
-
-        done();
+    badLineNumbers.forEach(l => {
+      cdp.isRuleEnabledOnLine
+        .bind(cdp, "rule", l)
+        .should.throw("Line number should be a positive integer.");
     });
 
-    it("should work as expected when calling private utility functions", done => {
-        const cdp = new CommentDirectiveParser(AST.comments, AST);
-        const texts = [
-            ["///////", "/////"],
-            ["//", ""],
-            ["//\t", "\t"],
-            ["//hello world", "hello world"],
-            ["//  foobar", "  foobar"],
-            ["//baz////", "baz////"],
-            ["/*****/", "***"],
-            ["/**/", ""],
-            ["/*\t\t*/", "\t\t"],
-            ["/*hello world*/", "hello world"],
-            ["/*  foobar   */", "  foobar   "],
-            ["/*hello\n\n@author bro<hello@world.com>\n\n*/", "hello\n\n@author bro<hello@world.com>\n\n"],
+    done();
+  });
 
-            ["// solium-disable", " solium-disable"],
-            ["// solium-disable pragma-on-top, indentation", " solium-disable pragma-on-top, indentation"],
-            ["// solium-disable foorule", " solium-disable foorule"],
-            ["// solium-disable-line", " solium-disable-line"],
-            ["// solium-disable-line pragma-on-top, indentation", " solium-disable-line pragma-on-top, indentation"],
-            ["// solium-disable-line foorule", " solium-disable-line foorule"],
-            ["/* solium-disable*/", " solium-disable"],
-            ["/* solium-disable pragma-on-top, indentation*/", " solium-disable pragma-on-top, indentation"],
-            ["/* solium-disable foorule*/", " solium-disable foorule"],
-            ["/* solium-disable-line*/", " solium-disable-line"],
-            ["/* solium-disable-line pragma-on-top, indentation*/", " solium-disable-line pragma-on-top, indentation"],
-            ["/* solium-disable-line foorule*/", " solium-disable-line foorule"]
-        ];
+  it("should work as expected when calling private utility functions", done => {
+    const cdp = new CommentDirectiveParser(AST.comments, AST);
+    const texts = [
+      ["///////", "/////"],
+      ["//", ""],
+      ["//\t", "\t"],
+      ["//hello world", "hello world"],
+      ["//  foobar", "  foobar"],
+      ["//baz////", "baz////"],
+      ["/*****/", "***"],
+      ["/**/", ""],
+      ["/*\t\t*/", "\t\t"],
+      ["/*hello world*/", "hello world"],
+      ["/*  foobar   */", "  foobar   "],
+      [
+        "/*hello\n\n@author bro<hello@world.com>\n\n*/",
+        "hello\n\n@author bro<hello@world.com>\n\n"
+      ],
 
-        texts.forEach(([dirty, clean]) => {
-            cdp._cleanCommentText(dirty).should.equal(clean);
-        });
+      ["// solium-disable", " solium-disable"],
+      [
+        "// solium-disable pragma-on-top, indentation",
+        " solium-disable pragma-on-top, indentation"
+      ],
+      ["// solium-disable foorule", " solium-disable foorule"],
+      ["// solium-disable-line", " solium-disable-line"],
+      [
+        "// solium-disable-line pragma-on-top, indentation",
+        " solium-disable-line pragma-on-top, indentation"
+      ],
+      ["// solium-disable-line foorule", " solium-disable-line foorule"],
+      ["/* solium-disable*/", " solium-disable"],
+      [
+        "/* solium-disable pragma-on-top, indentation*/",
+        " solium-disable pragma-on-top, indentation"
+      ],
+      ["/* solium-disable foorule*/", " solium-disable foorule"],
+      ["/* solium-disable-line*/", " solium-disable-line"],
+      [
+        "/* solium-disable-line pragma-on-top, indentation*/",
+        " solium-disable-line pragma-on-top, indentation"
+      ],
+      ["/* solium-disable-line foorule*/", " solium-disable-line foorule"]
+    ];
 
-
-        const ruleCodes = [
-            ["  \tsolium-disable\t  ", "all", "solium-disable"],
-            ["  \tsolium-disable pragma-on-top,   indentation", "pragma-on-top,indentation", "solium-disable"],
-            ["  \tsolium-disable  \tfoorule", "foorule", "solium-disable"],
-            ["  \tsolium-disable-line", "all", "solium-disable-line"],
-            ["  \tsolium-disable-line   pragma-on-top\t,  indentation", "pragma-on-top,indentation", "solium-disable-line"],
-            ["  \tsolium-disable-line foorule", "foorule", "solium-disable-line"],
-            ["  \tsolium-disable-next-line", "all", "solium-disable-next-line"],
-            ["  \tsolium-disable-next-line   pragma-on-top\t,  indentation", "pragma-on-top,indentation", "solium-disable-next-line"],
-            ["  \tsolium-disable-next-line foorule", "foorule", "solium-disable-next-line"],
-            ["  \tsolium-disable", "all", "solium-disable"],
-            ["  \tsolium-disable pragma-on-top, indentation", "pragma-on-top,indentation", "solium-disable"],
-            ["  \tsolium-disable foorule", "foorule", "solium-disable"],
-            ["  \tsolium-disable-line", "all", "solium-disable-line"],
-            ["  \tsolium-disable-line  pragma-on-top,\t\tindentation", "pragma-on-top,indentation", "solium-disable-line"],
-            ["  \tsolium-disable-line foorule", "foorule", "solium-disable-line"]
-        ];
-
-        ruleCodes.forEach(([text, expectedOutput, p2r]) => {
-            let rules = cdp._parseRuleNames(text, p2r);
-
-            if (rules.constructor.name === "Array") {
-                rules = rules.join();
-            }
-
-            rules.should.equal(expectedOutput);
-        });
-
-
-        let counter = 7;
-        cdp.lastLine = 96;
-
-        cdp._toEndOfFile(counter, currentLine => {
-            currentLine.should.equal(counter++);
-        });
-
-        done();
+    texts.forEach(([dirty, clean]) => {
+      cdp._cleanCommentText(dirty).should.equal(clean);
     });
 
+    const ruleCodes = [
+      ["  \tsolium-disable\t  ", "all", "solium-disable"],
+      [
+        "  \tsolium-disable pragma-on-top,   indentation",
+        "pragma-on-top,indentation",
+        "solium-disable"
+      ],
+      ["  \tsolium-disable  \tfoorule", "foorule", "solium-disable"],
+      ["  \tsolium-disable-line", "all", "solium-disable-line"],
+      [
+        "  \tsolium-disable-line   pragma-on-top\t,  indentation",
+        "pragma-on-top,indentation",
+        "solium-disable-line"
+      ],
+      ["  \tsolium-disable-line foorule", "foorule", "solium-disable-line"],
+      ["  \tsolium-disable-next-line", "all", "solium-disable-next-line"],
+      [
+        "  \tsolium-disable-next-line   pragma-on-top\t,  indentation",
+        "pragma-on-top,indentation",
+        "solium-disable-next-line"
+      ],
+      [
+        "  \tsolium-disable-next-line foorule",
+        "foorule",
+        "solium-disable-next-line"
+      ],
+      ["  \tsolium-disable", "all", "solium-disable"],
+      [
+        "  \tsolium-disable pragma-on-top, indentation",
+        "pragma-on-top,indentation",
+        "solium-disable"
+      ],
+      ["  \tsolium-disable foorule", "foorule", "solium-disable"],
+      ["  \tsolium-disable-line", "all", "solium-disable-line"],
+      [
+        "  \tsolium-disable-line  pragma-on-top,\t\tindentation",
+        "pragma-on-top,indentation",
+        "solium-disable-line"
+      ],
+      ["  \tsolium-disable-line foorule", "foorule", "solium-disable-line"]
+    ];
+
+    ruleCodes.forEach(([text, expectedOutput, p2r]) => {
+      let rules = cdp._parseRuleNames(text, p2r);
+
+      if (rules.constructor.name === "Array") {
+        rules = rules.join();
+      }
+
+      rules.should.equal(expectedOutput);
+    });
+
+    let counter = 7;
+    cdp.lastLine = 96;
+
+    cdp._toEndOfFile(counter, currentLine => {
+      currentLine.should.equal(counter++);
+    });
+
+    done();
+  });
 });

--- a/test/lib/rule-context.js
+++ b/test/lib/rule-context.js
@@ -6,185 +6,207 @@
 "use strict";
 
 let RuleContext = require("../../lib/rule-context"),
-    Solium = require("../../lib/solium"),
-    _ = require("lodash");
+  Solium = require("../../lib/solium"),
+  _ = require("lodash");
 
 /* eslint-disable no-unused-vars */
 
 describe("Testing RuleContext object", function() {
-    let ruleDesc = {
-        enabled: true,
-        recommended: true,
-        type: "warning",
-        description: "boo!",
-        id: 1,
-        custom: false,
-        options: ["double", 2, { modifies: true }]
-    };
+  let ruleDesc = {
+    enabled: true,
+    recommended: true,
+    type: "warning",
+    description: "boo!",
+    id: 1,
+    custom: false,
+    options: ["double", 2, { modifies: true }]
+  };
 
-    let meta = {
-        docs: {
-            recommended: true,
-            type: "error",
-            description: "Ensure that all strings use only 1 style - either double quotes or single quotes."
+  let meta = {
+    docs: {
+      recommended: true,
+      type: "error",
+      description:
+        "Ensure that all strings use only 1 style - either double quotes or single quotes."
+    },
+    schema: []
+  };
+
+  let sourceCode = "contract Visual {\n\tfunction foobar () {}\n}";
+
+  it("should create a RuleContext instance and expose an API when valid arguments are passed", function(done) {
+    let rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
+
+    rcObject.should.be.type("object");
+    rcObject.should.be.instanceOf(RuleContext);
+    rcObject.should.have.size(3); // name & meta are readable props, so not counted as ownProperty of object
+
+    rcObject.should.have.ownProperty("getSourceCode");
+    rcObject.getSourceCode.should.be.type("function");
+
+    rcObject.should.have.ownProperty("report");
+    rcObject.report.should.be.type("function");
+
+    //read-only properties
+    rcObject.should.have.ownProperty("name");
+    rcObject.name.should.be.type("string");
+    Object.getOwnPropertyDescriptor(rcObject, "name").writable.should.equal(
+      false
+    ); //check for read-only
+
+    rcObject.should.have.ownProperty("meta");
+    rcObject.meta.should.be.type("object");
+    _.isEqual(rcObject.meta, ruleDesc).should.equal(true);
+    Object.getOwnPropertyDescriptor(rcObject, "meta").writable.should.equal(
+      false
+    ); //check for read-only
+
+    rcObject.should.have.ownProperty("options");
+    rcObject.options.should.be.type("object");
+    rcObject.options.constructor.name.should.equal("Array");
+    rcObject.options[0].should.equal("double");
+    rcObject.options[1].should.equal(2);
+    rcObject.options[2].modifies.should.equal(true);
+
+    done();
+  });
+
+  it("should behave as expected upon calling getSourceCode ()", function(done) {
+    let rcObject, scObject;
+
+    Solium.lint(sourceCode, { rules: {} });
+    rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
+    scObject = rcObject.getSourceCode();
+
+    scObject.should.be.type("object");
+    scObject.constructor.name.should.equal("SourceCode");
+    scObject.should.have.ownProperty("text");
+    scObject.text.should.equal(sourceCode);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should handle invalid argument(s) passed to report()", function(done) {
+    let rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
+
+    rcObject.report.bind(rcObject).should.throw();
+    rcObject.report.bind(rcObject, null).should.throw();
+    rcObject.report.bind(rcObject, 100).should.throw();
+    rcObject.report.bind(rcObject, "foo").should.throw();
+    rcObject.report.bind(rcObject, []).should.throw();
+
+    let sampleNode = { type: "Literal", start: 0, end: 10 };
+
+    rcObject.report.bind(rcObject, {}).should.throw();
+    rcObject.report.bind(rcObject, { message: 91072 }).should.throw();
+    rcObject.report
+      .bind(rcObject, { message: "hello", node: true })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, { message: "hello", node: sampleNode, randomAttr: {} })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, {
+        message: "hello",
+        node: sampleNode,
+        location: { randomAttr: 1908 }
+      })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, {
+        message: "hello",
+        node: sampleNode,
+        location: { line: 90.1897 }
+      })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, {
+        message: "hello",
+        node: sampleNode,
+        location: { column: null }
+      })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, {
+        message: "hello",
+        node: sampleNode,
+        location: { line: 0 }
+      })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, {
+        message: "hello",
+        node: sampleNode,
+        location: { column: -1 }
+      })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, { message: "hello", node: sampleNode, location: NaN })
+      .should.throw();
+    rcObject.report
+      .bind(rcObject, {
+        message: "hello",
+        node: sampleNode,
+        fix: "this is a fix!!"
+      })
+      .should.throw();
+
+    // A minimal valid object should not throw
+    rcObject.report
+      .bind(rcObject, { message: "hello", node: sampleNode })
+      .should.not.throw();
+
+    // A maximal valid object should not throw
+    rcObject.report
+      .bind(rcObject, {
+        message: "hello",
+        node: sampleNode,
+        location: {
+          line: 7,
+          column: 56
         },
-        schema: []
-    };
+        fix(fixer) {
+          return null;
+        }
+      })
+      .should.not.throw();
 
-    let sourceCode = "contract Visual {\n\tfunction foobar () {}\n}";
+    Solium.reset(); // important here because the above 2 report()s add error messages to Solium that we need to remove.
+    done();
+  });
 
-    it("should create a RuleContext instance and expose an API when valid arguments are passed", function(done) {
-        let rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
+  it("should behave as expected upon calling report ()", function(done) {
+    let rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
 
-        rcObject.should.be.type("object");
-        rcObject.should.be.instanceOf(RuleContext);
-        rcObject.should.have.size(3);	// name & meta are readable props, so not counted as ownProperty of object
-
-        rcObject.should.have.ownProperty("getSourceCode");
-        rcObject.getSourceCode.should.be.type("function");
-
-        rcObject.should.have.ownProperty("report");
-        rcObject.report.should.be.type("function");
-
-        //read-only properties
-        rcObject.should.have.ownProperty("name");
-        rcObject.name.should.be.type("string");
-        Object.getOwnPropertyDescriptor(rcObject, "name").writable.should.equal(false);	//check for read-only
-
-        rcObject.should.have.ownProperty("meta");
-        rcObject.meta.should.be.type("object");
-        _.isEqual(rcObject.meta, ruleDesc).should.equal(true);
-        Object.getOwnPropertyDescriptor(rcObject, "meta").writable.should.equal(false);	//check for read-only
-
-        rcObject.should.have.ownProperty("options");
-        rcObject.options.should.be.type("object");
-        rcObject.options.constructor.name.should.equal("Array");
-        rcObject.options [0].should.equal("double");
-        rcObject.options [1].should.equal(2);
-        rcObject.options [2].modifies.should.equal(true);
-
-        done();
+    rcObject.report({
+      node: { type: "TestNode", start: 0, end: 2 },
+      message: "test run"
     });
+    let errorObjects = Solium.lint(sourceCode, { rules: {} }, true);
 
-    it("should behave as expected upon calling getSourceCode ()", function(done) {
-        let rcObject, scObject;
+    errorObjects.length.should.equal(1);
+    let err = errorObjects[0];
 
-        Solium.lint(sourceCode, { rules: {} });
-        rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
-        scObject = rcObject.getSourceCode();
+    err.should.be.type("object");
+    err.should.have.ownProperty("ruleName");
+    err.ruleName.should.equal("foo");
+    err.should.have.ownProperty("type");
+    err.type.should.equal("warning");
+    err.should.have.ownProperty("node");
+    err.node.should.be.type("object");
+    err.node.should.have.ownProperty("type");
+    err.node.type.should.equal("TestNode");
+    err.should.have.ownProperty("message");
+    err.message.should.equal("test run");
+    err.should.have.ownProperty("line");
+    err.line.should.equal(1);
+    err.should.have.ownProperty("column");
+    err.column.should.equal(0);
 
-        scObject.should.be.type("object");
-        scObject.constructor.name.should.equal("SourceCode");
-        scObject.should.have.ownProperty("text");
-        scObject.text.should.equal(sourceCode);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should handle invalid argument(s) passed to report()", function(done) {
-        let rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
-
-        rcObject.report.bind(rcObject).should.throw();
-        rcObject.report.bind(rcObject, null).should.throw();
-        rcObject.report.bind(rcObject, 100).should.throw();
-        rcObject.report.bind(rcObject, "foo").should.throw();
-        rcObject.report.bind(rcObject, []).should.throw();
-
-        let sampleNode = { type: "Literal", start: 0, end: 10 };
-
-        rcObject.report.bind(rcObject, {}).should.throw();
-        rcObject.report.bind(rcObject, {message: 91072}).should.throw();
-        rcObject.report.bind(rcObject, {message: "hello", node: true}).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, randomAttr: {}}
-        ).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, location: {randomAttr: 1908}}
-        ).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, location: {line: 90.1897}}
-        ).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, location: {column: null}}
-        ).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, location: {line: 0}}
-        ).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, location: {column: -1}}
-        ).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, location: NaN}
-        ).should.throw();
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode, fix: "this is a fix!!"}
-        ).should.throw();
-
-        // A minimal valid object should not throw
-        rcObject.report.bind(
-            rcObject,
-            {message: "hello", node: sampleNode}
-        ).should.not.throw();
-
-        // A maximal valid object should not throw
-        rcObject.report.bind(
-            rcObject,
-            {
-                message: "hello",
-                node: sampleNode,
-                location: {
-                    line: 7,
-                    column: 56
-                },
-                fix(fixer) { return null; }
-            }
-        ).should.not.throw();
-
-        Solium.reset(); // important here because the above 2 report()s add error messages to Solium that we need to remove.
-        done();
-    });
-
-    it("should behave as expected upon calling report ()", function(done) {
-        let rcObject = new RuleContext("foo", ruleDesc, meta, Solium);
-
-        rcObject.report({
-            node: {type: "TestNode", start: 0, end: 2},
-            message: "test run"
-        });
-        let errorObjects = Solium.lint(sourceCode, { rules: {} }, true);
-
-        errorObjects.length.should.equal(1);
-        let err = errorObjects [0];
-
-        err.should.be.type("object");
-        err.should.have.ownProperty("ruleName");
-        err.ruleName.should.equal("foo");
-        err.should.have.ownProperty("type");
-        err.type.should.equal("warning");
-        err.should.have.ownProperty("node");
-        err.node.should.be.type("object");
-        err.node.should.have.ownProperty("type");
-        err.node.type.should.equal("TestNode");
-        err.should.have.ownProperty("message");
-        err.message.should.equal("test run");
-        err.should.have.ownProperty("line");
-        err.line.should.equal(1);
-        err.should.have.ownProperty("column");
-        err.column.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 /* eslint-enable no-unused-vars */

--- a/test/lib/rules.js
+++ b/test/lib/rules.js
@@ -7,443 +7,452 @@
 "use strict";
 
 let rules = require("../../lib/rules"),
-    path = require("path");
+  path = require("path");
 
 describe("Checking exported rules object", function() {
+  it("should be an object that exposes a set of functions", function(done) {
+    rules.should.be.type("object");
+    rules.should.be.size(5);
 
-    it("should be an object that exposes a set of functions", function(done) {
-        rules.should.be.type("object");
-        rules.should.be.size(5);
+    rules.should.have.ownProperty("loadUsingDeprecatedConfigFormat");
+    rules.loadUsingDeprecatedConfigFormat.should.be.type("function");
 
-        rules.should.have.ownProperty("loadUsingDeprecatedConfigFormat");
-        rules.loadUsingDeprecatedConfigFormat.should.be.type("function");
+    rules.should.have.ownProperty("get");
+    rules.get.should.be.type("function");
 
-        rules.should.have.ownProperty("get");
-        rules.get.should.be.type("function");
+    rules.should.have.ownProperty("reset");
+    rules.reset.should.be.type("function");
 
-        rules.should.have.ownProperty("reset");
-        rules.reset.should.be.type("function");
+    rules.should.have.ownProperty("load");
+    rules.load.should.be.type("function");
 
-        rules.should.have.ownProperty("load");
-        rules.load.should.be.type("function");
+    rules.should.have.ownProperty("getRuleSeverity");
+    rules.getRuleSeverity.should.be.type("function");
 
-        rules.should.have.ownProperty("getRuleSeverity");
-        rules.getRuleSeverity.should.be.type("function");
+    done();
+  });
 
-        done();
+  it("should handle invalid arguments passed to rules.get ()", function(done) {
+    rules.get.bind(rules).should.throw();
+    rules.get.bind(rules, null).should.throw();
+    rules.get.bind(rules, 100).should.throw();
+    rules.get.bind(rules, "").should.throw();
+    rules.get.bind(rules, []).should.throw();
+    rules.get.bind(rules, {}).should.throw();
+    rules.get.bind(rules, 89.18).should.throw();
+    rules.get.bind(rules, function() {}).should.throw();
+
+    rules.get.bind(rules, "foobar").should.not.throw();
+
+    done();
+  });
+
+  it("should handle invalid arguments passed to rules.loadUsingDeprecatedConfigFormat ()", function(done) {
+    //invalid userRules object
+    rules.loadUsingDeprecatedConfigFormat.bind(rules).should.throw();
+    rules.loadUsingDeprecatedConfigFormat.bind(rules, null).should.throw();
+    rules.loadUsingDeprecatedConfigFormat.bind(rules, []).should.throw();
+
+    //valid userRules object
+    rules.loadUsingDeprecatedConfigFormat.bind(rules, {}).should.not.throw();
+
+    //specified rule is neither pre-defined nor custom
+    rules.loadUsingDeprecatedConfigFormat
+      .bind(rules, { NON_EXISTANT_RULE_1: true })
+      .should.throw();
+
+    done();
+  });
+
+  it("should return a rule object after valid call to loadUsingDeprecatedConfigFormat () & get ()", function(done) {
+    let config = { mixedcase: true, camelcase: false, lbrace: true };
+    rules.loadUsingDeprecatedConfigFormat(
+      config,
+      path.join(__dirname, "../extras/custom-rules-file.js")
+    );
+
+    let ret = rules.get("mixedcase");
+    ret.should.be.type("object");
+    ret.should.have.ownProperty("create");
+    ret.create.should.be.type("function");
+
+    ret = rules.get("camelcase");
+    (typeof ret).should.equal("undefined");
+
+    //overlapping rule - lbrace (custom) should overwrite lbrace (pre-defined)
+    ret = rules.get("lbrace");
+    ret.should.be.type("object");
+    ret.should.have.ownProperty("create");
+    ret.create.should.be.type("function");
+
+    //rule definition exists in the file but shouldn't be included in rules because we don't enable it
+    ret = rules.get("not-included");
+    (typeof ret).should.equal("undefined");
+
+    config = { CUSTOM_RULE: true };
+    rules.loadUsingDeprecatedConfigFormat
+      .bind(
+        rules,
+        config,
+        path.join(__dirname, "../extras/custom-rules-file.js")
+      )
+      .should.throw();
+
+    rules.reset();
+    done();
+  });
+
+  it("rules set to false to be deleted, rest (pre-defined) should be expanded with rule meta info in loadUsingDeprecatedConfigFormat()", function(done) {
+    let config = {
+      mixedcase: true,
+      camelcase: false,
+      lbrace: true,
+      NON_EXISTANT_RULE_2: false
+    };
+
+    rules.loadUsingDeprecatedConfigFormat(
+      config,
+      path.join(__dirname, "../extras/custom-rules-file.js")
+    );
+
+    config.should.be.type("object");
+    config.should.not.have.ownProperty("camelcase");
+    config.should.not.have.ownProperty("NON_EXISTANT_RULE_2");
+
+    //a non-existant rule set to true must NOT be deleted by load (), this might be a custom-defined rule
+
+    config.should.have.ownProperty("mixedcase");
+    config.mixedcase.should.be.type("object");
+    config.mixedcase.should.have.ownProperty("enabled");
+    config.mixedcase.enabled.should.equal(true);
+    config.mixedcase.should.have.ownProperty("custom");
+    config.mixedcase.custom.should.equal(false);
+    config.mixedcase.should.have.ownProperty("recommended");
+    config.mixedcase.recommended.should.be.type("boolean");
+    config.mixedcase.should.have.ownProperty("type");
+    config.mixedcase.should.have.ownProperty("description");
+    config.mixedcase.should.have.ownProperty("id");
+    config.mixedcase.id.should.be.type("number");
+
+    config.should.have.ownProperty("lbrace");
+    config.lbrace.should.be.type("object");
+    config.lbrace.should.have.ownProperty("enabled");
+    config.lbrace.enabled.should.equal(true);
+    config.lbrace.should.have.ownProperty("custom");
+    config.lbrace.custom.should.equal(false);
+    config.lbrace.should.have.ownProperty("type");
+    config.lbrace.type.should.equal("error");
+    config.lbrace.should.have.ownProperty("id");
+    config.lbrace.id.should.be.type("number");
+
+    done();
+  });
+
+  it("should handle invalid arguments passed to getRuleSeverity()", function(done) {
+    rules.getRuleSeverity.bind(rules).should.throw();
+    rules.getRuleSeverity.bind(rules, undefined).should.throw();
+    rules.getRuleSeverity.bind(rules, null).should.throw();
+    rules.getRuleSeverity.bind(rules, {}).should.throw();
+    rules.getRuleSeverity.bind(rules, 19.8927).should.throw();
+    rules.getRuleSeverity.bind(rules, -1).should.throw();
+    rules.getRuleSeverity.bind(rules, 3).should.throw();
+    rules.getRuleSeverity.bind(rules, 19028).should.throw();
+    rules.getRuleSeverity.bind(rules, "arbitrary").should.throw();
+    rules.getRuleSeverity.bind(rules, { a: true, b: "c" }).should.throw();
+    rules.getRuleSeverity.bind(rules, []).should.throw();
+    rules.getRuleSeverity.bind(rules, [null]).should.throw();
+
+    done();
+  });
+
+  it("should return severity integer when a valid config value is passed", function(done) {
+    rules.getRuleSeverity(0).should.equal(0);
+    rules.getRuleSeverity(1).should.equal(1);
+    rules.getRuleSeverity(2).should.equal(2);
+    rules.getRuleSeverity("off").should.equal(0);
+    rules.getRuleSeverity("warning").should.equal(1);
+    rules.getRuleSeverity("error").should.equal(2);
+    rules.getRuleSeverity([0]).should.equal(0);
+    rules.getRuleSeverity([1]).should.equal(1);
+    rules.getRuleSeverity([2]).should.equal(2);
+    rules.getRuleSeverity(["off"]).should.equal(0);
+    rules.getRuleSeverity(["warning"]).should.equal(1);
+    rules.getRuleSeverity(["error"]).should.equal(2);
+
+    done();
+  });
+
+  it('should load rules from the new config format using load() when both "extends" & "rules" are passed', function(done) {
+    let config = {
+      extends: "solium:all",
+      plugins: [],
+      rules: {
+        "pragma-on-top": "off",
+        "no-with": "warning",
+        "deprecated-suicide": "error",
+        "variable-declarations": 0,
+        "imports-on-top": 1,
+        "array-declarations": 2,
+        "operator-whitespace": ["off", "double"],
+        lbrace: ["warning", 1, 2, { a: 100, h: "world" }],
+        mixedcase: ["error"],
+        camelcase: [0, 100, "hello", 9.283],
+        uppercase: [1],
+        "double-quotes": [2, "double"]
+      },
+      options: { autofix: false }
+    };
+
+    let ruleDescriptions = rules.load(config);
+
+    ruleDescriptions.should.be.type("object");
+
+    ruleDescriptions.should.not.have.ownProperty("pragma-on-top");
+    ruleDescriptions.should.not.have.ownProperty("variable-declarations");
+    ruleDescriptions.should.not.have.ownProperty("operator-whitespace");
+    ruleDescriptions.should.not.have.ownProperty("camelcase");
+
+    ruleDescriptions["no-with"].type.should.equal("warning");
+    ruleDescriptions["imports-on-top"].type.should.equal("warning");
+    ruleDescriptions["lbrace"].type.should.equal("warning");
+    ruleDescriptions["uppercase"].type.should.equal("warning");
+
+    ruleDescriptions["deprecated-suicide"].type.should.equal("error");
+    ruleDescriptions["array-declarations"].type.should.equal("error");
+    ruleDescriptions["mixedcase"].type.should.equal("error");
+    ruleDescriptions["double-quotes"].type.should.equal("error");
+
+    // We extend ALL solium core rules and eliminate a few by setting their severity to 0.
+    // The rest of the rules should all be available.
+    // The below count will keep changing with every change in the number of core rules that exist in solium.
+    Object.keys(ruleDescriptions).length.should.equal(27);
+
+    done();
+  });
+
+  it('should load rules from the new config format using load() when only "rules" is passed', function(done) {
+    let config = {
+      rules: {
+        "pragma-on-top": "off",
+        "no-with": "warning",
+        "deprecated-suicide": "error",
+        "variable-declarations": 0,
+        "imports-on-top": 1,
+        "array-declarations": 2,
+        "operator-whitespace": ["off", "double"],
+        lbrace: ["warning", 1, 2, { a: 100, h: "world" }],
+        mixedcase: ["error"],
+        camelcase: [0, 100, "hello", 9.283],
+        uppercase: [1],
+        "double-quotes": [2, "double"]
+      }
+    };
+
+    let ruleDescriptions = rules.load(config);
+
+    ruleDescriptions.should.be.type("object");
+
+    ruleDescriptions.should.not.have.ownProperty("pragma-on-top");
+    ruleDescriptions.should.not.have.ownProperty("variable-declarations");
+    ruleDescriptions.should.not.have.ownProperty("operator-whitespace");
+    ruleDescriptions.should.not.have.ownProperty("camelcase");
+
+    ruleDescriptions["no-with"].type.should.equal("warning");
+    ruleDescriptions["imports-on-top"].type.should.equal("warning");
+    ruleDescriptions["lbrace"].type.should.equal("warning");
+    ruleDescriptions["uppercase"].type.should.equal("warning");
+
+    ruleDescriptions["deprecated-suicide"].type.should.equal("error");
+    ruleDescriptions["array-declarations"].type.should.equal("error");
+    ruleDescriptions["mixedcase"].type.should.equal("error");
+    ruleDescriptions["double-quotes"].type.should.equal("error");
+
+    // Check for existence of options
+    ruleDescriptions["lbrace"].should.have.ownProperty("options");
+    ruleDescriptions["lbrace"].options.should.be.Array();
+
+    ruleDescriptions["double-quotes"].should.have.ownProperty("options");
+    ruleDescriptions["double-quotes"].options.should.be.Array();
+
+    // Check for options contents
+    ruleDescriptions["lbrace"].options.length.should.equal(3);
+    ruleDescriptions["lbrace"].options[0].should.equal(1);
+
+    ruleDescriptions["double-quotes"].options.length.should.equal(1);
+    ruleDescriptions["double-quotes"].options[0].should.equal("double");
+
+    // Also ensure that these rules' definitions are loaded as expected
+    Object.keys(ruleDescriptions).forEach(function(name) {
+      let ruleDefinition = rules.get(name);
+
+      ruleDefinition.should.be.type("object");
+      ruleDefinition.should.have.size(2);
+      ruleDefinition.should.have.ownProperty("meta");
+      ruleDefinition.should.have.ownProperty("create");
+      ruleDefinition.meta.should.be.type("object");
+      ruleDefinition.create.should.be.type("function");
     });
 
-    it("should handle invalid arguments passed to rules.get ()", function(done) {
-        rules.get.bind(rules).should.throw();
-        rules.get.bind(rules, null).should.throw();
-        rules.get.bind(rules, 100).should.throw();
-        rules.get.bind(rules, "").should.throw();
-        rules.get.bind(rules, []).should.throw();
-        rules.get.bind(rules, {}).should.throw();
-        rules.get.bind(rules, 89.18).should.throw();
-        rules.get.bind(rules, function(){}).should.throw();
+    // There should be exactly 8 properties - the rules described in "rules" with severity > 0.
+    Object.keys(ruleDescriptions).length.should.equal(8);
 
-        rules.get.bind(rules, "foobar").should.not.throw();
+    done();
+  });
 
-        done();
+  it("should load rules from specified plugin(s) if they are installed", function(done) {
+    let config = {
+      extends: "solium:all",
+      plugins: ["test"],
+      rules: {
+        quotes: 1,
+        "test/foo": 1,
+        "test/bar": ["error"]
+      }
+    };
+
+    let ruleDescriptions = rules.load(config);
+
+    ruleDescriptions.should.be.type("object");
+    ruleDescriptions.should.have.ownProperty("test/foo");
+    ruleDescriptions["test/foo"].type.should.equal("warning");
+    ruleDescriptions.should.have.ownProperty("test/bar");
+    ruleDescriptions["test/bar"].type.should.equal("error");
+
+    ["test/foo", "test/bar"].forEach(function(name) {
+      let ruleDefinition = rules.get(name);
+
+      ruleDefinition.should.be.type("object");
+      ruleDefinition.should.have.size(2);
+      ruleDefinition.should.have.ownProperty("meta");
+      ruleDefinition.should.have.ownProperty("create");
+      ruleDefinition.meta.should.be.type("object");
+      ruleDefinition.create.should.be.type("function");
     });
 
-    it("should handle invalid arguments passed to rules.loadUsingDeprecatedConfigFormat ()", function(done) {
-        //invalid userRules object
-        rules.loadUsingDeprecatedConfigFormat.bind(rules).should.throw();
-        rules.loadUsingDeprecatedConfigFormat.bind(rules, null).should.throw();
-        rules.loadUsingDeprecatedConfigFormat.bind(rules, []).should.throw();
+    delete config.extends;
+    config.rules["test/foo"] = [2];
+    ruleDescriptions = rules.load(config);
 
-        //valid userRules object
-        rules.loadUsingDeprecatedConfigFormat.bind(rules, {}).should.not.throw();
+    ruleDescriptions.should.be.type("object");
+    ruleDescriptions.should.have.ownProperty("test/foo");
+    ruleDescriptions["test/foo"].type.should.equal("error");
+    ruleDescriptions.should.have.ownProperty("test/bar");
+    ruleDescriptions["test/bar"].type.should.equal("error");
 
-        //specified rule is neither pre-defined nor custom
-        rules.loadUsingDeprecatedConfigFormat.bind(rules, {"NON_EXISTANT_RULE_1": true}).should.throw();
+    ["test/foo", "test/bar"].forEach(function(name) {
+      let ruleDefinition = rules.get(name);
 
-        done();
+      ruleDefinition.should.be.type("object");
+      ruleDefinition.should.have.size(2);
+      ruleDefinition.should.have.ownProperty("meta");
+      ruleDefinition.should.have.ownProperty("create");
+      ruleDefinition.meta.should.be.type("object");
+      ruleDefinition.create.should.be.type("function");
     });
 
-    it("should return a rule object after valid call to loadUsingDeprecatedConfigFormat () & get ()", function(done) {
-        let config = { "mixedcase": true, "camelcase": false, "lbrace": true };
-        rules.loadUsingDeprecatedConfigFormat(config, path.join(__dirname, "../extras/custom-rules-file.js"));
+    delete config.rules.quotes;
+    config.rules["test/foo"] = [1];
+    ruleDescriptions = rules.load(config);
 
-        let ret = rules.get("mixedcase");
-        ret.should.be.type("object");
-        ret.should.have.ownProperty("create");
-        ret.create.should.be.type("function");
+    ruleDescriptions.should.be.type("object");
+    ruleDescriptions.should.have.ownProperty("test/foo");
+    ruleDescriptions["test/foo"].type.should.equal("warning");
+    ruleDescriptions.should.have.ownProperty("test/bar");
+    ruleDescriptions["test/bar"].type.should.equal("error");
 
-        ret = rules.get("camelcase");
-        (typeof ret).should.equal("undefined");
+    ["test/foo", "test/bar"].forEach(function(name) {
+      let ruleDefinition = rules.get(name);
 
-        //overlapping rule - lbrace (custom) should overwrite lbrace (pre-defined)
-        ret = rules.get("lbrace");
-        ret.should.be.type("object");
-        ret.should.have.ownProperty("create");
-        ret.create.should.be.type("function");
-
-        //rule definition exists in the file but shouldn't be included in rules because we don't enable it
-        ret = rules.get("not-included");
-        (typeof ret).should.equal("undefined");
-
-        config = { "CUSTOM_RULE": true };
-        rules.loadUsingDeprecatedConfigFormat.bind(rules, config, path.join(__dirname, "../extras/custom-rules-file.js")).should.throw();
-
-        rules.reset();
-        done();
+      ruleDefinition.should.be.type("object");
+      ruleDefinition.should.have.size(2);
+      ruleDefinition.should.have.ownProperty("meta");
+      ruleDefinition.should.have.ownProperty("create");
+      ruleDefinition.meta.should.be.type("object");
+      ruleDefinition.create.should.be.type("function");
     });
 
-    it("rules set to false to be deleted, rest (pre-defined) should be expanded with rule meta info in loadUsingDeprecatedConfigFormat()", function(done) {
-        let config = {
-            "mixedcase": true,
-            "camelcase": false,
-            "lbrace": true,
-            "NON_EXISTANT_RULE_2": false
-        };
+    delete config.rules;
+    config.extends = "solium:all";
+    config.rules = { "test/foo": "error", "test/bar": 1 };
+    ruleDescriptions = rules.load(config);
 
-        rules.loadUsingDeprecatedConfigFormat(config, path.join(__dirname, "../extras/custom-rules-file.js"));
+    ruleDescriptions.should.be.type("object");
+    ruleDescriptions.should.have.ownProperty("test/foo");
+    ruleDescriptions["test/foo"].type.should.equal("error");
+    ruleDescriptions.should.have.ownProperty("test/bar");
+    ruleDescriptions["test/bar"].type.should.equal("warning");
 
-        config.should.be.type("object");
-        config.should.not.have.ownProperty("camelcase");
-        config.should.not.have.ownProperty("NON_EXISTANT_RULE_2");
+    ["test/foo", "test/bar"].forEach(function(name) {
+      let ruleDefinition = rules.get(name);
 
-        //a non-existant rule set to true must NOT be deleted by load (), this might be a custom-defined rule
-
-        config.should.have.ownProperty("mixedcase");
-        config.mixedcase.should.be.type("object");
-        config.mixedcase.should.have.ownProperty("enabled");
-        config.mixedcase.enabled.should.equal(true);
-        config.mixedcase.should.have.ownProperty("custom");
-        config.mixedcase.custom.should.equal(false);
-        config.mixedcase.should.have.ownProperty("recommended");
-        config.mixedcase.recommended.should.be.type("boolean");
-        config.mixedcase.should.have.ownProperty("type");
-        config.mixedcase.should.have.ownProperty("description");
-        config.mixedcase.should.have.ownProperty("id");
-        config.mixedcase.id.should.be.type("number");
-
-        config.should.have.ownProperty("lbrace");
-        config.lbrace.should.be.type("object");
-        config.lbrace.should.have.ownProperty("enabled");
-        config.lbrace.enabled.should.equal(true);
-        config.lbrace.should.have.ownProperty("custom");
-        config.lbrace.custom.should.equal(false);
-        config.lbrace.should.have.ownProperty("type");
-        config.lbrace.type.should.equal("error");
-        config.lbrace.should.have.ownProperty("id");
-        config.lbrace.id.should.be.type("number");
-
-        done();
+      ruleDefinition.should.be.type("object");
+      ruleDefinition.should.have.size(2);
+      ruleDefinition.should.have.ownProperty("meta");
+      ruleDefinition.should.have.ownProperty("create");
+      ruleDefinition.meta.should.be.type("object");
+      ruleDefinition.create.should.be.type("function");
     });
 
-    it("should handle invalid arguments passed to getRuleSeverity()", function(done) {
-        rules.getRuleSeverity.bind(rules).should.throw();
-        rules.getRuleSeverity.bind(rules, undefined).should.throw();
-        rules.getRuleSeverity.bind(rules, null).should.throw();
-        rules.getRuleSeverity.bind(rules, {}).should.throw();
-        rules.getRuleSeverity.bind(rules, 19.8927).should.throw();
-        rules.getRuleSeverity.bind(rules, -1).should.throw();
-        rules.getRuleSeverity.bind(rules, 3).should.throw();
-        rules.getRuleSeverity.bind(rules, 19028).should.throw();
-        rules.getRuleSeverity.bind(rules, "arbitrary").should.throw();
-        rules.getRuleSeverity.bind(rules, {a: true, b: "c"}).should.throw();
-        rules.getRuleSeverity.bind(rules, []).should.throw();
-        rules.getRuleSeverity.bind(rules, [null]).should.throw();
+    delete config.rules;
+    ruleDescriptions = rules.load(config);
 
-        done();
+    ruleDescriptions.should.be.type("object");
+    ruleDescriptions.should.have.ownProperty("test/foo");
+    ruleDescriptions.should.have.ownProperty("test/bar");
+
+    ["test/foo", "test/bar"].forEach(function(name) {
+      (rules.get(name) === undefined).should.be.false();
     });
 
-    it("should return severity integer when a valid config value is passed", function(done) {
-        rules.getRuleSeverity(0).should.equal(0);
-        rules.getRuleSeverity(1).should.equal(1);
-        rules.getRuleSeverity(2).should.equal(2);
-        rules.getRuleSeverity("off").should.equal(0);
-        rules.getRuleSeverity("warning").should.equal(1);
-        rules.getRuleSeverity("error").should.equal(2);
-        rules.getRuleSeverity([0]).should.equal(0);
-        rules.getRuleSeverity([1]).should.equal(1);
-        rules.getRuleSeverity([2]).should.equal(2);
-        rules.getRuleSeverity(["off"]).should.equal(0);
-        rules.getRuleSeverity(["warning"]).should.equal(1);
-        rules.getRuleSeverity(["error"]).should.equal(2);
+    config.rules = { "test/foo": 0, "test/bar": 0 };
+    ruleDescriptions = rules.load(config);
 
-        done();
+    ruleDescriptions.should.be.type("object");
+    ruleDescriptions.should.not.have.ownProperty("test/foo");
+    ruleDescriptions.should.not.have.ownProperty("test/bar");
+
+    ["test/foo", "test/bar"].forEach(function(name) {
+      (rules.get(name) === undefined).should.be.true();
     });
 
-    it("should load rules from the new config format using load() when both \"extends\" & \"rules\" are passed", function(done) {
-        let config = {
-            "extends": "solium:all",
-            "plugins": [],
-            "rules": {
-                "pragma-on-top": "off",
-                "no-with": "warning",
-                "deprecated-suicide": "error",
-                "variable-declarations": 0,
-                "imports-on-top": 1,
-                "array-declarations": 2,
-                "operator-whitespace": ["off", "double"],
-                "lbrace": ["warning", 1, 2, {a: 100, h: "world"}],
-                "mixedcase": ["error"],
-                "camelcase": [0, 100, "hello", 9.283],
-                "uppercase": [1],
-                "double-quotes": [2, "double"]
-            },
-            "options": { "autofix": false }
-        };
+    done();
+  });
 
-        let ruleDescriptions = rules.load(config);
+  it("should handle when a specified plugin is not installed", function(done) {
+    let config = {
+      extends: "solium:all",
+      plugins: ["16%^54#$^%3"]
+    };
 
-        ruleDescriptions.should.be.type("object");
+    rules.load.bind(rules, config).should.throw();
 
-        ruleDescriptions.should.not.have.ownProperty("pragma-on-top");
-        ruleDescriptions.should.not.have.ownProperty("variable-declarations");
-        ruleDescriptions.should.not.have.ownProperty("operator-whitespace");
-        ruleDescriptions.should.not.have.ownProperty("camelcase");
+    config.plugins = "test";
+    config.rules = {
+      "test/somerandomrule": 1
+    };
 
-        ruleDescriptions ["no-with"].type.should.equal("warning");
-        ruleDescriptions ["imports-on-top"].type.should.equal("warning");
-        ruleDescriptions ["lbrace"].type.should.equal("warning");
-        ruleDescriptions ["uppercase"].type.should.equal("warning");
+    rules.load.bind(rules, config).should.throw();
 
-        ruleDescriptions ["deprecated-suicide"].type.should.equal("error");
-        ruleDescriptions ["array-declarations"].type.should.equal("error");
-        ruleDescriptions ["mixedcase"].type.should.equal("error");
-        ruleDescriptions ["double-quotes"].type.should.equal("error");
+    config = {
+      extends: "solium:all",
+      plugins: ["test-invalid-schema"]
+    };
 
-        // We extend ALL solium core rules and eliminate a few by setting their severity to 0.
-        // The rest of the rules should all be available.
-        // The below count will keep changing with every change in the number of core rules that exist in solium.
-        Object.keys(ruleDescriptions).length.should.equal(27);
+    rules.load.bind(rules, config).should.throw();
 
-        done();
-    });
+    done();
+  });
 
-    it("should load rules from the new config format using load() when only \"rules\" is passed", function(done) {
-        let config = {
-            "rules": {
-                "pragma-on-top": "off",
-                "no-with": "warning",
-                "deprecated-suicide": "error",
-                "variable-declarations": 0,
-                "imports-on-top": 1,
-                "array-declarations": 2,
-                "operator-whitespace": ["off", "double"],
-                "lbrace": ["warning", 1, 2, {a: 100, h: "world"}],
-                "mixedcase": ["error"],
-                "camelcase": [0, 100, "hello", 9.283],
-                "uppercase": [1],
-                "double-quotes": [2, "double"]
-            }
-        };
+  it("should throw when a non-existant plugin rule is specified in config", done => {
+    const config = {
+      rules: {
+        "security/buttercup": 2
+      }
+    };
 
-        let ruleDescriptions = rules.load(config);
-
-        ruleDescriptions.should.be.type("object");
-
-        ruleDescriptions.should.not.have.ownProperty("pragma-on-top");
-        ruleDescriptions.should.not.have.ownProperty("variable-declarations");
-        ruleDescriptions.should.not.have.ownProperty("operator-whitespace");
-        ruleDescriptions.should.not.have.ownProperty("camelcase");
-
-        ruleDescriptions ["no-with"].type.should.equal("warning");
-        ruleDescriptions ["imports-on-top"].type.should.equal("warning");
-        ruleDescriptions ["lbrace"].type.should.equal("warning");
-        ruleDescriptions ["uppercase"].type.should.equal("warning");
-
-        ruleDescriptions ["deprecated-suicide"].type.should.equal("error");
-        ruleDescriptions ["array-declarations"].type.should.equal("error");
-        ruleDescriptions ["mixedcase"].type.should.equal("error");
-        ruleDescriptions ["double-quotes"].type.should.equal("error");
-
-        // Check for existence of options
-        ruleDescriptions ["lbrace"].should.have.ownProperty("options");
-        ruleDescriptions ["lbrace"].options.should.be.Array();
-
-        ruleDescriptions ["double-quotes"].should.have.ownProperty("options");
-        ruleDescriptions ["double-quotes"].options.should.be.Array();
-
-        // Check for options contents
-        ruleDescriptions ["lbrace"].options.length.should.equal(3);
-        ruleDescriptions ["lbrace"].options [0].should.equal(1);
-
-        ruleDescriptions ["double-quotes"].options.length.should.equal(1);
-        ruleDescriptions ["double-quotes"].options [0].should.equal("double");
-
-        // Also ensure that these rules' definitions are loaded as expected
-        Object.keys(ruleDescriptions).forEach(function(name) {
-            let ruleDefinition = rules.get(name);
-
-            ruleDefinition.should.be.type("object");
-            ruleDefinition.should.have.size(2);
-            ruleDefinition.should.have.ownProperty("meta");
-            ruleDefinition.should.have.ownProperty("create");
-            ruleDefinition.meta.should.be.type("object");
-            ruleDefinition.create.should.be.type("function");
-        });
-
-        // There should be exactly 8 properties - the rules described in "rules" with severity > 0.
-        Object.keys(ruleDescriptions).length.should.equal(8);
-
-        done();
-    });
-
-    it("should load rules from specified plugin(s) if they are installed", function(done) {
-        let config = {
-            "extends": "solium:all",
-            "plugins": ["test"],
-            "rules": {
-                "quotes": 1,
-                "test/foo": 1,
-                "test/bar": ["error"]
-            }
-        };
-
-        let ruleDescriptions = rules.load(config);
-
-        ruleDescriptions.should.be.type("object");
-        ruleDescriptions.should.have.ownProperty("test/foo");
-        ruleDescriptions ["test/foo"].type.should.equal("warning");
-        ruleDescriptions.should.have.ownProperty("test/bar");
-        ruleDescriptions ["test/bar"].type.should.equal("error");
-
-        ["test/foo", "test/bar"].forEach(function(name) {
-            let ruleDefinition = rules.get(name);
-
-            ruleDefinition.should.be.type("object");
-            ruleDefinition.should.have.size(2);
-            ruleDefinition.should.have.ownProperty("meta");
-            ruleDefinition.should.have.ownProperty("create");
-            ruleDefinition.meta.should.be.type("object");
-            ruleDefinition.create.should.be.type("function");
-        });
-
-
-        delete config.extends;
-        config.rules ["test/foo"] = [2];
-        ruleDescriptions = rules.load(config);
-
-        ruleDescriptions.should.be.type("object");
-        ruleDescriptions.should.have.ownProperty("test/foo");
-        ruleDescriptions ["test/foo"].type.should.equal("error");
-        ruleDescriptions.should.have.ownProperty("test/bar");
-        ruleDescriptions ["test/bar"].type.should.equal("error");
-
-        ["test/foo", "test/bar"].forEach(function(name) {
-            let ruleDefinition = rules.get(name);
-
-            ruleDefinition.should.be.type("object");
-            ruleDefinition.should.have.size(2);
-            ruleDefinition.should.have.ownProperty("meta");
-            ruleDefinition.should.have.ownProperty("create");
-            ruleDefinition.meta.should.be.type("object");
-            ruleDefinition.create.should.be.type("function");
-        });
-
-
-        delete config.rules.quotes;
-        config.rules ["test/foo"] = [1];
-        ruleDescriptions = rules.load(config);
-
-        ruleDescriptions.should.be.type("object");
-        ruleDescriptions.should.have.ownProperty("test/foo");
-        ruleDescriptions ["test/foo"].type.should.equal("warning");
-        ruleDescriptions.should.have.ownProperty("test/bar");
-        ruleDescriptions ["test/bar"].type.should.equal("error");
-
-        ["test/foo", "test/bar"].forEach(function(name) {
-            let ruleDefinition = rules.get(name);
-
-            ruleDefinition.should.be.type("object");
-            ruleDefinition.should.have.size(2);
-            ruleDefinition.should.have.ownProperty("meta");
-            ruleDefinition.should.have.ownProperty("create");
-            ruleDefinition.meta.should.be.type("object");
-            ruleDefinition.create.should.be.type("function");
-        });
-
-
-        delete config.rules;
-        config.extends = "solium:all";
-        config.rules = { "test/foo": "error", "test/bar": 1 };
-        ruleDescriptions = rules.load(config);
-
-        ruleDescriptions.should.be.type("object");
-        ruleDescriptions.should.have.ownProperty("test/foo");
-        ruleDescriptions ["test/foo"].type.should.equal("error");
-        ruleDescriptions.should.have.ownProperty("test/bar");
-        ruleDescriptions ["test/bar"].type.should.equal("warning");
-
-        ["test/foo", "test/bar"].forEach(function(name) {
-            let ruleDefinition = rules.get(name);
-
-            ruleDefinition.should.be.type("object");
-            ruleDefinition.should.have.size(2);
-            ruleDefinition.should.have.ownProperty("meta");
-            ruleDefinition.should.have.ownProperty("create");
-            ruleDefinition.meta.should.be.type("object");
-            ruleDefinition.create.should.be.type("function");
-        });
-
-
-        delete config.rules;
-        ruleDescriptions = rules.load(config);
-
-        ruleDescriptions.should.be.type("object");
-        ruleDescriptions.should.have.ownProperty("test/foo");
-        ruleDescriptions.should.have.ownProperty("test/bar");
-
-        ["test/foo", "test/bar"].forEach(function(name) {
-            (rules.get(name) === undefined).should.be.false();
-        });
-
-
-        config.rules = { "test/foo": 0, "test/bar": 0 };
-        ruleDescriptions = rules.load(config);
-
-        ruleDescriptions.should.be.type("object");
-        ruleDescriptions.should.not.have.ownProperty("test/foo");
-        ruleDescriptions.should.not.have.ownProperty("test/bar");
-
-        ["test/foo", "test/bar"].forEach(function(name) {
-            (rules.get(name) === undefined).should.be.true();
-        });
-
-        done();
-    });
-
-    it("should handle when a specified plugin is not installed", function(done) {
-        let config = {
-            "extends": "solium:all",
-            "plugins": ["16%^54#$^%3"]
-        };
-
-        rules.load.bind(rules, config).should.throw();
-
-        config.plugins = "test";
-        config.rules = {
-            "test/somerandomrule": 1
-        };
-
-        rules.load.bind(rules, config).should.throw();
-
-        config = {
-            "extends": "solium:all",
-            "plugins": ["test-invalid-schema"]
-        };
-
-        rules.load.bind(rules, config).should.throw();
-
-        done();
-    });
-
-    it("should throw when a non-existant plugin rule is specified in config", done => {
-        const config = {
-            "rules": {
-                "security/buttercup": 2
-            }
-        };
-
-        rules.load.bind(rules, config).should.throw("\"security/buttercup\" - No such rule exists.");
-        done();
-    });
-
+    rules.load
+      .bind(rules, config)
+      .should.throw('"security/buttercup" - No such rule exists.');
+    done();
+  });
 });

--- a/test/lib/rules/arg-overflow/arg-overflow.js
+++ b/test/lib/rules/arg-overflow/arg-overflow.js
@@ -6,263 +6,289 @@
 "use strict";
 
 let Solium = require("../../../../lib/solium"),
-    wrappers = require("../../../utils/wrappers");
-let toContract = wrappers.toContract, toFunction = wrappers.toFunction;
+  wrappers = require("../../../utils/wrappers");
+let toContract = wrappers.toContract,
+  toFunction = wrappers.toFunction;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "arg-overflow": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "arg-overflow": true
+  }
 };
 
 describe("[RULE] arg-overflow: Rejections", function() {
+  it("should enforce the rule that excess element lists must go on individual lines", function(done) {
+    let code = toContract(
+        "function ArgumentOverflow(int one, int two, int three, int four) {}"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should enforce the rule that excess element lists must go on individual lines", function(done) {
-        let code = toContract("function ArgumentOverflow(int one, int two, int three, int four) {}"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "In case of more than 3 parameters, drop each into its own line."
+    );
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors[0].message.should.equal(
-            "In case of more than 3 parameters, drop each into its own line.");
-        
-        code = toContract("constructor(int one, int two, int three, int four) {}"),
-        errors = Solium.lint(code, userConfig);
+    (code = toContract(
+      "constructor(int one, int two, int three, int four) {}"
+    )),
+      (errors = Solium.lint(code, userConfig));
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors[0].message.should.equal(
-            "In case of more than 3 parameters, drop each into its own line.");
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "In case of more than 3 parameters, drop each into its own line."
+    );
 
-        code = toFunction("myFuncCall (10, \"hello world\", 20.67, 0x0);");
-        errors = Solium.lint(code, userConfig);
+    code = toFunction('myFuncCall (10, "hello world", 20.67, 0x0);');
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "Function \"myFuncCall\": in case of more than 3 arguments, drop each into its own line.");
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      'Function "myFuncCall": in case of more than 3 arguments, drop each into its own line.'
+    );
 
-        code = toFunction("uint[] x = [1,2,3,4];");
-        errors = Solium.lint(code, userConfig);
+    code = toFunction("uint[] x = [1,2,3,4];");
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "In case of more than 3 elements, array expression needs to be spread over multiple lines with 1 element per line.");
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "In case of more than 3 elements, array expression needs to be spread over multiple lines with 1 element per line."
+    );
 
-        code = toContract("struct Sample {address a; uint b; string c; int d;}");
-        errors = Solium.lint(code, userConfig);
+    code = toContract("struct Sample {address a; uint b; string c; int d;}");
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "\"Sample\": In case of more than 3 properties, struct declaration needs to be spread over multiple lines with 1 property per line.");
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      '"Sample": In case of more than 3 properties, struct declaration needs to be spread over multiple lines with 1 property per line.'
+    );
 
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] arg-overflow: Acceptances", function() {
+  it("should accept <= 3 arguments on single line", function(done) {
+    let code = toContract(
+        "function ArgumentOverflow(int one, int two, int three) {}"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept <= 3 arguments on single line", function(done) {
-        let code = toContract("function ArgumentOverflow(int one, int two, int three) {}"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toFunction('myFuncCall (10, "hello world", 20.67);');
+    errors = Solium.lint(code, userConfig);
 
-        code = toFunction("myFuncCall (10, \"hello world\", 20.67);");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toFunction("uint[] x = [1,2,3];");
+    errors = Solium.lint(code, userConfig);
 
-        code = toFunction("uint[] x = [1,2,3];");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toContract("struct Sample {address a; uint b; string c;}");
+    errors = Solium.lint(code, userConfig);
 
-        code = toContract("struct Sample {address a; uint b; string c;}");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept > 3 arguments only when they are on their own lines", function(done) {
+    let code = toContract(
+        "function ArgumentOverflow(\nint one,\nint two,\nint three,\nint four) {}"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept > 3 arguments only when they are on their own lines", function(done) {
-        let code = toContract("function ArgumentOverflow(\nint one,\nint two,\nint three,\nint four) {}"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toFunction('myFuncCall (\n10,\n"hello world",\n20.67,\n0x0);');
+    errors = Solium.lint(code, userConfig);
 
-        code = toFunction("myFuncCall (\n10,\n\"hello world\",\n20.67,\n0x0);");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toFunction("uint[] x = [\n1,\n2,\n3,\n4];");
+    errors = Solium.lint(code, userConfig);
 
-        code = toFunction("uint[] x = [\n1,\n2,\n3,\n4];");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toContract(
+      "struct Sample {\naddress a;\nuint b;\nstring c; \nuint d;}"
+    );
+    errors = Solium.lint(code, userConfig);
 
-        code = toContract("struct Sample {\naddress a;\nuint b;\nstring c; \nuint d;}");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] arg-overflow: Handling options", function() {
+  it("should accept <= N arguments in same line, N supplied through config", function(done) {
+    let userConfig = {
+      rules: {
+        "arg-overflow": [1, 4]
+      }
+    };
 
-    it("should accept <= N arguments in same line, N supplied through config", function(done) {
-        let userConfig = {
-            "rules": {
-                "arg-overflow": [1, 4]
-            }
-        };
+    let code = toContract(
+        "function ArgumentOverflow(int one, int two, int three, int four) {}"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-        let code = toContract("function ArgumentOverflow(int one, int two, int three, int four) {}"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toFunction('myFuncCall (10, "hello world", 20.67, 0x0);');
+    errors = Solium.lint(code, userConfig);
 
-        code = toFunction("myFuncCall (10, \"hello world\", 20.67, 0x0);");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toFunction("uint[] x = [1,2,3,6];");
+    errors = Solium.lint(code, userConfig);
 
-        code = toFunction("uint[] x = [1,2,3,6];");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toContract("struct Sample {address a; uint b; string c; int d;}");
+    errors = Solium.lint(code, userConfig);
 
-        code = toContract("struct Sample {address a; uint b; string c; int d;}");
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = toFunction('myFuncCall (\n10,\n"hello world",\n20.67,\n0x0,\n100);');
+    errors = Solium.lint(code, userConfig);
 
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        code = toFunction("myFuncCall (\n10,\n\"hello world\",\n20.67,\n0x0,\n100);");
-        errors = Solium.lint(code, userConfig);
+    code = toFunction("uint[] x = [\n1,\n2,\n3,\n4,\n10];");
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        code = toFunction("uint[] x = [\n1,\n2,\n3,\n4,\n10];");
-        errors = Solium.lint(code, userConfig);
+    code = toContract(
+      "struct Sample {\naddress a;\nuint b;\nstring c; \nuint d;\nstring x;}"
+    );
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        code = toContract("struct Sample {\naddress a;\nuint b;\nstring c; \nuint d;\nstring x;}");
-        errors = Solium.lint(code, userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+  it("should reject > N arguments in same line, N supplied through config", function(done) {
+    let userConfig = {
+      rules: {
+        "arg-overflow": [1, 4]
+      }
+    };
 
-        Solium.reset();
-        done();
-    });
+    let code = toContract(
+        "function ArgumentOverflow(int one, int two, int three, int four, int five) {}"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should reject > N arguments in same line, N supplied through config", function(done) {
-        let userConfig = {
-            "rules": {
-                "arg-overflow": [1, 4]
-            }
-        };
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        let code = toContract("function ArgumentOverflow(int one, int two, int three, int four, int five) {}"),
-            errors = Solium.lint(code, userConfig);
+    code = toFunction('myFuncCall (10, "hello world", 20.67, 0x0, 100);');
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        code = toFunction("myFuncCall (10, \"hello world\", 20.67, 0x0, 100);");
-        errors = Solium.lint(code, userConfig);
+    code = toFunction("uint[] x = [1,2,3,6,18];");
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        code = toFunction("uint[] x = [1,2,3,6,18];");
-        errors = Solium.lint(code, userConfig);
+    code = toContract(
+      "struct Sample {address a; uint b; string c; int d; string f;}"
+    );
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        code = toContract("struct Sample {address a; uint b; string c; int d; string f;}");
-        errors = Solium.lint(code, userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+  it("should reject invalid option values", function(done) {
+    let config = {
+      rules: {
+        "arg-overflow": [1, 0]
+      }
+    };
+    let code = toContract("struct A { uint i; }");
 
-        Solium.reset();
-        done();
-    });
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-    it("should reject invalid option values", function(done) {
-        let config = {
-            "rules": {
-                "arg-overflow": [1, 0]
-            }
-        };
-        let code = toContract("struct A { uint i; }");
+    config.rules["arg-overflow"][1] = null;
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
+    config.rules["arg-overflow"][1] = [];
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        config.rules ["arg-overflow"] [1] = null;
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
+    config.rules["arg-overflow"][1] = {};
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        config.rules ["arg-overflow"] [1] = [];
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
+    config.rules["arg-overflow"][1] = 9.2;
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        config.rules ["arg-overflow"] [1] = {};
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
+    config.rules["arg-overflow"][1] = -1;
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        config.rules ["arg-overflow"] [1] = 9.2;
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
+    config.rules["arg-overflow"][1] = [2];
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        config.rules ["arg-overflow"] [1] = -1;
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
+    config.rules["arg-overflow"][1] = 4.01;
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        config.rules ["arg-overflow"] [1] = [2];
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
+    config.rules["arg-overflow"][1] = "winniethepooh";
+    Solium.lint
+      .bind(Solium, code, config)
+      .should.throw('Invalid options were passed to rule "arg-overflow".');
 
-        config.rules ["arg-overflow"] [1] = 4.01;
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
-
-        config.rules ["arg-overflow"] [1] = "winniethepooh";
-        Solium.lint.bind(
-            Solium, code, config).should.throw("Invalid options were passed to rule \"arg-overflow\".");
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/array-declarations/array-declarations.js
+++ b/test/lib/rules/array-declarations/array-declarations.js
@@ -5,266 +5,295 @@
 
 "use strict";
 
-let fs = require("fs"), path = require("path"),
-    Solium = require("../../../../lib/solium"), wrappers = require("../../../utils/wrappers");
+let fs = require("fs"),
+  path = require("path"),
+  Solium = require("../../../../lib/solium"),
+  wrappers = require("../../../utils/wrappers");
 
 let toContract = wrappers.toContract;
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "array-declarations": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "array-declarations": true
+  }
 };
 
 describe("[RULE] array-declarations: Acceptances", function() {
+  it('should accept "uint[] x;"', function(done) {
+    let code = "uint[] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should accept \"uint[] x;\"", function(done) {
-        let code = "uint[] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it('should accept "uint[10] x;"', function(done) {
+    let code = "uint[10] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should accept \"uint[10] x;\"", function(done) {
-        let code = "uint[10] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] array-declarations: Rejections", function() {
+  it('should reject "uint[ ] x;"', function(done) {
+    let code = "uint[ ] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should reject \"uint[ ] x;\"", function(done) {
-        let code = "uint[ ] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "There should be no whitespace between opening & closing square brackets. Use [] instead."
+    );
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "There should be no whitespace between opening & closing square brackets. Use [] instead.");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it('should reject "uint[\t] x;" (\\t)', function(done) {
+    let code = "uint[\t] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should reject \"uint[\t] x;\" (\\t)", function(done) {
-        let code = "uint[\t] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "There should be no whitespace between opening & closing square brackets. Use [] instead."
+    );
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "There should be no whitespace between opening & closing square brackets. Use [] instead.");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it('should reject "uint[\n] x;"', function(done) {
+    let code = "uint[\n] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should reject \"uint[\n] x;\"", function(done) {
-        let code = "uint[\n] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "There should be no whitespace between opening & closing square brackets. Use [] instead."
+    );
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "There should be no whitespace between opening & closing square brackets. Use [] instead.");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it('should reject "uint[  ] x;" (2 spaces)', function(done) {
+    let code = "uint[  ] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should reject \"uint[  ] x;\" (2 spaces)", function(done) {
-        let code = "uint[  ] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "There should be no whitespace between opening & closing square brackets. Use [] instead."
+    );
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "There should be no whitespace between opening & closing square brackets. Use [] instead.");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should reject \"a.b.c.d[\t \n ] x = [1,2,3,'4'];\" (after member access)", function(done) {
+    let code = "a.b.c.d[\t \n ] x = [1,2,3,'4'];",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should reject \"a.b.c.d[\t \n ] x = [1,2,3,'4'];\" (after member access)", function(done) {
-        let code = "a.b.c.d[\t \n ] x = [1,2,3,'4'];",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "There should be no whitespace between opening & closing square brackets. Use [] instead."
+    );
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "There should be no whitespace between opening & closing square brackets. Use [] instead.");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should reject \"mapping (uint => string)[  ] x = [1,2,3,'4'];\" (mapping)", function(done) {
+    let code = "mapping (uint => string)[  ] x = [1,2,3,'4'];",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should reject \"mapping (uint => string)[  ] x = [1,2,3,'4'];\" (mapping)", function(done) {
-        let code = "mapping (uint => string)[  ] x = [1,2,3,'4'];",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "There should be no whitespace between opening & closing square brackets. Use [] instead."
+    );
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "There should be no whitespace between opening & closing square brackets. Use [] instead.");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it('should reject "uint [] x;" (space between literal and opening brackets', function(done) {
+    let code = "uint [] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      'There should be no whitespace between "uint" and the opening square bracket.'
+    );
 
+    Solium.reset();
+    done();
+  });
 
-    it("should reject \"uint [] x;\" (space between literal and opening brackets", function(done) {
-        let code = "uint [] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+  it('should reject "string\n[] x;" (linebreak between literal and opening brackets', function(done) {
+    let code = "string\n[] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal("There should be no whitespace between \"uint\" and the opening square bracket.");
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      'There should be no whitespace between "string" and the opening square bracket.'
+    );
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject \"string\n[] x;\" (linebreak between literal and opening brackets", function(done) {
-        let code = "string\n[] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+  it('should reject "bytes32\t[] x;" (tab between literal and opening brackets', function(done) {
+    let code = "bytes32\t[] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal("There should be no whitespace between \"string\" and the opening square bracket.");
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      'There should be no whitespace between "bytes32" and the opening square bracket.'
+    );
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject \"bytes32\t[] x;\" (tab between literal and opening brackets", function(done) {
-        let code = "bytes32\t[] x;",
-            errors = Solium.lint(toContract(code), userConfig);
+  it('should reject "a.b.c.d\t \t  [] doo = [];" (arry dec. after member access)', function(done) {
+    let code = "a.b.c.d\t \t  [] doo = [];",
+      errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal("There should be no whitespace between \"bytes32\" and the opening square bracket.");
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      'There should be no whitespace between "a.b.c.d" and the opening square bracket.'
+    );
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject \"a.b.c.d\t \t  [] doo = [];\" (arry dec. after member access)", function(done) {
-        let code = "a.b.c.d\t \t  [] doo = [];",
-            errors = Solium.lint(toContract(code), userConfig);
+  it('should reject "mapping (uint => string)\n  [] m;" (mapping array dec)', function(done) {
+    let code = "mapping (uint => string)\n  [] m;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal("There should be no whitespace between \"a.b.c.d\" and the opening square bracket.");
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      'There should be no whitespace between "mapping (uint => string)" and the opening square bracket.'
+    );
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject \"mapping (uint => string)\n  [] m;\" (mapping array dec)", function(done) {
-        let code = "mapping (uint => string)\n  [] m;",
-            errors = Solium.lint(toContract(code), userConfig);
+  it('should reject "uint  [  ] x;"', function(done) {
+    let code = "uint  [  ] x;",
+      errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-        errors [0].message.should.equal(
-            "There should be no whitespace between \"mapping (uint => string)\" and the opening square bracket.");
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+    errors[1].message.should.equal(
+      "There should be no whitespace between opening & closing square brackets. Use [] instead."
+    );
+    errors[0].message.should.equal(
+      'There should be no whitespace between "uint" and the opening square bracket.'
+    );
 
-        Solium.reset();
-        done();
-    });
-
-
-
-    it("should reject \"uint  [  ] x;\"", function(done) {
-        let code = "uint  [  ] x;",
-            errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-        errors [1].message.should.equal("There should be no whitespace between opening & closing square brackets. Use [] instead.");
-        errors [0].message.should.equal("There should be no whitespace between \"uint\" and the opening square bracket.");
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] array-declarations: Fixes", function() {
+  it("should fix Whitespace between Literal & opening bracket", function(done) {
+    let unfixed = fs.readFileSync(
+        path.join(__dirname, "./unfixed/ws-btw-lit-op.sol"),
+        "utf8"
+      ),
+      fixed = fs.readFileSync(
+        path.join(__dirname, "./fixed/ws-btw-op-clos.sol"),
+        "utf8"
+      );
 
-    it("should fix Whitespace between Literal & opening bracket", function(done) {
-        let unfixed = fs.readFileSync(path.join(__dirname, "./unfixed/ws-btw-lit-op.sol"), "utf8"),
-            fixed = fs.readFileSync(path.join(__dirname, "./fixed/ws-btw-op-clos.sol"), "utf8");
+    fixed = Solium.lintAndFix(unfixed, userConfig);
 
-        fixed = Solium.lintAndFix(unfixed, userConfig);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixed.fixedSourceCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(6);
 
-        fixed.fixedSourceCode.should.equal(fixed.fixedSourceCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(6);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should fix Whitespace between opening & closing brackets", function(done) {
+    let unfixed = fs.readFileSync(
+        path.join(__dirname, "./unfixed/ws-btw-op-clos.sol"),
+        "utf8"
+      ),
+      fixed = fs.readFileSync(
+        path.join(__dirname, "./fixed/ws-btw-op-clos.sol"),
+        "utf8"
+      );
 
-    it("should fix Whitespace between opening & closing brackets", function(done) {
-        let unfixed = fs.readFileSync(path.join(__dirname, "./unfixed/ws-btw-op-clos.sol"), "utf8"),
-            fixed = fs.readFileSync(path.join(__dirname, "./fixed/ws-btw-op-clos.sol"), "utf8");
+    fixed = Solium.lintAndFix(unfixed, userConfig);
 
-        fixed = Solium.lintAndFix(unfixed, userConfig);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixed.fixedSourceCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(5);
 
-        fixed.fixedSourceCode.should.equal(fixed.fixedSourceCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(5);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should handle and fix a mix of the errors", function(done) {
+    let unfixed = fs.readFileSync(
+        path.join(__dirname, "./unfixed/mixed.sol"),
+        "utf8"
+      ),
+      fixed = fs.readFileSync(
+        path.join(__dirname, "./fixed/ws-btw-op-clos.sol"),
+        "utf8"
+      );
 
-    it("should handle and fix a mix of the errors", function(done) {
-        let unfixed = fs.readFileSync(path.join(__dirname, "./unfixed/mixed.sol"), "utf8"),
-            fixed = fs.readFileSync(path.join(__dirname, "./fixed/ws-btw-op-clos.sol"), "utf8");
+    fixed = Solium.lintAndFix(unfixed, userConfig);
 
-        fixed = Solium.lintAndFix(unfixed, userConfig);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixed.fixedSourceCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(10);
 
-        fixed.fixedSourceCode.should.equal(fixed.fixedSourceCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(10);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/blank-lines/blank-lines.js
+++ b/test/lib/rules/blank-lines/blank-lines.js
@@ -6,68 +6,79 @@
 "use strict";
 
 const Solium = require("../../../../lib/solium"),
-    wrappers = require("../../../utils/wrappers"),
-    fs = require("fs"),
-    path = require("path");
+  wrappers = require("../../../utils/wrappers"),
+  fs = require("fs"),
+  path = require("path");
 
 const userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "blank-lines": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "blank-lines": true
+  }
 };
 
 const addPragma = wrappers.addPragma;
 
 describe("[RULE] blank-lines: Acceptances", () => {
+  it("should accept contract declarations succeeded by 2 blank lines (all declarations except for last)", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./accept/contract.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should accept contract declarations succeeded by 2 blank lines (all declarations except for last)", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./accept/contract.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept library declarations succeeded by 2 blank lines (all declarations except for last)", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./accept/library.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should accept library declarations succeeded by 2 blank lines (all declarations except for last)", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./accept/library.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept single contract declaration", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./accept/contract-single.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should accept single contract declaration", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./accept/contract-single.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept single library declaration", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./accept/library-single.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should accept single library declaration", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./accept/library-single.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
-
-    it("should accept properly separated top level declarations accompanied by comments", done => {
-        let snippets = [
-            `
+  it("should accept properly separated top level declarations accompanied by comments", done => {
+    let snippets = [
+      `
 			pragma solidity ^0.4.17;
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
 
@@ -79,7 +90,7 @@ describe("[RULE] blank-lines: Acceptances", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 
@@ -91,7 +102,7 @@ describe("[RULE] blank-lines: Acceptances", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
 
@@ -104,7 +115,7 @@ describe("[RULE] blank-lines: Acceptances", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
 
@@ -116,7 +127,7 @@ describe("[RULE] blank-lines: Acceptances", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 
@@ -128,7 +139,7 @@ describe("[RULE] blank-lines: Acceptances", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
 
@@ -141,7 +152,7 @@ describe("[RULE] blank-lines: Acceptances", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
 
@@ -161,91 +172,101 @@ describe("[RULE] blank-lines: Acceptances", () => {
 			// inherits
 			contract bar is foobar {}
 			`
-        ];
+    ];
 
-        snippets.forEach(code => {
-            let errors = Solium.lint(code, userConfig);
-            errors.should.be.Array();
-            errors.should.have.size(0);
-        });
-
-        Solium.reset();
-        done();
+    snippets.forEach(code => {
+      let errors = Solium.lint(code, userConfig);
+      errors.should.be.Array();
+      errors.should.have.size(0);
     });
 
-    it("should accept single-line functions without blank lines between them & multiline functions WITH them", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./accept/function.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should accept single-line functions without blank lines between them & multiline functions WITH them", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./accept/function.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-    it("should not enforce blank line rules on top level declarations other than contract & library declarations", done => {
-        let code = "import * as x from \"y\";\nimport * as x from \"y\";\nimport * as x from \"y\";\n\n\ncontract Yoda {} import * as foo from \"bar.sol\";",
-            errors = Solium.lint(addPragma(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should not enforce blank line rules on top level declarations other than contract & library declarations", done => {
+    let code =
+        'import * as x from "y";\nimport * as x from "y";\nimport * as x from "y";\n\n\ncontract Yoda {} import * as foo from "bar.sol";',
+      errors = Solium.lint(addPragma(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] blank-lines: Rejections", () => {
+  it("should reject contract declarations with < 2 lines of gap between them", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./reject/contract.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should reject contract declarations with < 2 lines of gap between them", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./reject/contract.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
+    errors[0].node.name.should.equal("Bcd");
+    errors[1].node.name.should.equal("Cde");
+    errors[2].node.name.should.equal("Def");
 
-        errors [0].node.name.should.equal("Bcd");
-        errors [1].node.name.should.equal("Cde");
-        errors [2].node.name.should.equal("Def");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should reject library declarations with < 2 lines of gap between them", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./reject/library.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should reject library declarations with < 2 lines of gap between them", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./reject/library.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
+    errors[0].node.name.should.equal("Bcd");
+    errors[1].node.name.should.equal("Cde");
+    errors[2].node.name.should.equal("Def");
 
-        errors [0].node.name.should.equal("Bcd");
-        errors [1].node.name.should.equal("Cde");
-        errors [2].node.name.should.equal("Def");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should reject a multiline function that is not followed by a blank line", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./reject/function.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should reject a multiline function that is not followed by a blank line", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./reject/function.sol"), "utf8"),
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(5);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(5);
+    errors[0].node.name.should.equal("spam");
 
-        errors [0].node.name.should.equal("spam");
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
-
-    it("should reject top level declarations accompanied by comments but not gapped properly", done => {
-        let snippets = [
-            `
+  it("should reject top level declarations accompanied by comments but not gapped properly", done => {
+    let snippets = [
+      `
 			pragma solidity ^0.4.17;
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
 
@@ -256,7 +277,7 @@ describe("[RULE] blank-lines: Rejections", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
@@ -267,7 +288,7 @@ describe("[RULE] blank-lines: Rejections", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
 
@@ -279,7 +300,7 @@ describe("[RULE] blank-lines: Rejections", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
@@ -291,7 +312,7 @@ describe("[RULE] blank-lines: Rejections", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
@@ -303,7 +324,7 @@ describe("[RULE] blank-lines: Rejections", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
@@ -317,60 +338,69 @@ describe("[RULE] blank-lines: Rejections", () => {
 
 			}
 			`
-        ];
+    ];
 
-        snippets.forEach(code => {
-            let errors = Solium.lint(code, userConfig);
-            errors.should.be.Array();
-            errors.should.have.size(1);
-        });
-
-        Solium.reset();
-        done();
+    snippets.forEach(code => {
+      let errors = Solium.lint(code, userConfig);
+      errors.should.be.Array();
+      errors.should.have.size(1);
     });
 
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] blank-lines: Fixes", () => {
+  it("Should correct spacing between top level declarations with < 2 lines of gap between them", done => {
+    const code = fs.readFileSync(
+      path.join(__dirname, "./reject/contract.sol"),
+      "utf8"
+    );
+    let { errorMessages: errors, fixedSourceCode } = Solium.lintAndFix(
+      addPragma(code),
+      userConfig
+    );
 
-    it("Should correct spacing between top level declarations with < 2 lines of gap between them", done => {
-        const code = fs.readFileSync(path.join(__dirname, "./reject/contract.sol"), "utf8");
-        let {errorMessages: errors, fixedSourceCode} = Solium.lintAndFix(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    // The fixes should have fixed all linting errors with respect to this rule
+    errors = Solium.lint(fixedSourceCode, userConfig);
 
-        // The fixes should have fixed all linting errors with respect to this rule
-        errors = Solium.lint(fixedSourceCode, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("Should correct multiline functions not followed by a blank line", done => {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./reject/function.sol"),
+        "utf8"
+      ),
+      { errorMessages: errors, fixedSourceCode } = Solium.lintAndFix(
+        addPragma(code),
+        userConfig
+      );
 
-    it("Should correct multiline functions not followed by a blank line", done => {
-        let code = fs.readFileSync(path.join(__dirname, "./reject/function.sol"), "utf8"),
-            {errorMessages: errors, fixedSourceCode} = Solium.lintAndFix(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    // The fixes should have fixed all linting errors with respect to this rule
+    errors = Solium.lint(fixedSourceCode, userConfig);
 
-        // The fixes should have fixed all linting errors with respect to this rule
-        errors = Solium.lint(fixedSourceCode, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
-
-    it("should correct top level declarations accompanied by comments but not gapped properly", done => {
-        let snippets = [
-            `
+  it("should correct top level declarations accompanied by comments but not gapped properly", done => {
+    let snippets = [
+      `
 			pragma solidity ^0.4.17;
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
 
@@ -381,7 +411,7 @@ describe("[RULE] blank-lines: Fixes", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
@@ -392,7 +422,7 @@ describe("[RULE] blank-lines: Fixes", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 			// import 'zeppelin-solidity/contracts/token/StandardToken.sol';
 
@@ -404,7 +434,7 @@ describe("[RULE] blank-lines: Fixes", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
@@ -416,7 +446,7 @@ describe("[RULE] blank-lines: Fixes", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
@@ -428,7 +458,7 @@ describe("[RULE] blank-lines: Fixes", () => {
 
 			}
 			`,
-            `
+      `
 			pragma solidity ^0.4.17;
 
 			/* import 'zeppelin-solidity/contracts/token/StandardToken.sol'; */
@@ -442,7 +472,7 @@ describe("[RULE] blank-lines: Fixes", () => {
 
 			}
 			`,
-            `
+      `
             pragma solidity ^0.4.17;
             
             /*
@@ -453,27 +483,29 @@ describe("[RULE] blank-lines: Fixes", () => {
                   
             }
             `,
-            `
+      `
             pragma solidity ^0.4.17;
             
             
             contract T {} // Test
             contract S {}
             `
-        ];
+    ];
 
-        snippets.forEach(code => {
-            let {errorMessages: errors, fixedSourceCode} = Solium.lintAndFix(code, userConfig);
-            errors.should.be.Array();
-            errors.should.have.size(0);
+    snippets.forEach(code => {
+      let { errorMessages: errors, fixedSourceCode } = Solium.lintAndFix(
+        code,
+        userConfig
+      );
+      errors.should.be.Array();
+      errors.should.have.size(0);
 
-            errors = Solium.lint(fixedSourceCode, userConfig);
-            errors.should.be.Array();
-            errors.should.have.size(0);
-        });
-
-        Solium.reset();
-        done();
+      errors = Solium.lint(fixedSourceCode, userConfig);
+      errors.should.be.Array();
+      errors.should.have.size(0);
     });
 
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/camelcase/camelcase.js
+++ b/test/lib/rules/camelcase/camelcase.js
@@ -11,365 +11,376 @@ let toContract = wrappers.toContract;
 let addPragma = wrappers.addPragma;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "camelcase": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    camelcase: true
+  }
 };
 
 describe("[RULE] camelcase: Acceptances", function() {
+  it("accepts valid contract names", function(done) {
+    let code = [
+      "contract Hello {}",
+      "contract HelloWorld {}",
+      "contract He {}",
+      "contract HELlOWoRlD {}",
+      "contract HeLLOWORLd {}",
+      "contract MyToken2 {}",
+      "contract My29Token10 {}",
+      "contract M123 {}"
+    ];
+    let errors;
 
-    it("accepts valid contract names", function(done) {
-        let code = [
-            "contract Hello {}",
-            "contract HelloWorld {}",
-            "contract He {}",
-            "contract HELlOWoRlD {}",
-            "contract HeLLOWORLd {}",
-            "contract MyToken2 {}",
-            "contract My29Token10 {}",
-            "contract M123 {}"
-        ];
-        let errors;
-
-        code = code.map(function(item){return addPragma(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return addPragma(item);
     });
 
-    it("accepts valid library names", function(done) {
-        let code = [
-            "library Hello {}",
-            "library HelloWorld {}",
-            "library He {}",
-            "library HELlOWoRlD {}",
-            "library HeLLOWORLd {}",
-            "library MyToken2 {}",
-            "library My29Token10 {}",
-            "library M123 {}"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = code.map(function(item){return addPragma(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("accepts valid library names", function(done) {
+    let code = [
+      "library Hello {}",
+      "library HelloWorld {}",
+      "library He {}",
+      "library HELlOWoRlD {}",
+      "library HeLLOWORLd {}",
+      "library MyToken2 {}",
+      "library My29Token10 {}",
+      "library M123 {}"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return addPragma(item);
     });
 
-    it("accepts valid event names", function(done) {
-        let code = [
-            "event Hello();",
-            "event HelloWorld();",
-            "event He();",
-            "event HELlOWoRlD();",
-            "event HeLLOWORLd();",
-            "event MyToken2();",
-            "event My29Token10();",
-            "event M123();"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("accepts valid event names", function(done) {
+    let code = [
+      "event Hello();",
+      "event HelloWorld();",
+      "event He();",
+      "event HELlOWoRlD();",
+      "event HeLLOWORLd();",
+      "event MyToken2();",
+      "event My29Token10();",
+      "event M123();"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("accepts valid struct names", function(done) {
-        let code = [
-            "struct Hello {}",
-            "struct HelloWorld {}",
-            "struct He {}",
-            "struct HELlOWoRlD {}",
-            "struct HeLLOWORLd {}",
-            "struct MyToken2 {}",
-            "struct My29Token10 {}",
-            "struct M123 {}"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("accepts valid struct names", function(done) {
+    let code = [
+      "struct Hello {}",
+      "struct HelloWorld {}",
+      "struct He {}",
+      "struct HELlOWoRlD {}",
+      "struct HeLLOWORLd {}",
+      "struct MyToken2 {}",
+      "struct My29Token10 {}",
+      "struct M123 {}"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] camelcase: Rejections", function() {
+  it("rejects invalid contract names", function(done) {
+    let code = [
+      "contract hello {}",
+      "contract H {}",
+      "contract h {}",
+      "contract Hello_World {}",
+      "contract hello_1world {}"
+    ];
+    let errors;
 
-    it("rejects invalid contract names", function(done) {
-        let code = [
-            "contract hello {}",
-            "contract H {}",
-            "contract h {}",
-            "contract Hello_World {}",
-            "contract hello_1world {}"
-        ];
-        let errors;
-
-        code = code.map(function(item){return addPragma(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return addPragma(item);
     });
 
-    it("rejects invalid library names", function(done) {
-        let code = [
-            "library hello {}",
-            "library H {}",
-            "library h {}",
-            "library Hello_World {}",
-            "library hello_1world {}"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = code.map(function(item){return addPragma(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("rejects invalid library names", function(done) {
+    let code = [
+      "library hello {}",
+      "library H {}",
+      "library h {}",
+      "library Hello_World {}",
+      "library hello_1world {}"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return addPragma(item);
     });
 
-    it("rejects invalid event names", function(done) {
-        let code = [
-            "event hello();",
-            "event H();",
-            "event h();",
-            "event Hello_World();",
-            "event hello_1world();"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("rejects invalid event names", function(done) {
+    let code = [
+      "event hello();",
+      "event H();",
+      "event h();",
+      "event Hello_World();",
+      "event hello_1world();"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("rejects invalid struct names", function(done) {
-        let code = [
-            "struct hello {}",
-            "struct H {}",
-            "struct h {}",
-            "struct Hello_World {}",
-            "struct hello_1world {}"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("rejects invalid struct names", function(done) {
+    let code = [
+      "struct hello {}",
+      "struct H {}",
+      "struct h {}",
+      "struct Hello_World {}",
+      "struct hello_1world {}"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/deprecated-suicide/deprecated-suicide.js
+++ b/test/lib/rules/deprecated-suicide/deprecated-suicide.js
@@ -7,81 +7,82 @@
 
 let Solium = require("../../../../lib/solium");
 let wrappers = require("../../../utils/wrappers"),
-    toContract = wrappers.toContract, toFunction = wrappers.toFunction;
+  toContract = wrappers.toContract,
+  toFunction = wrappers.toFunction;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "deprecated-suicide": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "deprecated-suicide": true
+  }
 };
 
 describe("[RULE] deprecated-suicide", function() {
+  it("should reject contracts using suicide", function(done) {
+    let code = toContract("function foo () { suicide(0x0); }"),
+      errors = Solium.lint(code, userConfig);
 
-    it("should reject contracts using suicide", function(done) {
-        let code = toContract("function foo () { suicide(0x0); }"),
-            errors = Solium.lint(code, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should replace suicide by selfdestruct when fix is applied", function(done) {
+    let unfixedCode = toFunction("suicide(0x0);"),
+      fixedCode = toFunction("selfdestruct(0x0);");
 
-    it("should replace suicide by selfdestruct when fix is applied", function(done) {
-        let unfixedCode = toFunction("suicide(0x0);"),
-            fixedCode = toFunction("selfdestruct(0x0);");
+    let fixed = Solium.lintAndFix(unfixedCode, userConfig);
 
-        let fixed = Solium.lintAndFix(unfixedCode, userConfig);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(1);
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(1);
+    unfixedCode = toFunction("suicide (0x0);");
+    fixedCode = toFunction("selfdestruct (0x0);");
 
+    fixed = Solium.lintAndFix(unfixedCode, userConfig);
 
-        unfixedCode = toFunction("suicide (0x0);");
-        fixedCode = toFunction("selfdestruct (0x0);");
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed = Solium.lintAndFix(unfixedCode, userConfig);
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(1);
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    unfixedCode = toContract(
+      "function a () { suicide(0x0); }\nfunction b () { suicide(0x0); }"
+    );
+    fixedCode = toContract(
+      "function a () { selfdestruct(0x0); }\nfunction b () { selfdestruct(0x0); }"
+    );
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(1);
+    fixed = Solium.lintAndFix(unfixedCode, userConfig);
 
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        unfixedCode = toContract("function a () { suicide(0x0); }\nfunction b () { suicide(0x0); }");
-        fixedCode = toContract("function a () { selfdestruct(0x0); }\nfunction b () { selfdestruct(0x0); }");
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(2);
 
-        fixed = Solium.lintAndFix(unfixedCode, userConfig);
-
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
-
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(2);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/double-quotes/double-quotes.js
+++ b/test/lib/rules/double-quotes/double-quotes.js
@@ -9,46 +9,47 @@
 "use strict";
 
 let Solium = require("../../../../lib/solium"),
-    wrappers = require("../../../utils/wrappers"),
-    fs = require("fs"),
-    path = require("path");
+  wrappers = require("../../../utils/wrappers"),
+  fs = require("fs"),
+  path = require("path");
 
 let toContract = wrappers.toContract;
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "double-quotes": true
-    },
-    "options": { "returnInternalIssues": true }
+  "custom-rules-filename": null,
+  rules: {
+    "double-quotes": true
+  },
+  options: { returnInternalIssues: true }
 };
 
 describe("[RULE] double-quotes: Acceptances", function() {
+  it("should accept strings quoted with double quotes", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./accept/double-quoted.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should accept strings quoted with double quotes", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./accept/double-quoted.sol"), "utf8"),
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] double-quotes: Rejections", function() {
+  it("should reject strings quoted with single quotes", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./reject/single-quoted.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should reject strings quoted with single quotes", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./reject/single-quoted.sol"), "utf8"),
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(7);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(7);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/emit/emit.js
+++ b/test/lib/rules/emit/emit.js
@@ -7,30 +7,28 @@
 
 const Solium = require("../../../../lib/solium");
 const userConfig = {
-    "rules": {
-        "emit": "error"
-    }
+  rules: {
+    emit: "error"
+  }
 };
 
-
 describe("[RULE] emit: Acceptances", () => {
-
-    it("should accept code without any event declarations", done => {
-        let code = `contract Foo {
+  it("should accept code without any event declarations", done => {
+    let code = `contract Foo {
             function bar() {
                 callFunc(100, "hello");
             }
         }`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        done();
-    });
+    done();
+  });
 
-    it("should accept code in which emit is used when events are declared", done => {
-        let code = `contract Foo {
+  it("should accept code in which emit is used when events are declared", done => {
+    let code = `contract Foo {
             event Blast(uint radius);
             event LogString(string desc);
 
@@ -49,16 +47,16 @@ describe("[RULE] emit: Acceptances", () => {
                 }
             }
         }`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        done();
-    });
+    done();
+  });
 
-    it("should accept code in which CallExpression is a function call, not event trigger", done => {
-        let code = `contract Foo {
+  it("should accept code in which CallExpression is a function call, not event trigger", done => {
+    let code = `contract Foo {
             event Blast(uint radius);
             event LogString(string desc);
 
@@ -75,16 +73,16 @@ describe("[RULE] emit: Acceptances", () => {
                 }
             }
         }`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        done();
-    });
+    done();
+  });
 
-    it("should accept when CallExpression & event declaration have same name but are in different scopes", done => {
-        let code = `contract UnrelatedContract {
+  it("should accept when CallExpression & event declaration have same name but are in different scopes", done => {
+    let code = `contract UnrelatedContract {
             event Blast(uint radius);
             event LogString(string desc);
 
@@ -107,21 +105,18 @@ describe("[RULE] emit: Acceptances", () => {
                 }
             }
         }`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        done();
-    });
-
+    done();
+  });
 });
 
-
 describe("[RULE] emit: Rejections", () => {
-
-    it("should reject if event declared in the same contract is triggered without emit", done => {
-        let code = `contract Foo {
+  it("should reject if event declared in the same contract is triggered without emit", done => {
+    let code = `contract Foo {
             event Blast(uint radius);
             event LogString(string desc);
 
@@ -143,29 +138,26 @@ describe("[RULE] emit: Rejections", () => {
                 }
             }
         }`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.have.size(4);
+    errors.should.be.Array();
+    errors.should.have.size(4);
 
-        done();
-    });
+    done();
+  });
 
-    // Below test case will be enabled only once
-    // emit rule can detect event declarations from inherited contracts
-    /*
+  // Below test case will be enabled only once
+  // emit rule can detect event declarations from inherited contracts
+  /*
     it("should reject if event declared in an inherited contract is triggered without emit", done => {
         done();
     });
     */
-
 });
 
-
 describe("[RULE] emit: Fixes", () => {
-
-    it("should add emit keyword before non-emit event trigger statements when declaration & usage are in same contract", done => {
-        let code = `contract Foo {
+  it("should add emit keyword before non-emit event trigger statements when declaration & usage are in same contract", done => {
+    let code = `contract Foo {
             event Blast(uint radius);
             event LogString(string desc);
 
@@ -188,7 +180,7 @@ describe("[RULE] emit: Fixes", () => {
             }
         }`;
 
-        let fixedCode = `contract Foo {
+    let fixedCode = `contract Foo {
             event Blast(uint radius);
             event LogString(string desc);
 
@@ -211,21 +203,25 @@ describe("[RULE] emit: Fixes", () => {
             }
         }`;
 
-        const { originalSourceCode, fixesApplied,
-            fixedSourceCode, errorMessages } = Solium.lintAndFix(code, userConfig);
+    const {
+      originalSourceCode,
+      fixesApplied,
+      fixedSourceCode,
+      errorMessages
+    } = Solium.lintAndFix(code, userConfig);
 
-        originalSourceCode.should.equal(code);
-        fixedSourceCode.should.equal(fixedCode);
-        errorMessages.should.be.Array();
-        errorMessages.should.be.empty();
-        fixesApplied.should.be.Array();
-        fixesApplied.should.have.size(4);
+    originalSourceCode.should.equal(code);
+    fixedSourceCode.should.equal(fixedCode);
+    errorMessages.should.be.Array();
+    errorMessages.should.be.empty();
+    fixesApplied.should.be.Array();
+    fixesApplied.should.have.size(4);
 
-        done();
-    });
+    done();
+  });
 
-    it("should shouldn't attempt to fix statements which already use emit keyword", done => {
-        let code = `contract Foo {
+  it("should shouldn't attempt to fix statements which already use emit keyword", done => {
+    let code = `contract Foo {
             event Blast(uint radius);
             event LogString(string desc);
 
@@ -248,17 +244,20 @@ describe("[RULE] emit: Fixes", () => {
             }
         }`;
 
-        const { originalSourceCode, fixesApplied,
-            fixedSourceCode, errorMessages } = Solium.lintAndFix(code, userConfig);
-        
-        originalSourceCode.should.equal(code);
-        fixedSourceCode.should.equal(code);
-        fixesApplied.should.be.Array();
-        fixesApplied.should.be.empty();
-        errorMessages.should.be.Array();
-        errorMessages.should.be.empty();
+    const {
+      originalSourceCode,
+      fixesApplied,
+      fixedSourceCode,
+      errorMessages
+    } = Solium.lintAndFix(code, userConfig);
 
-        done();
-    });
+    originalSourceCode.should.equal(code);
+    fixedSourceCode.should.equal(code);
+    fixesApplied.should.be.Array();
+    fixesApplied.should.be.empty();
+    errorMessages.should.be.Array();
+    errorMessages.should.be.empty();
 
+    done();
+  });
 });

--- a/test/lib/rules/error-reason/error-reason.js
+++ b/test/lib/rules/error-reason/error-reason.js
@@ -6,119 +6,114 @@
 "use strict";
 
 const Solium = require("../../../../lib/solium"),
-    { toFunction } = require("../../../utils/wrappers");
+  { toFunction } = require("../../../utils/wrappers");
 
 const userConfigDefault = {
-    "rules": {
-        "error-reason": "warning"
-    }
+  rules: {
+    "error-reason": "warning"
+  }
 };
 
 describe("[RULE] error-reason: Acceptances", function() {
+  it("should accept revert calls with an error message", function(done) {
+    const code = toFunction('revert("Error message");'),
+      errors = Solium.lint(code, userConfigDefault);
 
-    it("should accept revert calls with an error message", function(done) {
-        const code = toFunction("revert(\"Error message\");"),
-            errors = Solium.lint(code, userConfigDefault);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept revert calls without an error message when it is disabled", function(done) {
+    const userConfig = {
+      rules: {
+        "error-reason": ["error", { revert: false, require: true }]
+      }
+    };
 
-    it("should accept revert calls without an error message when it is disabled", function(done) {
-        const userConfig = {
-            "rules": {
-                "error-reason": ["error", { "revert": false, "require": true }]
-            }
-        };
+    const code = toFunction("revert();"),
+      errors = Solium.lint(code, userConfig);
 
-        const code = toFunction("revert();"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept require calls with an error message", function(done) {
+    const code = toFunction('require(1 == 1, "Error message");'),
+      errors = Solium.lint(code, userConfigDefault);
 
-    it("should accept require calls with an error message", function(done) {
-        const code = toFunction("require(1 == 1, \"Error message\");"),
-            errors = Solium.lint(code, userConfigDefault);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept require calls without an error message when it is disabled", function(done) {
+    const userConfig = {
+      rules: {
+        "error-reason": ["warning", { revert: true, require: false }]
+      }
+    };
 
-    it("should accept require calls without an error message when it is disabled", function(done) {
-        const userConfig = {
-            "rules": {
-                "error-reason": ["warning", { "revert": true, "require": false }]
-            }
-        };
+    const code = toFunction("require(1 == 1);"),
+      errors = Solium.lint(code, userConfig);
 
-        const code = toFunction("require(1 == 1);"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] error-reason: Rejections", function() {
+  it("should reject revert calls without an error message", function(done) {
+    let code = "revert();",
+      errors = Solium.lint(toFunction(code), userConfigDefault);
 
-    it("should reject revert calls without an error message", function(done) {
-        let code = "revert();",
-            errors = Solium.lint(toFunction(code), userConfigDefault);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        errors.should.be.Array();
-        errors.should.have.size(1);
+    const userConfig = {
+      rules: {
+        "error-reason": ["warning", { revert: true, require: false }]
+      }
+    };
 
-        const userConfig = {
-            "rules": {
-                "error-reason": ["warning", { "revert": true, "require": false }]
-            }
-        };
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        errors.should.be.Array();
-        errors.should.have.size(1);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should reject require calls without an error message", function(done) {
+    let code = "require(1 == 1);",
+      errors = Solium.lint(toFunction(code), userConfigDefault);
 
-    it("should reject require calls without an error message", function(done) {
-        let code = "require(1 == 1);",
-            errors = Solium.lint(toFunction(code), userConfigDefault);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        errors.should.be.Array();
-        errors.should.have.size(1);
+    const userConfig = {
+      rules: {
+        "error-reason": ["warning", { revert: false, require: true }]
+      }
+    };
 
-        const userConfig = {
-            "rules": {
-                "error-reason": ["warning", { "revert": false, "require": true }]
-            }
-        };
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        errors.should.be.Array();
-        errors.should.have.size(1);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
-

--- a/test/lib/rules/function-order/function-order.js
+++ b/test/lib/rules/function-order/function-order.js
@@ -7,16 +7,15 @@
 
 const Solium = require("../../../../lib/solium");
 const userConfig = {
-    "rules": {
-        "function-order": "error"
-    }
+  rules: {
+    "function-order": "error"
+  }
 };
 
-
 describe("[RULE] function-order: Acceptances", function() {
-
-    it("should accept functions ordered correctly inside a contract", done => {
-        let codes = [`
+  it("should accept functions ordered correctly inside a contract", done => {
+    let codes = [
+      `
 			contract Foo {
 				function Foo() {}
 				string myName = "Hello";
@@ -46,9 +45,10 @@ describe("[RULE] function-order: Acceptances", function() {
 				function a() private {}
 				function a(uint x) myModif private returns (uint) {}
 			}
-		`];
+		`
+    ];
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				constructor(string name, address account) {
 
@@ -65,7 +65,7 @@ describe("[RULE] function-order: Acceptances", function() {
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function Foo() {}
 				string myName = "Hello";
@@ -82,11 +82,11 @@ describe("[RULE] function-order: Acceptances", function() {
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function a(uint x) myModif internal returns (uint);
 				uint stateV1 = 100;
@@ -97,70 +97,67 @@ describe("[RULE] function-order: Acceptances", function() {
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function Foo() {}
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function() {}
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function a() external {}
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function a() {}
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function a() internal {}
 			}
 		`);
 
-        codes.push(`
+    codes.push(`
 			contract Foo {
 				function a() private {}
 			}
 		`);
 
-        codes.forEach(code => {
-            const errors = Solium.lint(code, userConfig);
-            errors.should.be.Array();
-            errors.should.have.size(0);
-        });
-
-        Solium.reset();
-        done();
+    codes.forEach(code => {
+      const errors = Solium.lint(code, userConfig);
+      errors.should.be.Array();
+      errors.should.have.size(0);
     });
 
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] function-order: Rejections", function() {
-
-    it("should reject functions ordered incorrectly inside a contract", done => {
-        let code = `
+  it("should reject functions ordered incorrectly inside a contract", done => {
+    let code = `
 			contract Foo {
 				function bar() {}
 				function Foo(string f) {}
 			}
 		`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.have.size(1);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        code = `
+    code = `
 			contract Foo {
 				function a(uint x) myModif private returns (uint) {}
 				function a() private {}
@@ -194,13 +191,12 @@ describe("[RULE] function-order: Rejections", function() {
 				}
 			}
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.have.size(14);
+    errors.should.be.Array();
+    errors.should.have.size(14);
 
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/imports-on-top/imports-on-top.js
+++ b/test/lib/rules/imports-on-top/imports-on-top.js
@@ -6,38 +6,41 @@
 "use strict";
 
 const Solium = require("../../../../lib/solium"),
-    fs = require("fs"), path = require("path"), { EOL } = require("os");
+  fs = require("fs"),
+  path = require("path"),
+  { EOL } = require("os");
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "imports-on-top": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "imports-on-top": true
+  }
 };
 
-
 describe("[RULE] imports-on-top: Acceptances", function() {
+  it("should accept if all import statements are on top of the file (but below the pragma directive)", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./accept/on-top.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept if all import statements are on top of the file (but below the pragma directive)", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./accept/on-top.sol"), "utf8"),
-            errors = Solium.lint(code, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        // imports without pragmas
-        code = `
+    // imports without pragmas
+    code = `
 			import "filename";
 			import * as symbolName from "filename";
 			import {symbol1 as alias, symbol2} from "filename";
 			import "filename" as symbolName;
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `
+    code = `
 			pragma solidity ^0.4.0;
 			import "filename";
 			import * as symbolName from "filename";
@@ -45,12 +48,12 @@ describe("[RULE] imports-on-top: Acceptances", function() {
 			import "filename" as symbolName;
 			contract Foo {}
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `
+    code = `
 			pragma experimental blahblah;
 			import "filename";
 			import * as symbolName from "filename";
@@ -59,40 +62,38 @@ describe("[RULE] imports-on-top: Acceptances", function() {
 
 			library Foo {}
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] imports-on-top: Rejections", function() {
+  it("should reject any import statement NOT on top of file", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./reject/intermingled.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should reject any import statement NOT on top of file", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./reject/intermingled.sol"), "utf8"),
-            errors = Solium.lint(code, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] imports-on-top: Fixes", function() {
-
-    it("Should do nothing if source code is empty or has no import-related issues", done => {
-        // Absolutely empty string results in exception from Solium.lintAndFix()
-        let codes = [
-            "// hello world",
-            `
+  it("Should do nothing if source code is empty or has no import-related issues", done => {
+    // Absolutely empty string results in exception from Solium.lintAndFix()
+    let codes = [
+      "// hello world",
+      `
             pragma solidity 0.4.0;
             pragma experimental ABIEncoderV2;
 
@@ -101,43 +102,47 @@ describe("[RULE] imports-on-top: Fixes", function() {
 
             contract Foo {}
             `,
-            `
+      `
             import "foobar";
             library Blah {}
             `,
-            `
+      `
             pragma experimental ABIEncoderV2;
             import "foobar";
             library Blah {}
             `,
-            `
+      `
             contract Drone {}
             library Jenny {}
             `
-        ];
+    ];
 
-        codes.forEach(code => {
-            let { errorMessages: errors, fixedSourceCode, fixesApplied } = Solium.lintAndFix(code, userConfig);
+    codes.forEach(code => {
+      let {
+        errorMessages: errors,
+        fixedSourceCode,
+        fixesApplied
+      } = Solium.lintAndFix(code, userConfig);
 
-            errors.should.be.Array();
-            errors.should.be.size(0);
-            fixedSourceCode.should.equal(code);
-            fixesApplied.should.be.Array();
-            fixesApplied.should.be.size(0);
-        });
-
-        Solium.reset();
-        done();
+      errors.should.be.Array();
+      errors.should.be.size(0);
+      fixedSourceCode.should.equal(code);
+      fixesApplied.should.be.Array();
+      fixesApplied.should.be.size(0);
     });
 
-    it("should place import below pragma solidity", done => {
-        const codes = [
-            `
+    Solium.reset();
+    done();
+  });
+
+  it("should place import below pragma solidity", done => {
+    const codes = [
+      `
             pragma solidity ^0.2.3;
             library Foo {}
             import "wow.sol";
             `,
-            `
+      `
             pragma solidity ^0.2.3;
 
 
@@ -145,115 +150,8 @@ describe("[RULE] imports-on-top: Fixes", function() {
             contract WiggleWiggle{}
             import "wow.sol";
             `,
-            `
+      `
             pragma solidity ^0.2.3;
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            import "wow.sol";
-            import "mickey";
-            import "minnie.sol";
-            `
-        ];
-        const fixedCodes = [
-            `
-            pragma solidity ^0.2.3;
-
-
-import "wow.sol";
-            library Foo {}
-            
-            `,
-            `
-            pragma solidity ^0.2.3;
-
-
-import "wow.sol";
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            
-            `,
-            `
-            pragma solidity ^0.2.3;
-
-
-import "wow.sol";
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            
-            import "mickey";
-            import "minnie.sol";
-            `
-        ];
-        
-
-        let result = Solium.lintAndFix(codes[0], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[0]);
-
-        result = Solium.lintAndFix(codes[1], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[1]);
-
-        result = Solium.lintAndFix(codes[2], userConfig);
-        result.errorMessages.should.be.size(2);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[2]);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should place import below pragma experimental", done => {
-        const codes = [
-            `
-            pragma experimental ABIEncoderV2;
-            library Foo {}
-            import "wow.sol";
-            `,
-            `
-            pragma experimental ABIEncoderV2;
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            import "wow.sol";
-            `,
-            `
-            pragma experimental ABIEncoderV2;
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            import "wow.sol";
-            import "mickey";
-            import "minnie.sol";
-            `,
-            `
-            pragma solidity ^0.2.3;
-            pragma experimental ABIEncoderV2;
-            library Foo {}
-            import "wow.sol";
-            `,
-            `
-            pragma solidity ^0.2.3;
-            pragma experimental ABIEncoderV2;
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            import "wow.sol";
-            `,
-            `
-            pragma solidity ^0.2.3;
-            pragma experimental ABIEncoderV2;
 
 
             library Foo {}
@@ -262,18 +160,18 @@ import "wow.sol";
             import "mickey";
             import "minnie.sol";
             `
-        ];
-        const fixedCodes = [
-            `
-            pragma experimental ABIEncoderV2;
+    ];
+    const fixedCodes = [
+      `
+            pragma solidity ^0.2.3;
 
 
 import "wow.sol";
             library Foo {}
             
             `,
-            `
-            pragma experimental ABIEncoderV2;
+      `
+            pragma solidity ^0.2.3;
 
 
 import "wow.sol";
@@ -283,43 +181,8 @@ import "wow.sol";
             contract WiggleWiggle{}
             
             `,
-            `
-            pragma experimental ABIEncoderV2;
-
-
-import "wow.sol";
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            
-            import "mickey";
-            import "minnie.sol";
-            `,
-            `
+      `
             pragma solidity ^0.2.3;
-            pragma experimental ABIEncoderV2;
-
-
-import "wow.sol";
-            library Foo {}
-            
-            `,
-            `
-            pragma solidity ^0.2.3;
-            pragma experimental ABIEncoderV2;
-
-
-import "wow.sol";
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            
-            `,
-            `
-            pragma solidity ^0.2.3;
-            pragma experimental ABIEncoderV2;
 
 
 import "wow.sol";
@@ -331,53 +194,192 @@ import "wow.sol";
             import "mickey";
             import "minnie.sol";
             `
-        ];
-        
+    ];
 
-        let result = Solium.lintAndFix(codes[0], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[0]);
+    let result = Solium.lintAndFix(codes[0], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[0]);
 
-        result = Solium.lintAndFix(codes[1], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[1]);
+    result = Solium.lintAndFix(codes[1], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[1]);
 
-        result = Solium.lintAndFix(codes[2], userConfig);
-        result.errorMessages.should.be.size(2);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[2]);
+    result = Solium.lintAndFix(codes[2], userConfig);
+    result.errorMessages.should.be.size(2);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[2]);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should place import below pragma experimental", done => {
+    const codes = [
+      `
+            pragma experimental ABIEncoderV2;
+            library Foo {}
+            import "wow.sol";
+            `,
+      `
+            pragma experimental ABIEncoderV2;
 
 
-        result = Solium.lintAndFix(codes[3], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[3]);
+            library Foo {}
+            contract WiggleWiggle{}
+            import "wow.sol";
+            `,
+      `
+            pragma experimental ABIEncoderV2;
 
-        result = Solium.lintAndFix(codes[4], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[4]);
 
-        result = Solium.lintAndFix(codes[5], userConfig);
-        result.errorMessages.should.be.size(2);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[5]);
+            library Foo {}
+            contract WiggleWiggle{}
+            import "wow.sol";
+            import "mickey";
+            import "minnie.sol";
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+            library Foo {}
+            import "wow.sol";
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
 
-        Solium.reset();
-        done();
-    });
 
-    it("should place import below existing import statement", done => {
-        const codes = [
+            library Foo {}
+            contract WiggleWiggle{}
+            import "wow.sol";
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+
+
+            library Foo {}
+            contract WiggleWiggle{}
+            import "wow.sol";
+            import "mickey";
+            import "minnie.sol";
             `
+    ];
+    const fixedCodes = [
+      `
+            pragma experimental ABIEncoderV2;
+
+
+import "wow.sol";
+            library Foo {}
+            
+            `,
+      `
+            pragma experimental ABIEncoderV2;
+
+
+import "wow.sol";
+
+
+            library Foo {}
+            contract WiggleWiggle{}
+            
+            `,
+      `
+            pragma experimental ABIEncoderV2;
+
+
+import "wow.sol";
+
+
+            library Foo {}
+            contract WiggleWiggle{}
+            
+            import "mickey";
+            import "minnie.sol";
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+
+
+import "wow.sol";
+            library Foo {}
+            
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+
+
+import "wow.sol";
+
+
+            library Foo {}
+            contract WiggleWiggle{}
+            
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+
+
+import "wow.sol";
+
+
+            library Foo {}
+            contract WiggleWiggle{}
+            
+            import "mickey";
+            import "minnie.sol";
+            `
+    ];
+
+    let result = Solium.lintAndFix(codes[0], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[0]);
+
+    result = Solium.lintAndFix(codes[1], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[1]);
+
+    result = Solium.lintAndFix(codes[2], userConfig);
+    result.errorMessages.should.be.size(2);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[2]);
+
+    result = Solium.lintAndFix(codes[3], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[3]);
+
+    result = Solium.lintAndFix(codes[4], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[4]);
+
+    result = Solium.lintAndFix(codes[5], userConfig);
+    result.errorMessages.should.be.size(2);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[5]);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should place import below existing import statement", done => {
+    const codes = [
+      `
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
             library Foo {}
             import "wow.sol";
             `,
-            `
+      `
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
 
@@ -386,7 +388,7 @@ import "wow.sol";
             contract WiggleWiggle{}
             import "wow.sol";
             `,
-            `
+      `
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
 
@@ -397,14 +399,14 @@ import "wow.sol";
             import "mickey";
             import "minnie.sol";
             `,
-            `
+      `
             pragma solidity ^0.2.3;
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
             library Foo {}
             import "wow.sol";
             `,
-            `
+      `
             pragma solidity ^0.2.3;
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
@@ -414,7 +416,7 @@ import "wow.sol";
             contract WiggleWiggle{}
             import "wow.sol";
             `,
-            `
+      `
             pragma solidity ^0.2.3;
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
@@ -426,47 +428,16 @@ import "wow.sol";
             import "mickey";
             import "minnie.sol";
             `
-        ];
-        const fixedCodes = [
-            `
+    ];
+    const fixedCodes = [
+      `
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
 import "wow.sol";
             library Foo {}
             
             `,
-            `
-            pragma experimental ABIEncoderV2;
-            import "foobar.sol";
-import "wow.sol";
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            
-            `,
-            `
-            pragma experimental ABIEncoderV2;
-            import "foobar.sol";
-import "wow.sol";
-
-
-            library Foo {}
-            contract WiggleWiggle{}
-            
-            import "mickey";
-            import "minnie.sol";
-            `,
-            `
-            pragma solidity ^0.2.3;
-            pragma experimental ABIEncoderV2;
-            import "foobar.sol";
-import "wow.sol";
-            library Foo {}
-            
-            `,
-            `
-            pragma solidity ^0.2.3;
+      `
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
 import "wow.sol";
@@ -476,8 +447,7 @@ import "wow.sol";
             contract WiggleWiggle{}
             
             `,
-            `
-            pragma solidity ^0.2.3;
+      `
             pragma experimental ABIEncoderV2;
             import "foobar.sol";
 import "wow.sol";
@@ -488,161 +458,207 @@ import "wow.sol";
             
             import "mickey";
             import "minnie.sol";
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+            import "foobar.sol";
+import "wow.sol";
+            library Foo {}
+            
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+            import "foobar.sol";
+import "wow.sol";
+
+
+            library Foo {}
+            contract WiggleWiggle{}
+            
+            `,
+      `
+            pragma solidity ^0.2.3;
+            pragma experimental ABIEncoderV2;
+            import "foobar.sol";
+import "wow.sol";
+
+
+            library Foo {}
+            contract WiggleWiggle{}
+            
+            import "mickey";
+            import "minnie.sol";
             `
-        ];
-        
+    ];
 
-        let result = Solium.lintAndFix(codes[0], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[0]);
+    let result = Solium.lintAndFix(codes[0], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[0]);
 
-        result = Solium.lintAndFix(codes[1], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[1]);
+    result = Solium.lintAndFix(codes[1], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[1]);
 
-        result = Solium.lintAndFix(codes[2], userConfig);
-        result.errorMessages.should.be.size(2);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[2]);
+    result = Solium.lintAndFix(codes[2], userConfig);
+    result.errorMessages.should.be.size(2);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[2]);
 
+    result = Solium.lintAndFix(codes[3], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[3]);
 
-        result = Solium.lintAndFix(codes[3], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[3]);
+    result = Solium.lintAndFix(codes[4], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[4]);
 
-        result = Solium.lintAndFix(codes[4], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[4]);
+    result = Solium.lintAndFix(codes[5], userConfig);
+    result.errorMessages.should.be.size(2);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[5]);
 
-        result = Solium.lintAndFix(codes[5], userConfig);
-        result.errorMessages.should.be.size(2);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[5]);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
-
-    it("should place import on top", done => {
-        const codes = [
-            `
+  it("should place import on top", done => {
+    const codes = [
+      `
             contract foo {}
             import "coal.sol";
             `,
-            `
+      `
             contract foo {}
             library bar {}
             import "coal.sol";
             `,
-            `
+      `
             contract foo {}
             library bar {}
             import "coal.sol";
             import "june.sol";
             `
-        ];
-        const fixedCodes = [
-            `
+    ];
+    const fixedCodes = [
+      `
             import "coal.sol";
 contract foo {}
             
             `,
-            `
+      `
             import "coal.sol";
 contract foo {}
             library bar {}
             
             `,
-            `
+      `
             import "coal.sol";
 contract foo {}
             library bar {}
             
             import "june.sol";
             `
-        ];
+    ];
 
+    let result = Solium.lintAndFix(codes[0], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[0]);
 
-        let result = Solium.lintAndFix(codes[0], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[0]);
+    result = Solium.lintAndFix(codes[1], userConfig);
+    result.errorMessages.should.be.size(0);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[1]);
 
-        result = Solium.lintAndFix(codes[1], userConfig);
-        result.errorMessages.should.be.size(0);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[1]);
+    result = Solium.lintAndFix(codes[2], userConfig);
+    result.errorMessages.should.be.size(1);
+    result.fixesApplied.should.be.size(1);
+    result.fixedSourceCode.should.equal(fixedCodes[2]);
 
-        result = Solium.lintAndFix(codes[2], userConfig);
-        result.errorMessages.should.be.size(1);
-        result.fixesApplied.should.be.size(1);
-        result.fixedSourceCode.should.equal(fixedCodes[2]);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("Should move the import statements below the last valid import node", function(done) {
+    let code = fs.readFileSync(
+      path.join(__dirname, "./fixes/only-one-error.sol"),
+      "utf8"
+    );
+    let { errorMessages: errors, fixedSourceCode } = Solium.lintAndFix(
+      code,
+      userConfig
+    );
 
-    it("Should move the import statements below the last valid import node", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./fixes/only-one-error.sol"), "utf8");
-        let {errorMessages: errors, fixedSourceCode} = Solium.lintAndFix(code, userConfig);
+    // All errors should've been corrected
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        // All errors should've been corrected
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    // Ensure that the bad import is moved to the right place.
+    const importLine = fixedSourceCode.split(EOL)[4].trim();
+    importLine.should.equal('import "nano.sol";');
 
-        // Ensure that the bad import is moved to the right place.
-        const importLine = fixedSourceCode.split(EOL)[4].trim();
-        importLine.should.equal("import \"nano.sol\";");
+    // If we re-lint the fixedSourceCode with userConfig we should get no errors
+    errors = Solium.lint(fixedSourceCode, userConfig);
 
-        // If we re-lint the fixedSourceCode with userConfig we should get no errors
-        errors = Solium.lint(fixedSourceCode, userConfig);
+    // Code should've been fixed
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        // Code should've been fixed
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("Should move the import statements two lines below the pragma if no valid import exists", function(done) {
+    let code = fs.readFileSync(
+      path.join(__dirname, "./fixes/before-pragma.sol"),
+      "utf8"
+    );
+    let { errorMessages: errors, fixedSourceCode } = Solium.lintAndFix(
+      code,
+      userConfig
+    );
 
-    it("Should move the import statements two lines below the pragma if no valid import exists", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./fixes/before-pragma.sol"), "utf8");
-        let {errorMessages: errors, fixedSourceCode} = Solium.lintAndFix(code, userConfig);
+    // There should be no errors
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        // There should be no errors
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    // The fixed source code should have two new lines after the first pragma solidity then have all the imports
+    let lines = fixedSourceCode.split(EOL);
+    lines[3].should.equal('import "nano.sol";');
 
-        // The fixed source code should have two new lines after the first pragma solidity then have all the imports
-        let lines = fixedSourceCode.split(EOL);
-        lines[3].should.equal("import \"nano.sol\";");
+    errors = Solium.lint(fixedSourceCode, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(fixedSourceCode, userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("Should still fix the file correctly if there's only one invalid import statement", function(done) {
+    let code = fs.readFileSync(
+      path.join(__dirname, "./fixes/only-one-error.sol"),
+      "utf8"
+    );
+    let { errorMessages: errors, fixedSourceCode } = Solium.lintAndFix(
+      code,
+      userConfig
+    );
 
-    it("Should still fix the file correctly if there's only one invalid import statement", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./fixes/only-one-error.sol"), "utf8");
-        let {errorMessages: errors, fixedSourceCode} = Solium.lintAndFix(code, userConfig);
+    // There should be no errors
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        // There should be no errors
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(fixedSourceCode, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(fixedSourceCode, userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/indentation/indentation.js
+++ b/test/lib/rules/indentation/indentation.js
@@ -6,426 +6,426 @@
 "use strict";
 
 const fs = require("fs"),
-    path = require("path"),
-    Solium = require("../../../../lib/solium");
+  path = require("path"),
+  Solium = require("../../../../lib/solium");
 const acceptDir = path.join(__dirname, "accept"),
-    rejectDir = path.join(__dirname, "reject"),
-    { EOL } = require("os");
+  rejectDir = path.join(__dirname, "reject"),
+  { EOL } = require("os");
 
 describe("[RULE] indentation: Acceptances", function() {
-    it("should accept a valid file under the default options", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a valid file under the default options", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "config-default.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "config-default.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a valid file with tabs", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": ["error", "tab"]
-            }
-        };
+  it("should accept a valid file with tabs", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: ["error", "tab"]
+      }
+    };
 
-        let file = "config-tabs.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "config-tabs.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a valid file with two spaces", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": ["error", 2]
-            }
-        };
+  it("should accept a valid file with two spaces", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: ["error", 2]
+      }
+    };
 
-        let file = "config-two-spaces.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "config-two-spaces.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a file with a multiline array", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a file with a multiline array", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "multiline-array.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "multiline-array.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a file with a multiline call declaration", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a file with a multiline call declaration", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "multiline-call-declaration.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "multiline-call-declaration.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a file with a multiline call expression", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a file with a multiline call expression", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "multiline-call-expression.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "multiline-call-expression.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a file with a struct", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a file with a struct", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "struct.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "struct.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a file with a struct in one line", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a file with a struct in one line", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "one-line-struct.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "one-line-struct.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a file with an array in one line", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a file with an array in one line", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "one-line-array.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "one-line-array.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept a file with a function call in one line", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should accept a file with a function call in one line", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "one-line-function-call.sol";
-        let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
+    let file = "one-line-function-call.sol";
+    let code = fs.readFileSync(path.join(acceptDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] indentation: Rejections", function() {
-    it("should reject an invalid file under the default options", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject an invalid file under the default options", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "config-default.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "config-default.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(13);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(13);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject an invalid file with tabs", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": ["error", "tab"]
-            }
-        };
+  it("should reject an invalid file with tabs", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: ["error", "tab"]
+      }
+    };
 
-        let file = "config-tabs.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "config-tabs.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(11);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(11);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject an invalid file with two spaces", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": ["error", 2]
-            }
-        };
+  it("should reject an invalid file with two spaces", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: ["error", 2]
+      }
+    };
 
-        let file = "config-two-spaces.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "config-two-spaces.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(11);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(11);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject files with mixed tabs and spaces", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject files with mixed tabs and spaces", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "mixed-tabs-spaces.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "mixed-tabs-spaces.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject an invalid file with a multiline array", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject an invalid file with a multiline array", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "multiline-array.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "multiline-array.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(8);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(8);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject an invalid file with a multiline call declaration", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject an invalid file with a multiline call declaration", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "multiline-call-declaration.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "multiline-call-declaration.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject an invalid file with a multiline call expression", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject an invalid file with a multiline call expression", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "multiline-call-expression.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "multiline-call-expression.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject an invalid file with a struct", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject an invalid file with a struct", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "struct.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "struct.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(8);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(8);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject top level indentation", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject top level indentation", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "top-level-indent.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "top-level-indent.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject chars before top level declaration", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject chars before top level declaration", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "chars-before-top-level.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "chars-before-top-level.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject chars before top level declaration", function(done) {
-        let userConfig = {
-            "rules": {
-                "indentation": "error"
-            }
-        };
+  it("should reject chars before top level declaration", function(done) {
+    let userConfig = {
+      rules: {
+        indentation: "error"
+      }
+    };
 
-        let file = "indented-top-level-closing-brace.sol";
-        let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
+    let file = "indented-top-level-closing-brace.sol";
+    let code = fs.readFileSync(path.join(rejectDir, file), "utf8");
 
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject any kind of indent when indent is set to 0", done => {
-        const config = {
-            "rules": {
-                "indentation": ["error", 0]
-            }
-        };
-        const code = `contract Foo {${EOL}function bar() {${EOL}if (true) {${EOL}  lol(100, \'hello\');${EOL}}${EOL}}${EOL}}`,
-            errors = Solium.lint(code, config);
-        
-        errors.should.have.size(1);
+  it("should reject any kind of indent when indent is set to 0", done => {
+    const config = {
+      rules: {
+        indentation: ["error", 0]
+      }
+    };
+    const code = `contract Foo {${EOL}function bar() {${EOL}if (true) {${EOL}  lol(100, \'hello\');${EOL}}${EOL}}${EOL}}`,
+      errors = Solium.lint(code, config);
 
-        Solium.reset();
-        done();
-    });
+    errors.should.have.size(1);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/lbrace/lbrace.js
+++ b/test/lib/rules/lbrace/lbrace.js
@@ -6,35 +6,35 @@
 "use strict";
 
 const Solium = require("../../../../lib/solium"),
-    wrappers = require("../../../utils/wrappers");
+  wrappers = require("../../../utils/wrappers");
 
 const toContract = wrappers.toContract,
-    toFunction = wrappers.toFunction,
-    addPragma = wrappers.addPragma,
-    { EOL } = require("os");
+  toFunction = wrappers.toFunction,
+  addPragma = wrappers.addPragma,
+  { EOL } = require("os");
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "lbrace": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    lbrace: true
+  }
 };
 
 describe("[RULE] lbrace: Acceptances", function() {
+  it("should allow abstract functions", function(done) {
+    let code =
+        "function abstractFunc (uint x, string y) public returns (boolean);",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should allow abstract functions", function(done) {
-        let code = "function abstractFunc (uint x, string y) public returns (boolean);",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
-
-    it("should allow lbrace 1 line after returns declaration", done => {
-        let code = `contract Foo {
+  it("should allow lbrace 1 line after returns declaration", done => {
+    let code = `contract Foo {
     function calcUnclaimedRewards(uint gav)
         view
         returns (
@@ -47,13 +47,12 @@ describe("[RULE] lbrace: Acceptances", function() {
         //code
     }
 }`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-
-        code = `contract Foo {
+    code = `contract Foo {
     function calcUnclaimedRewards(uint gav)
         view
         returns (
@@ -65,156 +64,158 @@ describe("[RULE] lbrace: Acceptances", function() {
         //code
     }
 }`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should allow (short-declaration) bodies with opening brace on same line after a single space", function(done) {
-        let code = "contract Visual {}",
-            errors = Solium.lint(addPragma(code), userConfig);
+  it("should allow (short-declaration) bodies with opening brace on same line after a single space", function(done) {
+    let code = "contract Visual {}",
+      errors = Solium.lint(addPragma(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = "library Visual {}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    code = "library Visual {}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `function foobar (bytes32 name) returns (address) {${EOL}\t/*body*/${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function foobar (bytes32 name) returns (address) {${EOL}\t/*body*/${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `struct Student {${EOL}\tstring name;${EOL}\tuint age;${EOL}\taddress account;${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `struct Student {${EOL}\tstring name;${EOL}\tuint age;${EOL}\taddress account;${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `for (var i = 0; i < 10; i++) {${EOL}\thello ();${EOL}}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = `for (var i = 0; i < 10; i++) {${EOL}\thello ();${EOL}}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `uint i = 0; while (i < 10) {${EOL}\ti++;${EOL}}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = `uint i = 0; while (i < 10) {${EOL}\ti++;${EOL}}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `uint i = 0; do {${EOL}\ti++;${EOL}}${EOL}while (i < 10);`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = `uint i = 0; do {${EOL}\ti++;${EOL}}${EOL}while (i < 10);`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should allow when closing brace is on its own line unless the body is declared on a single line like if (..) {...}", function(done) {
-        let code = "if (true) { hello (); }",
-            errors = Solium.lint(toFunction(code), userConfig);
+  it("should allow when closing brace is on its own line unless the body is declared on a single line like if (..) {...}", function(done) {
+    let code = "if (true) { hello (); }",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `if (true) {${EOL}\thello ();${EOL}} else if (true) {${EOL}\tworld ();${EOL}} else {${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = `if (true) {${EOL}\thello ();${EOL}} else if (true) {${EOL}\tworld ();${EOL}} else {${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = "function foo () {hello ();}";
-        errors = Solium.lint(toContract(code), userConfig);
+    code = "function foo () {hello ();}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `function foo () {${EOL}\thello ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function foo () {${EOL}\thello ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should allow single-item, single-line bodies without braces", function(done) {
-        let code, errors;
+  it("should allow single-item, single-line bodies without braces", function(done) {
+    let code, errors;
 
-        //since this rule doesn't lint for indentation, only ${EOL} without \t should also be valid
-        code = `if (true)${EOL}newNumber = (10 * 78 + 982 % 6**2);${EOL}else${EOL}newNumber = 0;`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    //since this rule doesn't lint for indentation, only ${EOL} without \t should also be valid
+    code = `if (true)${EOL}newNumber = (10 * 78 + 982 % 6**2);${EOL}else${EOL}newNumber = 0;`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `if (true)${EOL}\tlaunchEvent (\"foo bar!\");`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = `if (true)${EOL}\tlaunchEvent (\"foo bar!\");`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = `if (true)${EOL}createStructObject ({ name: \"Chuck Norris\", age: \"inf\" });`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = `if (true)${EOL}createStructObject ({ name: \"Chuck Norris\", age: \"inf\" });`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
+    Solium.reset();
+    done();
+  });
 
-    });
+  it("should allow functions with arguments spanning over multiple lines to NOT have opening brace on same line", function(done) {
+    let code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL}) {${EOL}\tfoobar ();${EOL}}`,
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should allow functions with arguments spanning over multiple lines to NOT have opening brace on same line", function(done) {
-        let code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL}) {${EOL}\tfoobar ();${EOL}}`,
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should allow opening brace to be on its own line in case a function has modifiers", function(done) {
+    let code = `function modifs ()${EOL}public${EOL}owner${EOL}priced${EOL}returns (uint)${EOL}{${EOL}\tfoobar ();${EOL}}`,
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should allow opening brace to be on its own line in case a function has modifiers", function(done) {
-        let code = `function modifs ()${EOL}public${EOL}owner${EOL}priced${EOL}returns (uint)${EOL}{${EOL}\tfoobar ();${EOL}}`,
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = `function modifs (${EOL}\tuint x,${EOL}\tstring y${EOL})${EOL}public${EOL}owner${EOL}priced${EOL}returns (uint)${EOL}{${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        code = `function modifs (${EOL}\tuint x,${EOL}\tstring y${EOL})${EOL}public${EOL}owner${EOL}priced${EOL}returns (uint)${EOL}{${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = `pragma solidity ^4.4.0;${EOL}import {high} from \"low.sol\";${EOL.repeat(
+      3
+    )}contract MyContract {${EOL}    address public myAddress;${EOL.repeat(
+      2
+    )}    function MyContract(${EOL}        uint x,${EOL}        string y${EOL}    )${EOL}    public${EOL}    returns (uint)${EOL}    {${EOL}        myAddress = address(this);${EOL}    }${EOL}}`;
+    errors = Solium.lint(code, userConfig);
 
-        code = `pragma solidity ^4.4.0;${EOL}import {high} from \"low.sol\";${EOL.repeat(3)}contract MyContract {${EOL}    address public myAddress;${EOL.repeat(2)}    function MyContract(${EOL}        uint x,${EOL}        string y${EOL}    )${EOL}    public${EOL}    returns (uint)${EOL}    {${EOL}        myAddress = address(this);${EOL}    }${EOL}}`;
-        errors = Solium.lint(code, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = `function modifs (${EOL}\tuint x,${EOL}\tstring y${EOL})${EOL}public${EOL}owner${EOL}priced${EOL}returns (uint) \t${EOL}{${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        code = `function modifs (${EOL}\tuint x,${EOL}\tstring y${EOL})${EOL}public${EOL}owner${EOL}priced${EOL}returns (uint) \t${EOL}{${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-
-        code = `
+    code = `
             function requestSubscription(
                 uint giveQuantity,
                 uint shareQuantity,
@@ -227,13 +228,12 @@ describe("[RULE] lbrace: Acceptances", function() {
                 bar(100);
             }
         `;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-
-        code = `
+    code = `
             function requestSubscription(
                 uint giveQuantity,
                 uint shareQuantity,
@@ -248,597 +248,576 @@ describe("[RULE] lbrace: Acceptances", function() {
                 bar(100);
             }
         `;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
-		
-        Solium.reset();
-        done();
-    });
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-    it("should allow opening brace to be on its own line in case a function has modifiers (without brackets)", function(done) {
-        let code = `function modifs ()${EOL}public${EOL}owner${EOL}priced(0)${EOL}payable${EOL}{${EOL}\tfoobar ();${EOL}}`,
-            errors = Solium.lint(toContract(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should allow opening brace to be on its own line in case a function has modifiers (without brackets)", function(done) {
+    let code = `function modifs ()${EOL}public${EOL}owner${EOL}priced(0)${EOL}payable${EOL}{${EOL}\tfoobar ();${EOL}}`,
+      errors = Solium.lint(toContract(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-    it("should allow opening brace to be on its own line in case a function has base constructor arguments", function(done) {
-        let code = `function baseArgs ()${EOL}\tA (10)${EOL}\tB (\"hello\")${EOL}\tC (0x0)${EOL}\tD (frodo)${EOL}{${EOL}\tfoobar ();${EOL}}`,
-            errors = Solium.lint(toContract(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should allow opening brace to be on its own line in case a function has base constructor arguments", function(done) {
+    let code = `function baseArgs ()${EOL}\tA (10)${EOL}\tB (\"hello\")${EOL}\tC (0x0)${EOL}\tD (frodo)${EOL}{${EOL}\tfoobar ();${EOL}}`,
+      errors = Solium.lint(toContract(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-    it("should allow else clauses beginning on the same line as closing brace of if consequent", function(done) {
-        let code = "if (true) {h();} else if (true) {h();} else {h();}",
-            errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should allow else clauses beginning on the same line as closing brace of if consequent", function(done) {
+    let code = "if (true) {h();} else if (true) {h();} else {h();}",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {h();} else {h();}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = "if (true) {h();} else {h();}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {h();} else if (true) {h();}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = "if (true) {h();} else if (true) {h();}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `if (true) {h();} else if (true)${EOL}hello ();`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = `if (true) {h();} else if (true)${EOL}hello ();`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `if (true) {h();} else if (true)${EOL}hello ();`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = `if (true) {h();} else if (true)${EOL}hello ();`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] lbrace: Rejections", function() {
+  it("should reject any opening brace which is not preceded by EXACTLY single space (exception: functions with modifiers)", function(done) {
+    let code = "contract FooBar{}",
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should reject any opening brace which is not preceded by EXACTLY single space (exception: functions with modifiers)", function(done) {
-        let code = "contract FooBar{}",
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "contract FooBar  {}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        code = "contract FooBar  {}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "contract FooBar\t{}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        code = "contract FooBar\t{}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "contract FooBar/*comment*/{}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        code = "contract FooBar/*comment*/{}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "library FooBar{}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "library FooBar{}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    code = "library FooBar  {}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "library FooBar  {}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    code = "library FooBar\t{}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "library FooBar\t{}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    code = "library FooBar/*comment*/{}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "library FooBar/*comment*/{}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    code = "if (true){}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true)${EOL}{call();}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
+    code = `${EOL.repeat(4)}\tif (true)${EOL}{call();}${EOL.repeat(3)}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true){}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `if (true)${EOL}{call();}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true)  {}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `${EOL.repeat(4)}\tif (true)${EOL}{call();}${EOL.repeat(3)}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "if (true)\t{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true)  {}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "if (true)/*comment*/{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true)\t{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "if (true) {} else if (true){}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true)/*comment*/{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "if (true) {} else if (true)  {}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "if (true) {} else if (true){}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true) {} else if (true)\t{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "if (true) {} else if (true)  {}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true) {} else if (true)/*comment*/{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "if (true) {} else if (true)\t{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true) {} else{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "if (true) {} else if (true)/*comment*/{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true) {} else  {}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    code = "if (true) {} else\t{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {} else{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "if (true) {} else/*comment*/{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {} else  {}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "while (true) foo();";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {} else\t{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "while (true){}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {} else/*comment*/{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "while (true)  {}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "while (true) foo();";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "while (true)\t{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "while (true){}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "while (true)/*comment*/{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "while (true)  {}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "for (;;) foo();";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "while (true)\t{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "for (;;){}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "while (true)/*comment*/{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "for (;;)  {}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    code = "for (;;)\t{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "for (;;) foo();";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "for (;;)/*comment*/{}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "for (;;){}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `do{}${EOL}while (true);`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "for (;;)  {}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `do  {}${EOL}while (true);`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "for (;;)\t{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `do\t{}${EOL}while (true);`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "for (;;)/*comment*/{}";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `do/*comment*/{}${EOL}while (true);`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `do{}${EOL}while (true);`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "struct Student{}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `do  {}${EOL}while (true);`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "struct Student  {}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `do\t{}${EOL}while (true);`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "struct Student\t{}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `do/*comment*/{}${EOL}while (true);`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "struct Student/*comment*/{}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    code = "function foo (uint x) public modif returns (address){}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        code = "struct Student{}";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "function foo (uint x) public modif returns (address)  {}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        code = "struct Student  {}";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "function foo (uint x) public modif returns (address)\t{}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        code = "struct Student\t{}";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "function foo (uint x) public modif returns (address)/*comment*/{}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        code = "struct Student/*comment*/{}";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL}){${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "function foo (uint x) public modif returns (address){}";
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL})  {${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "function foo (uint x) public modif returns (address)  {}";
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL})\t{${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "function foo (uint x) public modif returns (address)\t{}";
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL})/*comment*/{${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "function foo (uint x) public modif returns (address)/*comment*/{}";
-        errors = Solium.lint(toContract(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject all function declarations having multiple modifiers over multiple lines whose brace does not open on the line after the last modifier", function(done) {
+    let code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address){${EOL}\tfoobar ();${EOL}}`,
+      errors = Solium.lint(toContract(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL}){${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address) {${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL})  {${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address)\t{${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL})\t{${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address)  {${EOL}\tfoobar ();${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `function lotsOfArgs (${EOL}\tuint x,${EOL}\tstring y,${EOL}\taddress z${EOL})/*comment*/{${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject all short declarations whose opening brace is not on the same line as theirs", function(done) {
+    let code = `contract Foo is Bar, Baz${EOL}{}`,
+      errors = Solium.lint(addPragma(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    code = `library Foo is Bar, Baz${EOL}{}`;
+    errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should reject all function declarations having multiple modifiers over multiple lines whose brace does not open on the line after the last modifier", function(done) {
-        let code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address){${EOL}\tfoobar ();${EOL}}`,
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true)${EOL}{} else if (true)${EOL}{} else${EOL}{}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address) {${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `while (true)${EOL}{}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address)\t{${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `for (;;)${EOL}{}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `function lotsOfArgs ()${EOL}\tpublic${EOL}\treturns (address)  {${EOL}\tfoobar ();${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `function increment(uint x) public onlyowner returns (uint)${EOL}{${EOL}\treturn x + 1;${EOL}}`;
+    errors = Solium.lint(toContract(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    Solium.reset();
+    done();
+  });
 
-    it("should reject all short declarations whose opening brace is not on the same line as theirs", function(done) {
-        let code = `contract Foo is Bar, Baz${EOL}{}`,
-            errors = Solium.lint(addPragma(code), userConfig);
+  it("should reject clauses with empty statements", function(done) {
+    let code = "if (true);",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `library Foo is Bar, Baz${EOL}{}`;
-        errors = Solium.lint(addPragma(code), userConfig);
+    code = `if (true) {}${EOL}else;`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `if (true)${EOL}{} else if (true)${EOL}{} else${EOL}{}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true) {} else if (true) {} else;";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `while (true)${EOL}{}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true) {} else if (true);";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `for (;;)${EOL}{}`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject statements which are neither inside blocks nor completely reside on a single line", function(done) {
+    let code = `if (true)${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`,
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `function increment(uint x) public onlyowner returns (uint)${EOL}{${EOL}\treturn x + 1;${EOL}}`;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true) {}${EOL}else${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    code = `if (true) {} else if (true) {} else${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-    it("should reject clauses with empty statements", function(done) {
-        let code = "if (true);",
-            errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true) {} else if (true)${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `if (true) {}${EOL}else;`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        code = "if (true) {} else if (true) {} else;";
-        errors = Solium.lint(toFunction(code), userConfig);
+  it("should reject statements which exist on the same line as clause and are not brace-enclosed", function(done) {
+    let code = "if (true) sayHello ();",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "if (true) {} else if (true);";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = `if (true) {}${EOL}else sayHello();`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    code = "if (true) {} else if (true) {} else sayHello();";
+    errors = Solium.lint(toFunction(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-    it("should reject statements which are neither inside blocks nor completely reside on a single line", function(done) {
-        let code = `if (true)${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`,
-            errors = Solium.lint(toFunction(code), userConfig);
+    code = "if (true) {} else if (true) sayHello ();";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `if (true) {}${EOL}else${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = "do foo(); while (true);";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = `if (true) {} else if (true) {} else${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject else clauses which are not on the same line as closing brace of if consequent", function(done) {
+    let code = `if (true) {h();}${EOL}else if (true) {h();}${EOL}else {h();}`,
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `if (true) {} else if (true)${EOL}Pacman ({${EOL}\tname: \"Shannon\"${EOL}});`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true) {h();}${EOL}else {h();}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    code = `if (true) {h();}${EOL}else if (true) {h();}`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-    it("should reject statements which exist on the same line as clause and are not brace-enclosed", function(done) {
-        let code = "if (true) sayHello ();",
-            errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true) {h();}${EOL}else if (true)${EOL}hello ();`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = `if (true) {}${EOL}else sayHello();`;
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true) {h();}${EOL}else if (true)${EOL}hello ();`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {} else if (true) {} else sayHello();";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = `if (true) {h();}${EOL}else hello ();`;
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "if (true) {} else if (true) sayHello ();";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-
-        code = "do foo(); while (true);";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        Solium.reset();
-        done();
-    });
-
-
-    it("should reject else clauses which are not on the same line as closing brace of if consequent", function(done) {
-        let code = `if (true) {h();}${EOL}else if (true) {h();}${EOL}else {h();}`,
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = `if (true) {h();}${EOL}else {h();}`;
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = `if (true) {h();}${EOL}else if (true) {h();}`;
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = `if (true) {h();}${EOL}else if (true)${EOL}hello ();`;
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = `if (true) {h();}${EOL}else if (true)${EOL}hello ();`;
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = `if (true) {h();}${EOL}else hello ();`;
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-
-        code = `contract Foo {
+    code = `contract Foo {
         function() returns (uint x, address y) {
                 if (true)
                         foo(); else chumma();}}`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.have.size(1);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject lbrace that's NOT 1 line after returns declaration", done => {
-        let code = `contract Foo {
+  it("should reject lbrace that's NOT 1 line after returns declaration", done => {
+    let code = `contract Foo {
     function calcUnclaimedRewards(uint gav)
         view
         returns (
@@ -850,13 +829,12 @@ describe("[RULE] lbrace: Rejections", function() {
         //code
     }
 }`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-
-        code = `contract Foo {
+    code = `contract Foo {
     function calcUnclaimedRewards(uint gav)
         view
         returns (
@@ -867,18 +845,17 @@ describe("[RULE] lbrace: Rejections", function() {
         //code
     }
 }`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-
-    it("should reject lbrace that's NOT 1 line after last modifier", done => {
-        let code = `
+  it("should reject lbrace that's NOT 1 line after last modifier", done => {
+    let code = `
             function requestSubscription(
                 uint giveQuantity,
                 uint shareQuantity,
@@ -890,13 +867,12 @@ describe("[RULE] lbrace: Rejections", function() {
                 bar(100);
             }
         `;
-        let errors = Solium.lint(toContract(code), userConfig);
+    let errors = Solium.lint(toContract(code), userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-
-        code = `
+    code = `
             function requestSubscription(
                 uint giveQuantity,
                 uint shareQuantity,
@@ -910,13 +886,12 @@ describe("[RULE] lbrace: Rejections", function() {
                 bar(100);
             }
         `;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-
-        code = `
+    code = `
             function requestSubscription(
                 uint giveQuantity,
                 uint shareQuantity,
@@ -931,13 +906,12 @@ describe("[RULE] lbrace: Rejections", function() {
                 bar(100);
             }
         `;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-
-        code = `
+    code = `
             function requestSubscription(
                 uint giveQuantity,
                 uint shareQuantity,
@@ -951,12 +925,11 @@ describe("[RULE] lbrace: Rejections", function() {
                 bar(100);
             }
         `;
-        errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(toContract(code), userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        done();
-    });
-
+    done();
+  });
 });

--- a/test/lib/rules/max-len/max-len.js
+++ b/test/lib/rules/max-len/max-len.js
@@ -6,191 +6,227 @@
 "use strict";
 
 const Solium = require("../../../../lib/solium"),
-    wrappers = require("../../../utils/wrappers"),
-    { addPragma } = wrappers;
+  wrappers = require("../../../utils/wrappers"),
+  { addPragma } = wrappers;
 const DEFAULT_MAX_ACCEPTABLE_LEN = 145;
 
 function makeString(length, character) {
-    return new Array(length + 1).join(character);
+  return new Array(length + 1).join(character);
 }
 
 describe("[RULE] max-len: default len", function() {
+  before(function(done) {
+    this.userConfig = {
+      rules: {
+        "max-len": true
+      }
+    };
+    done();
+  });
 
-    before(function(done) {
-        this.userConfig = {
-            "rules": {
-                "max-len": true
-            }
-        };
-        done();
+  describe("Acceptances", function() {
+    it("should allow line length <= default acceptable", function(done) {
+      let name = makeString(
+          DEFAULT_MAX_ACCEPTABLE_LEN - "contract  {}".length,
+          "a"
+        ),
+        code = `contract ${name} {}`,
+        errors = Solium.lint(addPragma(code), this.userConfig);
+
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(0);
+
+      name = makeString(
+        DEFAULT_MAX_ACCEPTABLE_LEN - 1 - "contract  {}".length,
+        "a"
+      );
+      code = `contract ${name} {}`;
+      errors = Solium.lint(addPragma(code), this.userConfig);
+
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(0);
+
+      Solium.reset();
+      done();
+    });
+  });
+
+  describe("Rejections", function() {
+    it("should reject line length > default acceptable on top level node", function(done) {
+      let name = makeString(
+          DEFAULT_MAX_ACCEPTABLE_LEN + 1 - "contract  {}".length,
+          "a"
+        ),
+        code = `contract ${name} {}`,
+        errors = Solium.lint(addPragma(code), this.userConfig);
+
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
+      errors[0].node.type.should.equal("ContractStatement");
+      errors[0].message.should.equal(
+        `Line exceeds the limit of ${DEFAULT_MAX_ACCEPTABLE_LEN} characters`
+      );
+
+      Solium.reset();
+      done();
     });
 
-    describe("Acceptances", function() {
+    it("should reject line length > default acceptable on child node", function(done) {
+      let name = makeString(
+          DEFAULT_MAX_ACCEPTABLE_LEN + 1 - "        uint ;".length,
+          "a"
+        ),
+        code =
+          "contract dummy {\n" +
+          "    function dummy() {\n" +
+          `        uint ${name};\n` +
+          "    }\n" +
+          "}",
+        errors = Solium.lint(addPragma(code), this.userConfig);
 
-        it("should allow line length <= default acceptable", function(done) {
-            let name = makeString(DEFAULT_MAX_ACCEPTABLE_LEN - "contract  {}".length, "a"),
-                code = `contract ${name} {}`,
-                errors = Solium.lint(addPragma(code), this.userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
+      errors[0].node.type.should.equal("ExpressionStatement");
+      errors[0].message.should.equal(
+        `Line exceeds the limit of ${DEFAULT_MAX_ACCEPTABLE_LEN} characters`
+      );
 
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(0);
-
-
-            name = makeString(DEFAULT_MAX_ACCEPTABLE_LEN - 1 - "contract  {}".length, "a");
-            code = `contract ${name} {}`;
-            errors = Solium.lint(addPragma(code), this.userConfig);
-
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(0);
-
-            Solium.reset();
-            done();
-        });
+      Solium.reset();
+      done();
     });
 
-    describe("Rejections", function() {
+    it("should reject line length > default acceptable only once", function(done) {
+      let name = makeString(
+          DEFAULT_MAX_ACCEPTABLE_LEN + 1 - "        uint short;uint ;".length,
+          "a"
+        ),
+        code =
+          "contract dummy {\n" +
+          "    function dummy() {\n" +
+          `        uint short;uint ${name};\n` +
+          "    }\n" +
+          "}",
+        errors = Solium.lint(addPragma(code), this.userConfig);
 
-        it("should reject line length > default acceptable on top level node", function(done) {
-            let name = makeString(DEFAULT_MAX_ACCEPTABLE_LEN + 1 - "contract  {}".length, "a"),
-                code = `contract ${name} {}`,
-                errors = Solium.lint(addPragma(code), this.userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
+      errors[0].node.type.should.equal("ExpressionStatement");
+      errors[0].message.should.equal(
+        `Line exceeds the limit of ${DEFAULT_MAX_ACCEPTABLE_LEN} characters`
+      );
 
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-            errors[0].node.type.should.equal("ContractStatement");
-            errors[0].message.should.equal(`Line exceeds the limit of ${DEFAULT_MAX_ACCEPTABLE_LEN} characters`);
-
-            Solium.reset();
-            done();
-        });
-
-        it("should reject line length > default acceptable on child node", function(done) {
-            let name = makeString(DEFAULT_MAX_ACCEPTABLE_LEN + 1 - "        uint ;".length, "a"),
-                code = (
-                    "contract dummy {\n" +
-                    "    function dummy() {\n" +
-                    `        uint ${name};\n` +
-                    "    }\n" +
-                    "}"),
-                errors = Solium.lint(addPragma(code), this.userConfig);
-
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-            errors[0].node.type.should.equal("ExpressionStatement");
-            errors[0].message.should.equal(`Line exceeds the limit of ${DEFAULT_MAX_ACCEPTABLE_LEN} characters`);
-
-            Solium.reset();
-            done();
-        });
-
-        it("should reject line length > default acceptable only once", function(done) {
-            let name = makeString(DEFAULT_MAX_ACCEPTABLE_LEN + 1 - "        uint short;uint ;".length, "a"),
-                code = (
-                    "contract dummy {\n" +
-                    "    function dummy() {\n" +
-                    `        uint short;uint ${name};\n` +
-                    "    }\n" +
-                    "}"),
-                errors = Solium.lint(addPragma(code), this.userConfig);
-
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-            errors[0].node.type.should.equal("ExpressionStatement");
-            errors[0].message.should.equal(`Line exceeds the limit of ${DEFAULT_MAX_ACCEPTABLE_LEN} characters`);
-
-            Solium.reset();
-            done();
-        });
+      Solium.reset();
+      done();
     });
+  });
 });
 
 describe("[RULE] max-len: custom len", function() {
+  before(function(done) {
+    this.CUSTOM_MAX_ACCEPTABLE_LEN = 200;
+    this.userConfig = {
+      rules: {
+        "max-len": ["error", this.CUSTOM_MAX_ACCEPTABLE_LEN]
+      }
+    };
+    done();
+  });
 
-    before(function(done) {
-        this.CUSTOM_MAX_ACCEPTABLE_LEN = 200;
-        this.userConfig = {
-            "rules": {
-                "max-len": ["error", this.CUSTOM_MAX_ACCEPTABLE_LEN]
-            }
-        };
-        done();
+  describe("Acceptances", function() {
+    it("should allow line length <= custom acceptable", function(done) {
+      let name = makeString(
+          this.CUSTOM_MAX_ACCEPTABLE_LEN - "contract  {}".length,
+          "a"
+        ),
+        code = `contract ${name} {}`,
+        errors = Solium.lint(addPragma(code), this.userConfig);
+
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(0);
+
+      name = makeString(
+        this.CUSTOM_MAX_ACCEPTABLE_LEN - 1 - "contract  {}".length,
+        "a"
+      );
+      code = `contract ${name} {}`;
+      errors = Solium.lint(addPragma(code), this.userConfig);
+
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(0);
+
+      Solium.reset();
+      done();
+    });
+  });
+
+  describe("Rejections", function() {
+    it("should reject line length > custom acceptable on top level node", function(done) {
+      let name = makeString(
+          this.CUSTOM_MAX_ACCEPTABLE_LEN + 1 - "contract  {}".length,
+          "a"
+        ),
+        code = `contract ${name} {}`,
+        errors = Solium.lint(addPragma(code), this.userConfig);
+
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
+      errors[0].node.type.should.equal("ContractStatement");
+      errors[0].message.should.equal(
+        `Line exceeds the limit of ${this.CUSTOM_MAX_ACCEPTABLE_LEN} characters`
+      );
+
+      Solium.reset();
+      done();
     });
 
-    describe("Acceptances", function() {
+    it("should reject line length > custom acceptable on child node", function(done) {
+      let name = makeString(
+          this.CUSTOM_MAX_ACCEPTABLE_LEN + 1 - "        uint ;".length,
+          "a"
+        ),
+        code =
+          "contract dummy {\n" +
+          "    function dummy() {\n" +
+          `        uint ${name};\n` +
+          "    }\n" +
+          "}",
+        errors = Solium.lint(addPragma(code), this.userConfig);
 
-        it("should allow line length <= custom acceptable", function(done) {
-            let name = makeString(this.CUSTOM_MAX_ACCEPTABLE_LEN - "contract  {}".length, "a"),
-                code = `contract ${name} {}`,
-                errors = Solium.lint(addPragma(code), this.userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
+      errors[0].node.type.should.equal("ExpressionStatement");
+      errors[0].message.should.equal(
+        `Line exceeds the limit of ${this.CUSTOM_MAX_ACCEPTABLE_LEN} characters`
+      );
 
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(0);
-
-
-            name = makeString(this.CUSTOM_MAX_ACCEPTABLE_LEN - 1 - "contract  {}".length, "a");
-            code = `contract ${name} {}`;
-            errors = Solium.lint(addPragma(code), this.userConfig);
-
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(0);
-
-            Solium.reset();
-            done();
-        });
+      Solium.reset();
+      done();
     });
 
-    describe("Rejections", function() {
+    it("should reject line length > custom acceptable only once", function(done) {
+      let name = makeString(
+          this.CUSTOM_MAX_ACCEPTABLE_LEN +
+            1 -
+            "        uint short;uint ;".length,
+          "a"
+        ),
+        code =
+          "contract dummy {\n" +
+          "    function dummy() {\n" +
+          `        uint short;uint ${name};\n` +
+          "    }\n" +
+          "}",
+        errors = Solium.lint(addPragma(code), this.userConfig);
 
-        it("should reject line length > custom acceptable on top level node", function(done) {
-            let name = makeString(this.CUSTOM_MAX_ACCEPTABLE_LEN + 1 - "contract  {}".length, "a"),
-                code = `contract ${name} {}`,
-                errors = Solium.lint(addPragma(code), this.userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
+      errors[0].node.type.should.equal("ExpressionStatement");
+      errors[0].message.should.equal(
+        `Line exceeds the limit of ${this.CUSTOM_MAX_ACCEPTABLE_LEN} characters`
+      );
 
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-            errors[0].node.type.should.equal("ContractStatement");
-            errors[0].message.should.equal(`Line exceeds the limit of ${this.CUSTOM_MAX_ACCEPTABLE_LEN} characters`);
-
-            Solium.reset();
-            done();
-        });
-
-        it("should reject line length > custom acceptable on child node", function(done) {
-            let name = makeString(this.CUSTOM_MAX_ACCEPTABLE_LEN + 1 - "        uint ;".length, "a"),
-                code = (
-                    "contract dummy {\n" +
-                    "    function dummy() {\n" +
-                    `        uint ${name};\n` +
-                    "    }\n" +
-                    "}"),
-                errors = Solium.lint(addPragma(code), this.userConfig);
-
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-            errors[0].node.type.should.equal("ExpressionStatement");
-            errors[0].message.should.equal(`Line exceeds the limit of ${this.CUSTOM_MAX_ACCEPTABLE_LEN} characters`);
-
-            Solium.reset();
-            done();
-        });
-
-        it("should reject line length > custom acceptable only once", function(done) {
-            let name = makeString(this.CUSTOM_MAX_ACCEPTABLE_LEN + 1 - "        uint short;uint ;".length, "a"),
-                code = (
-                    "contract dummy {\n" +
-                    "    function dummy() {\n" +
-                    `        uint short;uint ${name};\n` +
-                    "    }\n" +
-                    "}"),
-                errors = Solium.lint(addPragma(code), this.userConfig);
-
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-            errors[0].node.type.should.equal("ExpressionStatement");
-            errors[0].message.should.equal(`Line exceeds the limit of ${this.CUSTOM_MAX_ACCEPTABLE_LEN} characters`);
-
-            Solium.reset();
-            done();
-        });
+      Solium.reset();
+      done();
     });
+  });
 });

--- a/test/lib/rules/mixedcase/mixedcase.js
+++ b/test/lib/rules/mixedcase/mixedcase.js
@@ -11,527 +11,540 @@ let toContract = wrappers.toContract;
 let toFunction = wrappers.toFunction;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "mixedcase": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    mixedcase: true
+  }
 };
 
 describe("[RULE] mixedcase: Acceptances", function() {
+  it("should accept all valid function declarations", function(done) {
+    let code = [
+      "function helloWorld () {}",
+      "function h () {}",
+      "function he () {}",
+      "function hE () {}",
+      "function _h () {}",
+      "function _hE () {}",
+      "function hello123World () {}",
+      "function _h123 () {}",
+      "function hello_ () {}",
+      "function initialize (Controller _controller) external onlyControllerCaller returns(bool) {}",
+      "function initialize (Controller myController) returns(bool) {}"
+    ];
+    let errors;
 
-    it("should accept all valid function declarations", function(done) {
-        let code = [
-            "function helloWorld () {}",
-            "function h () {}",
-            "function he () {}",
-            "function hE () {}",
-            "function _h () {}",
-            "function _hE () {}",
-            "function hello123World () {}",
-            "function _h123 () {}",
-            "function hello_ () {}",
-            "function initialize (Controller _controller) external onlyControllerCaller returns(bool) {}",
-            "function initialize (Controller myController) returns(bool) {}"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toContract(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [9], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [10], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("should accept all valid modifier declarations", function(done) {
-        let code = [
-            "modifier helloWorld () {}",
-            "modifier h () {}",
-            "modifier he () {}",
-            "modifier hE () {}",
-            "modifier _h () {}",
-            "modifier _hE () {}",
-            "modifier hello123World () {}",
-            "modifier _h123 () {}",
-            "modifier hello_ () {}",
-            "modifier initialize (Controller _controller) external onlyControllerCaller {}",
-            "modifier initialize (Controller myController) {}"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[9], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[10], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [9], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [10], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should accept all valid modifier declarations", function(done) {
+    let code = [
+      "modifier helloWorld () {}",
+      "modifier h () {}",
+      "modifier he () {}",
+      "modifier hE () {}",
+      "modifier _h () {}",
+      "modifier _hE () {}",
+      "modifier hello123World () {}",
+      "modifier _h123 () {}",
+      "modifier hello_ () {}",
+      "modifier initialize (Controller _controller) external onlyControllerCaller {}",
+      "modifier initialize (Controller myController) {}"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("should accept all valid variable declarations", function(done) {
-        let code = [
-            "var helloWorld;",
-            "var h;",
-            "var he;",
-            "var hE;",
-            "var _h;",
-            "var _hE;",
-            "var hello123World;",
-            "var _h123;",
-            "var hello_;"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = code.map(function(item){return toFunction(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[9], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[10], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
+    Solium.reset();
+    done();
+  });
+
+  it("should accept all valid variable declarations", function(done) {
+    let code = [
+      "var helloWorld;",
+      "var h;",
+      "var he;",
+      "var hE;",
+      "var _h;",
+      "var _hE;",
+      "var hello123World;",
+      "var _h123;",
+      "var hello_;"
+    ];
+    let errors;
+
+    code = code.map(function(item) {
+      return toFunction(item);
     });
 
-    it("should accept all valid declarative expressions", function(done) {
-        let code = [
-            "uint helloWorld;",
-            "address h;",
-            "address he;",
-            "bytes32 hE;",
-            "uint _h;",
-            "string _hE;",
-            "bytes32 hello123World;",
-            "string _h123;",
-            "string hello_;"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should accept all valid declarative expressions", function(done) {
+    let code = [
+      "uint helloWorld;",
+      "address h;",
+      "address he;",
+      "bytes32 hE;",
+      "uint _h;",
+      "string _hE;",
+      "bytes32 hello123World;",
+      "string _h123;",
+      "string hello_;"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("should accept all valid function parameter names", function(done) {
-        let code = "function foo (helloWorld, h, he, hE, _h, _hE, hello123World, _h123, hello_) {}",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should accept all valid function parameter names", function(done) {
+    let code =
+        "function foo (helloWorld, h, he, hE, _h, _hE, hello123World, _h123, hello_) {}",
+      errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] mixedcase: Rejections", function() {
+  it("should reject all invalid function declarations", function(done) {
+    let code = [
+      "function _ () {}",
+      "function _H () {}",
+      "function Hello () {}",
+      "function HELLOWORLD () {}",
+      "function hello_world () {}",
+      "function __h() {}",
+      "function Hello$World () {}",
+      "function $helloWorld () {}",
+      "function __ () {}",
+      "function initialize(Controller $helloWorld) returns(bool) {}",
+      "function initialize(Controller BabysDayOut) {}"
+    ];
+    let errors;
 
-    it("should reject all invalid function declarations", function(done) {
-        let code = [
-            "function _ () {}",
-            "function _H () {}",
-            "function Hello () {}",
-            "function HELLOWORLD () {}",
-            "function hello_world () {}",
-            "function __h() {}",
-            "function Hello$World () {}",
-            "function $helloWorld () {}",
-            "function __ () {}",
-            "function initialize(Controller $helloWorld) returns(bool) {}",
-            "function initialize(Controller BabysDayOut) {}"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toContract(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [9], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [10], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("should reject all invalid modifier declarations", function(done) {
-        let code = [
-            "modifier _ () {}",
-            "modifier _H () {}",
-            "modifier Hello () {}",
-            "modifier HELLOWORLD () {}",
-            "modifier hello_world () {}",
-            "modifier __h() {}",
-            "modifier Hello$World () {}",
-            "modifier $helloWorld () {}",
-            "modifier __ () {}",
-            "modifier initialize (Controller $controller) external onlyControllerCaller {}",
-            "modifier initialize (Controller MyController) {}"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[9], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[10], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [9], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [10], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject all invalid modifier declarations", function(done) {
+    let code = [
+      "modifier _ () {}",
+      "modifier _H () {}",
+      "modifier Hello () {}",
+      "modifier HELLOWORLD () {}",
+      "modifier hello_world () {}",
+      "modifier __h() {}",
+      "modifier Hello$World () {}",
+      "modifier $helloWorld () {}",
+      "modifier __ () {}",
+      "modifier initialize (Controller $controller) external onlyControllerCaller {}",
+      "modifier initialize (Controller MyController) {}"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("should reject all invalid variable declarations", function(done) {
-        let code = [
-            "var _;",
-            "var _H;",
-            "var Hello;",
-            "var HELLOWORLD;",
-            "var hello_world;",
-            "var __h;",
-            "var Hello$World;",
-            "var $helloWorld;",
-            "var __;"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = code.map(function(item){return toFunction(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[9], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[10], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
+    Solium.reset();
+    done();
+  });
+
+  it("should reject all invalid variable declarations", function(done) {
+    let code = [
+      "var _;",
+      "var _H;",
+      "var Hello;",
+      "var HELLOWORLD;",
+      "var hello_world;",
+      "var __h;",
+      "var Hello$World;",
+      "var $helloWorld;",
+      "var __;"
+    ];
+    let errors;
+
+    code = code.map(function(item) {
+      return toFunction(item);
     });
 
-    it("should reject all invalid declarative expressions", function(done) {
-        let code = [
-            "uint _;",
-            "address _H;",
-            "bytes32 Hello;",
-            "string HELLOWORLD;",
-            "uint hello_world;",
-            "address __h;",
-            "bytes32 Hello$World;",
-            "string $helloWorld;",
-            "uint __;"
-        ];
-        let errors;
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = code.map(function(item){return toContract(item);});
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject all invalid declarative expressions", function(done) {
+    let code = [
+      "uint _;",
+      "address _H;",
+      "bytes32 Hello;",
+      "string HELLOWORLD;",
+      "uint hello_world;",
+      "address __h;",
+      "bytes32 Hello$World;",
+      "string $helloWorld;",
+      "uint __;"
+    ];
+    let errors;
 
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
-    it("should reject all invalid function parameter names", function(done) {
-        let code = "function foo (uint _, uint _H, uint Hello, uint HELLOWORLD, uint hello_world, uint __h, uint hello$world, uint $helloWorld) {}",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(8);
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should reject all invalid function parameter names", function(done) {
+    let code =
+        "function foo (uint _, uint _H, uint Hello, uint HELLOWORLD, uint hello_world, uint __h, uint hello$world, uint $helloWorld) {}",
+      errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(8);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/no-constant/no-constant.js
+++ b/test/lib/rules/no-constant/no-constant.js
@@ -7,89 +7,89 @@
 
 const Solium = require("../../../../lib/solium");
 const userConfig = {
-    "rules": {
-        "no-constant": "error"
-    }
+  rules: {
+    "no-constant": "error"
+  }
 };
 
-
 describe("[RULE] emit: Acceptances", () => {
+  it("should accept function declarations that don't have constant modifier", done => {
+    const declarations = [
+      "function foo() view pure returns(bool);",
+      "function foo() view pure returns(bool) {}",
+      "function foo() {}",
+      "function foo();",
+      "function(){}",
+      'function foo() myModifier(100, "hello") boo;'
+    ];
 
-    it("should accept function declarations that don't have constant modifier", done => {
-        const declarations = [
-            "function foo() view pure returns(bool);",
-            "function foo() view pure returns(bool) {}",
-            "function foo() {}",
-            "function foo();",
-            "function(){}",
-            "function foo() myModifier(100, \"hello\") boo;"
-        ];
+    declarations.forEach(func => {
+      const issues = Solium.lint(`contract Foo { ${func} }`, userConfig);
 
-        declarations.forEach(func => {
-            const issues = Solium.lint(`contract Foo { ${func} }`, userConfig);
-
-            issues.should.be.Array();
-            issues.should.be.empty();
-        });
-
-        done();
+      issues.should.be.Array();
+      issues.should.be.empty();
     });
 
+    done();
+  });
 });
-
 
 describe("[RULE] emit: Rejections", () => {
+  it("should reject function declarations that have constant modifier", done => {
+    const declarations = [
+      "function foo() view pure constant returns(bool);",
+      "function foo() constant pure returns(bool) {}",
+      "function foo() constant {}",
+      "function foo() constant;",
+      "function()constant{}",
+      'function foo() myModifier(100, "hello") constant boo;'
+    ];
 
-    it("should reject function declarations that have constant modifier", done => {
-        const declarations = [
-            "function foo() view pure constant returns(bool);",
-            "function foo() constant pure returns(bool) {}",
-            "function foo() constant {}",
-            "function foo() constant;",
-            "function()constant{}",
-            "function foo() myModifier(100, \"hello\") constant boo;"
-        ];
+    declarations.forEach(func => {
+      const issues = Solium.lint(`contract Foo { ${func} }`, userConfig);
 
-        declarations.forEach(func => {
-            const issues = Solium.lint(`contract Foo { ${func} }`, userConfig);
-
-            issues.should.be.Array();
-            issues.should.have.size(1);
-        });
-
-        done();
+      issues.should.be.Array();
+      issues.should.have.size(1);
     });
 
+    done();
+  });
 });
 
-
 describe("[RULE] emit: fixes", () => {
+  it("should replace constant with view", done => {
+    const declarations = [
+      {
+        bad: "function foo() view pure constant returns(bool);",
+        good: "function foo() view pure view returns(bool);"
+      },
+      {
+        bad: "function foo() constant pure returns(bool) {}",
+        good: "function foo() view pure returns(bool) {}"
+      },
+      { bad: "function foo() constant {}", good: "function foo() view {}" },
+      { bad: "function foo() constant;", good: "function foo() view;" },
+      { bad: "function()constant{}", good: "function()view{}" },
+      {
+        bad: 'function foo() myModifier(100, "hello") constant boo;',
+        good: 'function foo() myModifier(100, "hello") view boo;'
+      }
+    ];
 
-    it("should replace constant with view", done => {
-        const declarations = [
-            { bad: "function foo() view pure constant returns(bool);", good: "function foo() view pure view returns(bool);" },
-            { bad: "function foo() constant pure returns(bool) {}", good: "function foo() view pure returns(bool) {}" },
-            { bad: "function foo() constant {}", good: "function foo() view {}" },
-            { bad: "function foo() constant;", good: "function foo() view;" },
-            { bad: "function()constant{}", good: "function()view{}" },
-            {
-                bad: "function foo() myModifier(100, \"hello\") constant boo;",
-                good: "function foo() myModifier(100, \"hello\") view boo;"
-            }
-        ];
+    declarations.forEach(({ bad, good }) => {
+      const {
+        fixesApplied,
+        fixedSourceCode,
+        errorMessages
+      } = Solium.lintAndFix(`contract Foo { ${bad} }`, userConfig);
 
-        declarations.forEach(({ bad, good }) => {
-            const { fixesApplied, fixedSourceCode,
-                errorMessages } = Solium.lintAndFix(`contract Foo { ${bad} }`, userConfig);
-            
-            fixesApplied.should.be.Array();
-            fixesApplied.should.have.size(1);
-            errorMessages.should.be.Array();
-            errorMessages.should.be.empty();
-            fixedSourceCode.should.equal(`contract Foo { ${good} }`);
-        });
-
-        done();
+      fixesApplied.should.be.Array();
+      fixesApplied.should.have.size(1);
+      errorMessages.should.be.Array();
+      errorMessages.should.be.empty();
+      fixedSourceCode.should.equal(`contract Foo { ${good} }`);
     });
 
+    done();
+  });
 });

--- a/test/lib/rules/no-empty-blocks/no-empty-blocks.js
+++ b/test/lib/rules/no-empty-blocks/no-empty-blocks.js
@@ -12,188 +12,182 @@ let toFunction = wrappers.toFunction;
 let addPragma = wrappers.addPragma;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "no-empty-blocks": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "no-empty-blocks": true
+  }
 };
 
 describe("[RULE] no-empty-blocks: Acceptances", function() {
+  it("should accept all non-empty contract, library and interface statements", function(done) {
+    let code = "contract Foo { event bar (); }",
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should accept all non-empty contract, library and interface statements", function(done) {
-        let code = "contract Foo { event bar (); }",
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = "library Foo { event bar (); }";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        code = "library Foo { event bar (); }";
-        errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = "interface Foo { event bar (); }";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        code = "interface Foo { event bar (); }";
-        errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept all non-empty function declarations", function(done) {
+    let code = "function foo () { bar (); }",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should accept all non-empty function declarations", function(done) {
-        let code = "function foo () { bar (); }",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should ACCEPT all EMPTY function & constructor declarations (see fallback functions)", function(done) {
+    let code = "function foo () {}",
+      errors = Solium.lint(toContract(code), userConfig);
 
-    it("should ACCEPT all EMPTY function & constructor declarations (see fallback functions)", function(done) {
-        let code = "function foo () {}",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    // new constructor syntax
+    code = "constructor(uint x, string y, address z) {\n/*hello world*/\n}";
+    errors = Solium.lint(toContract(code), userConfig);
 
-        // new constructor syntax
-        code = "constructor(uint x, string y, address z) {\n/*hello world*/\n}";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    // fallback func
+    code = "function(){}";
+    errors = Solium.lint(toContract(code), userConfig);
 
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        // fallback func
-        code = "function(){}";
-        errors = Solium.lint(toContract(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+  it("should accept all non-empty if-else declarations", function(done) {
+    let code = "if (true) { foo (); } else { bar (); }",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-    it("should accept all non-empty if-else declarations", function(done) {
-        let code = "if (true) { foo (); } else { bar (); }",
-            errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-		
-        Solium.reset();
-        done();
-    });
+  it("should accept all non-empty for statements", function(done) {
+    let code = "for (i = 0; i < 10; i++) { foo (); }",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-    it("should accept all non-empty for statements", function(done) {
-        let code = "for (i = 0; i < 10; i++) { foo (); }",
-            errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-		
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should accept all non-empty do..while statements", function(done) {
-        let code = "do { foo (); } while (i < 20);",
-            errors = Solium.lint(toFunction(code), userConfig);
+  it("should accept all non-empty do..while statements", function(done) {
+    let code = "do { foo (); } while (i < 20);",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-		
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-    it("should accept all non-empty while statements", function(done) {
-        let code = "while (i < 20) { bar (); }",
-            errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-		
-        Solium.reset();
-        done();
-    });
+  it("should accept all non-empty while statements", function(done) {
+    let code = "while (i < 20) { bar (); }",
+      errors = Solium.lint(toFunction(code), userConfig);
 
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] no-empty-blocks: Rejections", function() {
+  it("should reject all empty contract, library & interface statements", function(done) {
+    let code = "contract Foo {}",
+      errors = Solium.lint(addPragma(code), userConfig);
 
-    it("should reject all empty contract, library & interface statements", function(done) {
-        let code = "contract Foo {}",
-            errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "library Foo {}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        code = "library Foo {}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "interface Foo {}";
+    errors = Solium.lint(addPragma(code), userConfig);
 
-        code = "interface Foo {}";
-        errors = Solium.lint(addPragma(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should reject all empty if-else declarations", function(done) {
+    let code = "if (true) {} else {}",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-    it("should reject all empty if-else declarations", function(done) {
-        let code = "if (true) {} else {}",
-            errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-		
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject all empty for statements", function(done) {
-        let code = "for (i = 0; i < 10; i++) {}",
-            errors = Solium.lint(toFunction(code), userConfig);
+  it("should reject all empty for statements", function(done) {
+    let code = "for (i = 0; i < 10; i++) {}",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject all empty do..while statements", function(done) {
-        let code = "do {} while (i < 20);",
-            errors = Solium.lint(toFunction(code), userConfig);
+  it("should reject all empty do..while statements", function(done) {
+    let code = "do {} while (i < 20);",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-		
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-    it("should reject all empty while statements", function(done) {
-        let code = "while (i < 20) {}",
-            errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject all empty while statements", function(done) {
+    let code = "while (i < 20) {}",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/no-experimental/no-experimental.js
+++ b/test/lib/rules/no-experimental/no-experimental.js
@@ -8,48 +8,45 @@
 const Solium = require("../../../../lib/solium");
 
 const userConfig = {
-    "rules": {
-        "no-experimental": "error"
-    }
+  rules: {
+    "no-experimental": "error"
+  }
 };
 
 describe("[RULE] no-experimental: Acceptances", () => {
+  it("should accept contracts without 'pragma experimental'", done => {
+    const code = "pragma solidity ^0.4.0; contract Foo {} library Bar {}",
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept contracts without 'pragma experimental'", done => {
-        const code = "pragma solidity ^0.4.0; contract Foo {} library Bar {}",
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
-
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] no-experimental: Rejections", function() {
-
-    it("should reject contracts with 'pragma experimental'", done => {
-        let code = `
+  it("should reject contracts with 'pragma experimental'", done => {
+    let code = `
             pragma experimental "^0.5.0";
             contract Foo {}
         `;
-        let errors = Solium.lint(code, userConfig);
-        errors.should.be.Array();
-        errors.should.have.size(1);
+    let errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        code = `
+    code = `
             pragma solidity ^0.4.0;
             pragma experimental "^0.5.0";
             contract Foo {}
             contract Bar {}
         `;
-        errors = Solium.lint(code, userConfig);
-        errors.should.be.Array();
-        errors.should.have.size(1);
+    errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.have.size(1);
 
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/no-unused-vars/no-unused-vars.js
+++ b/test/lib/rules/no-unused-vars/no-unused-vars.js
@@ -11,90 +11,89 @@ let toContract = wrappers.toContract;
 let toFunction = wrappers.toFunction;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "no-unused-vars": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "no-unused-vars": true
+  }
 };
 
 describe("[RULE] no-unused-vars: Acceptances", function() {
+  it("should accept all variables that are used at least once in the same program", function(done) {
+    let code = [
+      "uint x = 100; function foo () returns (uint) { return x; }",
+      'bytes32 x = "hello"; function foo () returns (bytes32) { return x; }',
+      'string x = "hello"; function foo () returns (int) { return x; }',
+      "address x = 0x0; function foo () returns (address) { return x; }",
+      "mapping (address => uint) x; function foo () returns (mapping) { return x; }",
+      "function foo() { var bax = 100; result = bax * 89; }",
+      'function foo() { string bax = "hello world"; callMyFunc(bax); }'
+    ];
+    let errors;
 
-    it("should accept all variables that are used at least once in the same program", function(done) {
-        let code = [
-            "uint x = 100; function foo () returns (uint) { return x; }",
-            "bytes32 x = \"hello\"; function foo () returns (bytes32) { return x; }",
-            "string x = \"hello\"; function foo () returns (int) { return x; }",
-            "address x = 0x0; function foo () returns (address) { return x; }",
-            "mapping (address => uint) x; function foo () returns (mapping) { return x; }",
-            "function foo() { var bax = 100; result = bax * 89; }",
-            "function foo() { string bax = \"hello world\"; callMyFunc(bax); }"
-        ];
-        let errors;
-
-        code.forEach(line => {
-            errors = Solium.lint(toContract(line), userConfig);
-            errors.should.be.Array();
-            errors.should.have.size(0);
-        });
-
-        Solium.reset();
-        done();
+    code.forEach(line => {
+      errors = Solium.lint(toContract(line), userConfig);
+      errors.should.be.Array();
+      errors.should.have.size(0);
     });
 
-    it("should accept if the variable's usage occurs above its declaration & definition.", function(done) {
-        let code = "contract Owned {\nfunction setOwner(address _new) onlyOwner { NewOwner(owner, _new); owner = _new; }\naddress public owner = msg.sender;}",
-            errors = Solium.lint(code, userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should accept if the variable's usage occurs above its declaration & definition.", function(done) {
+    let code =
+        "contract Owned {\nfunction setOwner(address _new) onlyOwner { NewOwner(owner, _new); owner = _new; }\naddress public owner = msg.sender;}",
+      errors = Solium.lint(code, userConfig);
 
-        Solium.reset();
-        done();
-    });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] no-unused-vars: Rejections", function() {
+  it("should reject all variables that haven't been used even once", function(done) {
+    let code = [
+      "var x = 100;",
+      "uint x = 100;",
+      'bytes32 x = "hello";',
+      'string x = "hello";',
+      "address x = 0x0;",
+      "mapping (address => uint) x;"
+    ];
+    let errors;
 
-    it("should reject all variables that haven't been used even once", function(done) {
-        let code = [
-            "var x = 100;",
-            "uint x = 100;",
-            "bytes32 x = \"hello\";",
-            "string x = \"hello\";",
-            "address x = 0x0;",
-            "mapping (address => uint) x;"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toFunction(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toFunction(item);
     });
 
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/no-with/no-with.js
+++ b/test/lib/rules/no-with/no-with.js
@@ -9,54 +9,59 @@ let Solium = require("../../../../lib/solium");
 let toFunction = require("../../../utils/wrappers").toFunction;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "no-with": true
-    },
-    "options": {
-        "returnInternalIssues": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "no-with": true
+  },
+  options: {
+    returnInternalIssues: true
+  }
 };
 
 describe("[RULE] no-with: Rejection", function() {
+  it("should produce deprecation warning if this rule is enabled", function(done) {
+    let code = toFunction(""),
+      errors = Solium.lint(code, userConfig);
 
-    it("should produce deprecation warning if this rule is enabled", function(done) {
-        let code = toFunction(""), errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.be.size(2);
 
-        errors.should.be.Array();
-        errors.should.be.size(2);
+    errors[0].type.should.equal("warning");
+    errors[0].internal.should.equal(true);
+    errors[0].message
+      .startsWith(
+        "[Deprecated] You are using a deprecated soliumrc configuration format."
+      )
+      .should.equal(true);
 
-        errors [0].type.should.equal("warning");
-        errors [0].internal.should.equal(true);
-        errors [0].message.startsWith(
-            "[Deprecated] You are using a deprecated soliumrc configuration format."
-        ).should.equal(true);
+    errors[1].type.should.equal("warning");
+    errors[1].internal.should.equal(true);
+    errors[1].message.should.equal(
+      '[Deprecated] Rule "no-with" is deprecated.'
+    );
 
-        errors [1].type.should.equal("warning");
-        errors [1].internal.should.equal(true);
-        errors [1].message.should.equal("[Deprecated] Rule \"no-with\" is deprecated.");
+    // Only rule deprecation warning with the new config
+    let newConfig = {
+      rules: {
+        "no-with": "error"
+      },
+      options: {
+        returnInternalIssues: true
+      }
+    };
 
-        // Only rule deprecation warning with the new config
-        let newConfig = {
-            "rules": {
-                "no-with": "error"
-            },
-            "options": {
-                "returnInternalIssues": true
-            }
-        };
+    errors = Solium.lint(code, newConfig);
 
-        errors = Solium.lint(code, newConfig);
+    errors.should.be.Array();
+    errors.should.be.size(1);
 
-        errors.should.be.Array();
-        errors.should.be.size(1);
+    errors[0].type.should.equal("warning");
+    errors[0].internal.should.equal(true);
+    errors[0].message.should.equal(
+      '[Deprecated] Rule "no-with" is deprecated.'
+    );
 
-        errors [0].type.should.equal("warning");
-        errors [0].internal.should.equal(true);
-        errors [0].message.should.equal("[Deprecated] Rule \"no-with\" is deprecated.");
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/operator-whitespace/operator-whitespace.js
+++ b/test/lib/rules/operator-whitespace/operator-whitespace.js
@@ -10,318 +10,327 @@ let wrappers = require("../../../utils/wrappers");
 let toFunction = wrappers.toFunction;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "operator-whitespace": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "operator-whitespace": true
+  }
 };
 
 describe("[RULE] operator-whitespace: Acceptances", function() {
+  it("should accept BinaryExpressions having no extraneous whitespace or comments with the operator", function(done) {
+    let code = [
+      "x [10]+y.foo;",
+      "x.foo + bar ();",
+      "x.foo * bar ();",
+      "x.foo**bar ();",
+      "x.foo ^ bar ();",
+      "x.foo >> bar ();",
+      "x.foo && bar ();",
+      "x.foo||bar ();",
+      "x.foo - bar ();",
+      "x.foo <= bar ();",
+      "x.foo%clu++;",
+      "x.foo <= (1 - 45);",
+      "(90.89 * 1) / (100 - 76 % (3**2));",
+      "!x + --8;",
+      "(90.89 * 1) / (100 - 76 % 3**2);",
+      "a ** b + c ** d;",
+      "8 * 9 / 3 % 2;",
+      "1 + 8 - 67;",
+      "1909 + 189 * 1 ** 29 / 190;",
+      "1909 + 189*1 ** 29/190;",
+      "1909+189*1**29/190;",
+      "x+189 * uy ** dex / 190;",
+      "z = foo ().baz;"
+    ];
+    let errors;
 
-    it("should accept BinaryExpressions having no extraneous whitespace or comments with the operator", function(done) {
-        let code = [
-            "x [10]+y.foo;",
-            "x.foo + bar ();",
-            "x.foo * bar ();",
-            "x.foo**bar ();",
-            "x.foo ^ bar ();",
-            "x.foo >> bar ();",
-            "x.foo && bar ();",
-            "x.foo||bar ();",
-            "x.foo - bar ();",
-            "x.foo <= bar ();",
-            "x.foo%clu++;",
-            "x.foo <= (1 - 45);",
-            "(90.89 * 1) / (100 - 76 % (3**2));",
-            "!x + --8;",
-            "(90.89 * 1) / (100 - 76 % 3**2);",
-            "a ** b + c ** d;",
-            "8 * 9 / 3 % 2;",
-            "1 + 8 - 67;",
-            "1909 + 189 * 1 ** 29 / 190;",
-            "1909 + 189*1 ** 29/190;",
-            "1909+189*1**29/190;",
-            "x+189 * uy ** dex / 190;",
-            "z = foo ().baz;"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toFunction(item);});
-        code.forEach(function(snippet) {
-            errors = Solium.lint(snippet, userConfig);
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(0);
-        });
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toFunction(item);
+    });
+    code.forEach(function(snippet) {
+      errors = Solium.lint(snippet, userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(0);
     });
 
-    it("should accept multi-line Binary Expression whose operator resides on the line where left side expression ends AND whose right side expression begins 1 line below the line where left expression ends.", function(done) {
-        let code = [
-            "if (foobarMotherfuckers (price, 100) &&\n\t++crazyCounter) {\n}",
-            "if (foobarMotherfuckers (price, 100)\t &&\n\t++crazyCounter) {\n}"
-        ];
+    Solium.reset();
+    done();
+  });
 
-        code = code.map(function(str) { return toFunction(str); });
-        code.forEach(function(snippet) {
-            let errors = Solium.lint(snippet, userConfig);
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(0);
-        });
+  it("should accept multi-line Binary Expression whose operator resides on the line where left side expression ends AND whose right side expression begins 1 line below the line where left expression ends.", function(done) {
+    let code = [
+      "if (foobarMotherfuckers (price, 100) &&\n\t++crazyCounter) {\n}",
+      "if (foobarMotherfuckers (price, 100)\t &&\n\t++crazyCounter) {\n}"
+    ];
 
-        Solium.reset();
-        done();
+    code = code.map(function(str) {
+      return toFunction(str);
+    });
+    code.forEach(function(snippet) {
+      let errors = Solium.lint(snippet, userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(0);
     });
 
-    it("should accept SequenceExpression & tuple nodes with no extraneous whitespace", function(done) {
-        const code = [
-            "var (a, b) = (10, foo(90, \"hello\"));",
-            "var (a) = 10;",
-            "var (a) = (10);",
-            "var (a, b, abra, kadabra) = (i,i,i,i);",
-            "var (myVar) = callSomeFunc(0x00, true);",
+    Solium.reset();
+    done();
+  });
 
-            "(a, b) = (10, foo(90, \"hello\"));",
-            "(a) = 10;",
-            "(a) = (10);",
-            "(a, b, abra, kadabra) = (i,i,i,i);",
-            "(myVar) = callSomeFunc(0x00, true);",
+  it("should accept SequenceExpression & tuple nodes with no extraneous whitespace", function(done) {
+    const code = [
+      'var (a, b) = (10, foo(90, "hello"));',
+      "var (a) = 10;",
+      "var (a) = (10);",
+      "var (a, b, abra, kadabra) = (i,i,i,i);",
+      "var (myVar) = callSomeFunc(0x00, true);",
 
-            "(a, b) += (10, foo(90, \"hello\"));",
-            "(a) += 10;",
-            "(a) += (10);",
-            "(a, b, abra, kadabra) += (i,i,i,i);",
-            "(myVar) += callSomeFunc(0x00, true);",
+      '(a, b) = (10, foo(90, "hello"));',
+      "(a) = 10;",
+      "(a) = (10);",
+      "(a, b, abra, kadabra) = (i,i,i,i);",
+      "(myVar) = callSomeFunc(0x00, true);",
 
-            "(a, b) *= (10, foo(90, \"hello\"));",
-            "(a) *= 10;",
-            "(a) *= (10);",
-            "(a, b, abra, kadabra) *= (i,i,i,i);",
-            "(myVar) *= callSomeFunc(0x00, true);",
+      '(a, b) += (10, foo(90, "hello"));',
+      "(a) += 10;",
+      "(a) += (10);",
+      "(a, b, abra, kadabra) += (i,i,i,i);",
+      "(myVar) += callSomeFunc(0x00, true);",
 
-            "(a, b) /= (10, foo(90, \"hello\"));",
-            "(a) /= 10;",
-            "(a) /= (10);",
-            "(a, b, abra, kadabra) /= (i,i,i,i);",
-            "(myVar) /= callSomeFunc(0x00, true);",
+      '(a, b) *= (10, foo(90, "hello"));',
+      "(a) *= 10;",
+      "(a) *= (10);",
+      "(a, b, abra, kadabra) *= (i,i,i,i);",
+      "(myVar) *= callSomeFunc(0x00, true);",
 
-            "(a, b) -= (10, foo(90, \"hello\"));",
-            "(a) -= 10;",
-            "(a) -= (10);",
-            "(a, b, abra, kadabra) -= (i,i,i,i);",
-            "(myVar) -= callSomeFunc(0x00, true);",
+      '(a, b) /= (10, foo(90, "hello"));',
+      "(a) /= 10;",
+      "(a) /= (10);",
+      "(a, b, abra, kadabra) /= (i,i,i,i);",
+      "(myVar) /= callSomeFunc(0x00, true);",
 
-            "(a, b) %= (10, foo(90, \"hello\"));",
-            "(a) %= 10;",
-            "(a) %= (10);",
-            "(a, b, abra, kadabra) %= (i,i,i,i);",
-            "(myVar) %= callSomeFunc(0x00, true);"
-        ];
+      '(a, b) -= (10, foo(90, "hello"));',
+      "(a) -= 10;",
+      "(a) -= (10);",
+      "(a, b, abra, kadabra) -= (i,i,i,i);",
+      "(myVar) -= callSomeFunc(0x00, true);",
 
-        code.forEach(statement => {
-            const errors = Solium.lint(toFunction(statement), userConfig);
+      '(a, b) %= (10, foo(90, "hello"));',
+      "(a) %= 10;",
+      "(a) %= (10);",
+      "(a, b, abra, kadabra) %= (i,i,i,i);",
+      "(myVar) %= callSomeFunc(0x00, true);"
+    ];
 
-            errors.should.be.Array();
-            errors.should.have.size(0);
-        });
+    code.forEach(statement => {
+      const errors = Solium.lint(toFunction(statement), userConfig);
 
-        Solium.reset();
-        done();
+      errors.should.be.Array();
+      errors.should.have.size(0);
     });
 
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] operator-whitespace: Rejections", function() {
+  it("should reject BinaryExpressions with extraneous whitespace or comments next to operators", function(done) {
+    let code = [
+      "x [10]  +y.foo;",
+      "x.foo +  bar ();",
+      "x.foo\t* bar ();",
+      "x.foo**\tbar ();",
+      "x.foo  ^ bar ();",
+      "x.foo\t>>\t\tbar ();",
+      "x.foo/**/&& bar ();",
+      "x.foo||/**/bar ();",
+      "x.foo/**/-/**/bar ();",
+      "x.foo /**/<=/**/ bar ();",
+      "x.foo% clu++;",
+      "x.foo/**/ <= /**/(1 - 45);",
+      "(90.89 * 1) /**/-/**/ (100 - 76 % (3**2));",
+      "x.foo          **\t    \tbar ();",
+      "8 *\t9 /\t3 % 2;",
+      "1+ 8- 67;",
+      "1909\t+\t\t189 * 1 ** 29 / 190;",
+      "1909\t+ 189*1\t** 29/190;",
+      "1909+ 189 *1**29/190;",
+      "x+189 * uy\t**\tdex / 190;"
+    ];
+    let errors;
 
-    it("should reject BinaryExpressions with extraneous whitespace or comments next to operators", function(done) {
-        let code = [
-            "x [10]  +y.foo;",
-            "x.foo +  bar ();",
-            "x.foo\t* bar ();",
-            "x.foo**\tbar ();",
-            "x.foo  ^ bar ();",
-            "x.foo\t>>\t\tbar ();",
-            "x.foo/**/&& bar ();",
-            "x.foo||/**/bar ();",
-            "x.foo/**/-/**/bar ();",
-            "x.foo /**/<=/**/ bar ();",
-            "x.foo% clu++;",
-            "x.foo/**/ <= /**/(1 - 45);",
-            "(90.89 * 1) /**/-/**/ (100 - 76 % (3**2));",
-            "x.foo          **\t    \tbar ();",
-            "8 *\t9 /\t3 % 2;",
-            "1+ 8- 67;",
-            "1909\t+\t\t189 * 1 ** 29 / 190;",
-            "1909\t+ 189*1\t** 29/190;",
-            "1909+ 189 *1**29/190;",
-            "x+189 * uy\t**\tdex / 190;"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toFunction(item);});
-		
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [9], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [10], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [11], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [12], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [13], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [14], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [15], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [16], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [17], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [18], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [19], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toFunction(item);
     });
 
-    it("should reject multi-line Binary Expression whose operator is not on the line where left side of the exp. ends.", function(done) {
-        let code = [
-            "if (foobarMotherfuckers (price, 100)\n&&\t++crazyCounter) {\n}",
-            "if (foobarMotherfuckers (price, 100)\t\n&&++crazyCounter) {\n}"
-        ];
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = code.map(function(str) { return toFunction(str); });
-        code.forEach(function(snippet) {
-            let errors = Solium.lint(snippet, userConfig);
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-        });
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        let opErrorAndRightExprErrorCode = "if (foobarMotherfuckers (price, 100)\n&&\n\t++crazyCounter) {\n}",
-            errors = Solium.lint(toFunction(opErrorAndRightExprErrorCode), userConfig);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[9], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[10], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[11], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[12], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[13], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[14], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[15], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[16], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[17], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[18], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[19], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should reject multi-line Binary Expression whose operator is not on the line where left side of the exp. ends.", function(done) {
+    let code = [
+      "if (foobarMotherfuckers (price, 100)\n&&\t++crazyCounter) {\n}",
+      "if (foobarMotherfuckers (price, 100)\t\n&&++crazyCounter) {\n}"
+    ];
+
+    code = code.map(function(str) {
+      return toFunction(str);
+    });
+    code.forEach(function(snippet) {
+      let errors = Solium.lint(snippet, userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
     });
 
-    it("should reject multi-line Binary Expression whose right side doesn't fall exactly 1 line below the ending line of left side of the expr.", function(done) {
-        let code = [
-            "if (foobarMotherfuckers (price, 100)&&\n\n\t++crazyCounter) {\n}",
-            "if (foobarMotherfuckers (price, 100)  &&\t\n\n\n\n++crazyCounter) {\n}"
-        ];
+    let opErrorAndRightExprErrorCode =
+        "if (foobarMotherfuckers (price, 100)\n&&\n\t++crazyCounter) {\n}",
+      errors = Solium.lint(
+        toFunction(opErrorAndRightExprErrorCode),
+        userConfig
+      );
 
-        code = code.map(function(str) { return toFunction(str); });
-        code.forEach(function(snippet) {
-            let errors = Solium.lint(snippet, userConfig);
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(1);
-        });
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        Solium.reset();
-        done();
+    Solium.reset();
+    done();
+  });
+
+  it("should reject multi-line Binary Expression whose right side doesn't fall exactly 1 line below the ending line of left side of the expr.", function(done) {
+    let code = [
+      "if (foobarMotherfuckers (price, 100)&&\n\n\t++crazyCounter) {\n}",
+      "if (foobarMotherfuckers (price, 100)  &&\t\n\n\n\n++crazyCounter) {\n}"
+    ];
+
+    code = code.map(function(str) {
+      return toFunction(str);
+    });
+    code.forEach(function(snippet) {
+      let errors = Solium.lint(snippet, userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(1);
     });
 
-    it("should reject SequenceExpression nodes with extraneous whitespace", function(done) {
-        const single = [
-            "(a, b)\n  = (10, foo(90, \"hello\"));",
-            "(a) =         10;",
-            "(a)             = (10);",
-            "(a, b, abra, kadabra)\n\n\t= (i,i,i,i);",
-            "(myVar) = \t \tcallSomeFunc(0x00, true);",
+    Solium.reset();
+    done();
+  });
 
-            "(a, b) +=\t(10, foo(90, \"hello\"));",
-            "(a) +=10;",
-            "(a) +=(10);",
-            "(a, b, abra, kadabra)+= (i,i,i,i);",
-            "(myVar) +=\t\n\t\ncallSomeFunc(0x00, true);",
+  it("should reject SequenceExpression nodes with extraneous whitespace", function(done) {
+    const single = [
+      '(a, b)\n  = (10, foo(90, "hello"));',
+      "(a) =         10;",
+      "(a)             = (10);",
+      "(a, b, abra, kadabra)\n\n\t= (i,i,i,i);",
+      "(myVar) = \t \tcallSomeFunc(0x00, true);",
 
-            "(a, b)     *=(10, foo(90, \"hello\"));",
-            "(a)*=10;",
-            "(a)   *=\t(10);",
-            "(a, b, abra, kadabra) \n*=\n (i,i,i,i);",
-            "(myVar)*=\t\t\t\n\ncallSomeFunc(0x00, true);",
+      '(a, b) +=\t(10, foo(90, "hello"));',
+      "(a) +=10;",
+      "(a) +=(10);",
+      "(a, b, abra, kadabra)+= (i,i,i,i);",
+      "(myVar) +=\t\n\t\ncallSomeFunc(0x00, true);",
 
-            "(a, b)/=(10, foo(90, \"hello\"));",
-            "(a) \n/=\t\t 10;",
-            "(a)     /=  (10);",
-            "(a, b, abra, kadabra)/=(i,i,i,i);",
-            "(myVar)   /=   callSomeFunc(0x00, true);"
-        ];
+      '(a, b)     *=(10, foo(90, "hello"));',
+      "(a)*=10;",
+      "(a)   *=\t(10);",
+      "(a, b, abra, kadabra) \n*=\n (i,i,i,i);",
+      "(myVar)*=\t\t\t\n\ncallSomeFunc(0x00, true);",
 
-        single.forEach(statement => {
-            const errors = Solium.lint(toFunction(statement), userConfig);
+      '(a, b)/=(10, foo(90, "hello"));',
+      "(a) \n/=\t\t 10;",
+      "(a)     /=  (10);",
+      "(a, b, abra, kadabra)/=(i,i,i,i);",
+      "(myVar)   /=   callSomeFunc(0x00, true);"
+    ];
 
-            errors.should.be.Array();
-            errors.should.have.size(1);
-        });
+    single.forEach(statement => {
+      const errors = Solium.lint(toFunction(statement), userConfig);
 
-        Solium.reset();
-        done();
+      errors.should.be.Array();
+      errors.should.have.size(1);
     });
 
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/pragma-on-top/pragma-on-top.js
+++ b/test/lib/rules/pragma-on-top/pragma-on-top.js
@@ -9,29 +9,27 @@ const { EOL } = require("os");
 const Solium = require("../../../../lib/solium");
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "pragma-on-top": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "pragma-on-top": true
+  }
 };
 
-
 describe("[RULE] pragma-on-top: Acceptances", function() {
+  it("should accept if program has only 1 pragma statement at the top of the file", function(done) {
+    let code = 'pragma solidity ^4.4.0;\nimport {foo} from "bar";',
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept if program has only 1 pragma statement at the top of the file", function(done) {
-        let code = "pragma solidity ^4.4.0;\nimport {foo} from \"bar\";",
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    code = "\n/*Foo Bar*/\n\npragma solidity 4.4.0;";
+    errors = Solium.lint(code, userConfig);
 
-        code = "\n\/*Foo Bar*\/\n\npragma solidity 4.4.0;";
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
-
-        code = `
+    code = `
 			pragma solidity ^4.4.0;
 			// Hello world
 			pragma experimental ABIEncoderV2;
@@ -42,104 +40,108 @@ describe("[RULE] pragma-on-top: Acceptances", function() {
 
 			contract Foo {}
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        code = "/*Foo Bar*\/";	// empty source code
-        errors = Solium.lint(code, userConfig);
+    code = "/*Foo Bar*/"; // empty source code
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] pragma-on-top: Rejections", function() {
+  it("should reject a non-empty program that doesn't have a pragma statement on top", function(done) {
+    let code = '/*Hello world*/\nimport {foo} from "bar";',
+      errors = Solium.lint(code, userConfig);
 
-    it("should reject a non-empty program that doesn't have a pragma statement on top", function(done) {
-        let code = "\/*Hello world*\/\nimport {foo} from \"bar\";",
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "No Pragma directive found at the top of file."
+    );
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors [0].message.should.equal("No Pragma directive found at the top of file.");
+    code = '/*Hello world*/\nimport {foo} from "bar";\npragma solidity ^4.4.0;';
+    errors = Solium.lint(code, userConfig);
 
-        code = "\/*Hello world*\/\nimport {foo} from \"bar\";\npragma solidity ^4.4.0;";
-        errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      '"pragma solidity ^4.4.0;" should be at the top of the file.'
+    );
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors [0].message.should.equal("\"pragma solidity ^4.4.0;\" should be at the top of the file.");
-
-        code = `
+    code = `
 			pragma experimental ABIEncoderV2;
 			pragma experimental "v0.5.0";
 			import {foo} from "bar";
 			contract Foo {}
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
-        errors [0].message.should.equal("No Pragma directive found at the top of file.");
+    errors.should.be.Array();
+    errors.length.should.equal(1);
+    errors[0].message.should.equal(
+      "No Pragma directive found at the top of file."
+    );
 
-        code = `
+    code = `
 			import {foo} from "bar";
 			pragma experimental ABIEncoderV2;
 			contract Foo {}
 			pragma experimental "v0.5.0";
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(3);	// issues reported: no pragma & experimental pragmas not on top
+    errors.should.be.Array();
+    errors.length.should.equal(3); // issues reported: no pragma & experimental pragmas not on top
 
-        code = `
+    code = `
 			pragma experimental ABIEncoderV2;
 			pragma solidity ^0.4.0;
 			import {foo} from "bar";
 			contract Foo {}
 		`;
-        errors = Solium.lint(code, userConfig);
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject program that has more than 1 pragma statement", function(done) {
-        let code = "pragma solidity ^4.4.0;\npragma solidity ^4.4.0;",
-            errors = Solium.lint(code, userConfig);
+  it("should reject program that has more than 1 pragma statement", function(done) {
+    let code = "pragma solidity ^4.4.0;\npragma solidity ^4.4.0;",
+      errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        code = "pragma solidity ^4.4.0;\ncontract Foo {}\npragma solidity ^4.4.0;";
-        errors = Solium.lint(code, userConfig);
+    code = "pragma solidity ^4.4.0;\ncontract Foo {}\npragma solidity ^4.4.0;";
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        code = "pragma solidity ^4.4.0;\npragma experimental ABIEncoderV2;\ncontract Foo {}\npragma solidity ^4.4.0;";
-        errors = Solium.lint(code, userConfig);
+    code =
+      "pragma solidity ^4.4.0;\npragma experimental ABIEncoderV2;\ncontract Foo {}\npragma solidity ^4.4.0;";
+    errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(1);
+    errors.should.be.Array();
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should reject pragma experimental statement(s) having anything except pragma above them", done => {
-        let code = `
+  it("should reject pragma experimental statement(s) having anything except pragma above them", done => {
+    let code = `
 			pragma solidity ^0.4.0;
 			pragma experimental "blahblah";
 			pragma experimental "blahblah2";
@@ -148,72 +150,68 @@ describe("[RULE] pragma-on-top: Rejections", function() {
 			contract Foo {}
 			pragma experimental "v0.5.0";
 		`;
-        let errors = Solium.lint(code, userConfig);
+    let errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.length.should.equal(2);
+    errors.should.be.Array();
+    errors.length.should.equal(2);
 
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] pragma-on-top: Fixes", function() {
+  it("should move an existing pragma statement to top of file (above all code) when fix is enabled", function(done) {
+    let config = {
+      rules: {
+        "pragma-on-top": "error"
+      }
+    };
 
-    it("should move an existing pragma statement to top of file (above all code) when fix is enabled", function(done) {
-        let config = {
-            "rules": {
-                "pragma-on-top": "error"
-            }
-        };
+    let unfixedCode = "contract Foo {}\npragma solidity ^0.4.0;",
+      fixedCode = "pragma solidity ^0.4.0;\ncontract Foo {}\n";
 
-        let unfixedCode = "contract Foo {}\npragma solidity ^0.4.0;",
-            fixedCode = "pragma solidity ^0.4.0;\ncontract Foo {}\n";
+    let fixed = Solium.lintAndFix(unfixedCode, config);
 
-        let fixed = Solium.lintAndFix(unfixedCode, config);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(1);
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should move an existing experimental pragma statement to top of file (above all code) when fix is enabled", done => {
+    const config = {
+      rules: {
+        "pragma-on-top": "error"
+      }
+    };
 
-    it("should move an existing experimental pragma statement to top of file (above all code) when fix is enabled", done => {
-        const config = {
-            "rules": {
-                "pragma-on-top": "error"
-            }
-        };
+    const unfixedCode = `pragma solidity ^0.4.0;${EOL}contract Foo {}${EOL}pragma experimental \"^0.5.0\";`,
+      fixedCode = `pragma solidity ^0.4.0;${EOL}pragma experimental \"^0.5.0\";${EOL}contract Foo {}${EOL}`;
 
-        const unfixedCode = `pragma solidity ^0.4.0;${EOL}contract Foo {}${EOL}pragma experimental \"^0.5.0\";`,
-            fixedCode = `pragma solidity ^0.4.0;${EOL}pragma experimental \"^0.5.0\";${EOL}contract Foo {}${EOL}`;
+    let fixed = Solium.lintAndFix(unfixedCode, config);
 
-        let fixed = Solium.lintAndFix(unfixedCode, config);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.should.be.empty();
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.should.have.size(1);
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.should.be.empty();
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.should.have.size(1);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/quotes/quotes.js
+++ b/test/lib/rules/quotes/quotes.js
@@ -6,229 +6,249 @@
 "use strict";
 
 let Solium = require("../../../../lib/solium"),
-    path = require("path"), fs = require("fs");
+  path = require("path"),
+  fs = require("fs");
 let toContract = require("../../../utils/wrappers").toContract;
 
 let userConfigSingle = {
-    "rules": {
-        "quotes": [1, "single"]
-    }
+  rules: {
+    quotes: [1, "single"]
+  }
 };
 
 describe("[RULE] quotes: Acceptances general", () => {
+  it("should not take action against any non-string Literals", done => {
+    const literals = ["19028", "0x00", "0x908d819", "90182.1892"];
 
-    it("should not take action against any non-string Literals", done => {
-        const literals = ["19028", "0x00", "0x908d819", "90182.1892"];
+    literals.forEach(lit => {
+      let code = toContract(`function foo() { var myVar = ${lit}; }`),
+        errors = Solium.lint(code, { rules: { quotes: [1, "single"] } });
 
-        literals.forEach(lit => {
-            let code = toContract(`function foo() { var myVar = ${lit}; }`),
-                errors = Solium.lint(code, { "rules": { "quotes": [1, "single"] } });
-
-            errors.should.be.Array();
-            errors.should.have.size(0);
-        });
-
-        Solium.reset();
-        done();
+      errors.should.be.Array();
+      errors.should.have.size(0);
     });
 
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] quotes: Acceptances for single quote", function() {
+  it("should accept when receiving single quote strings", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./single-quoted.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(toContract(code), userConfigSingle);
 
-    it("should accept when receiving single quote strings", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./single-quoted.sol"), "utf8"),
-            errors = Solium.lint(toContract(code), userConfigSingle);
+    errors.should.be.Array();
+    errors.length.should.equal(0);
 
-        errors.should.be.Array();
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] quotes: Rejections for single quote", function() {
+  it("should reject when receiving double quote strings", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./double-quoted.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(toContract(code), userConfigSingle);
 
-    it("should reject when receiving double quote strings", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./double-quoted.sol"), "utf8"),
-            errors = Solium.lint(toContract(code), userConfigSingle);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(41);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(41);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 let userConfigDouble = {
-    "rules": {
-        "quotes": ["error", "double"]
-    }
+  rules: {
+    quotes: ["error", "double"]
+  }
 };
 
 describe("[RULE] quotes: Acceptances for double quote", function() {
+  it("should accept when receiving double quote strings", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./double-quoted.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(toContract(code), userConfigDouble);
 
-    it("should accept when receiving double quote strings", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./double-quoted.sol"), "utf8"),
-            errors = Solium.lint(toContract(code), userConfigDouble);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] quotes: Rejections for double quote", function() {
+  it("should reject when receiving single quote strings", function(done) {
+    let code = fs.readFileSync(
+        path.join(__dirname, "./single-quoted.sol"),
+        "utf8"
+      ),
+      errors = Solium.lint(toContract(code), userConfigDouble);
 
-    it("should reject when receiving single quote strings", function(done) {
-        let code = fs.readFileSync(path.join(__dirname, "./single-quoted.sol"), "utf8"),
-            errors = Solium.lint(toContract(code), userConfigDouble);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(41);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(41);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] quotes: Fix when double quotes are mandatory", function() {
-    let config = {
-        "rules": {
-            "quotes": ["error", "double"]
-        }
-    };
+  let config = {
+    rules: {
+      quotes: ["error", "double"]
+    }
+  };
 
-    it("should fix single to double", function(done) {
-        let unfixedCode = fs.readFileSync(path.join(__dirname, "single-full.sol"), "utf8"),
-            fixedCode =  fs.readFileSync(path.join(__dirname, "double-full.sol"), "utf8");
+  it("should fix single to double", function(done) {
+    let unfixedCode = fs.readFileSync(
+        path.join(__dirname, "single-full.sol"),
+        "utf8"
+      ),
+      fixedCode = fs.readFileSync(
+        path.join(__dirname, "double-full.sol"),
+        "utf8"
+      );
 
-        let fixed = Solium.lintAndFix(unfixedCode, config);
+    let fixed = Solium.lintAndFix(unfixedCode, config);
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(11);
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(11);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should escape any unescaped double quotes in the text", function(done) {
-        let unfixedCode = toContract("string x = 'he\\'\"\\\"llo w\\\\\"or\\\\\\\"l\"d';"),
-            fixedCode = toContract("string x = \"he\\'\\\"\\\"llo w\\\\\\\"or\\\\\\\"l\\\"d\";");
+  it("should escape any unescaped double quotes in the text", function(done) {
+    let unfixedCode = toContract(
+        'string x = \'he\\\'"\\"llo w\\\\"or\\\\\\"l"d\';'
+      ),
+      fixedCode = toContract(
+        'string x = "he\\\'\\"\\"llo w\\\\\\"or\\\\\\"l\\"d";'
+      );
 
-        let fixed = Solium.lintAndFix(unfixedCode, config);
+    let fixed = Solium.lintAndFix(unfixedCode, config);
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(1);
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(1);
 
+    unfixedCode = toContract("string x = '';");
+    fixedCode = toContract('string x = "";');
+    fixed = Solium.lintAndFix(unfixedCode, config);
 
-        unfixedCode = toContract("string x = '';");
-        fixedCode = toContract("string x = \"\";");
-        fixed = Solium.lintAndFix(unfixedCode, config);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(1);
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(1);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] quotes: Fix when single quotes are mandatory", function() {
-    let config = {
-        "rules": {
-            "quotes": ["error", "single"]
-        }
-    };
+  let config = {
+    rules: {
+      quotes: ["error", "single"]
+    }
+  };
 
-    it("should fix double to single", function(done) {
-        let unfixedCode = fs.readFileSync(path.join(__dirname, "double-full.sol"), "utf8"),
-            fixedCode =  fs.readFileSync(path.join(__dirname, "single-full.sol"), "utf8");
+  it("should fix double to single", function(done) {
+    let unfixedCode = fs.readFileSync(
+        path.join(__dirname, "double-full.sol"),
+        "utf8"
+      ),
+      fixedCode = fs.readFileSync(
+        path.join(__dirname, "single-full.sol"),
+        "utf8"
+      );
 
-        let fixed = Solium.lintAndFix(unfixedCode, config);
+    let fixed = Solium.lintAndFix(unfixedCode, config);
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(11);
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(11);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 
-    it("should escape any unescaped single quotes in the text", function(done) {
-        let unfixedCode = toContract("string y = \"he\\\"'\\'llo w\\\\'or\\\\\\'l'd\";"),
-            fixedCode = toContract("string y = 'he\\\"\\'\\'llo w\\\\\\'or\\\\\\'l\\'d';");
+  it("should escape any unescaped single quotes in the text", function(done) {
+    let unfixedCode = toContract(
+        "string y = \"he\\\"'\\'llo w\\\\'or\\\\\\'l'd\";"
+      ),
+      fixedCode = toContract(
+        "string y = 'he\\\"\\'\\'llo w\\\\\\'or\\\\\\'l\\'d';"
+      );
 
-        let fixed = Solium.lintAndFix(unfixedCode, config);
+    let fixed = Solium.lintAndFix(unfixedCode, config);
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(1);
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(1);
 
+    unfixedCode = toContract('string x = "";');
+    fixedCode = toContract("string x = '';");
+    fixed = Solium.lintAndFix(unfixedCode, config);
 
-        unfixedCode = toContract("string x = \"\";");
-        fixedCode = toContract("string x = '';");
-        fixed = Solium.lintAndFix(unfixedCode, config);
+    fixed.should.be.type("object");
+    fixed.should.have.ownProperty("fixedSourceCode");
+    fixed.should.have.ownProperty("errorMessages");
+    fixed.should.have.ownProperty("fixesApplied");
 
-        fixed.should.be.type("object");
-        fixed.should.have.ownProperty("fixedSourceCode");
-        fixed.should.have.ownProperty("errorMessages");
-        fixed.should.have.ownProperty("fixesApplied");
+    fixed.fixedSourceCode.should.equal(fixedCode);
+    fixed.errorMessages.should.be.Array();
+    fixed.errorMessages.length.should.equal(0);
+    fixed.fixesApplied.should.be.Array();
+    fixed.fixesApplied.length.should.equal(1);
 
-        fixed.fixedSourceCode.should.equal(fixedCode);
-        fixed.errorMessages.should.be.Array();
-        fixed.errorMessages.length.should.equal(0);
-        fixed.fixesApplied.should.be.Array();
-        fixed.fixesApplied.length.should.equal(1);
-
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/uppercase/uppercase.js
+++ b/test/lib/rules/uppercase/uppercase.js
@@ -10,79 +10,78 @@ let wrappers = require("../../../utils/wrappers");
 let toContract = wrappers.toContract;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "uppercase": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    uppercase: true
+  }
 };
 
 describe("[RULE] uppercase: Acceptances", function() {
+  it("should accept all constants that are uppercase", function(done) {
+    let code = [
+      "uint constant HE = 100;",
+      "address constant HELLO_WORLD = 0x0;",
+      'bytes32 constant HELLOWORLD = "dd";',
+      'string constant HELLO = "dd";',
+      "address constant HELLO_NUMBER_9 = 0x0;",
+      "uint constant HELLO_NUMBER_0 = 190;",
+      'string constant HELLO_NUMBER89116 = "hello";',
+      'string constant HELLO_98_NUMBER = "number";',
+      "address constant H0 = 0x1;"
+    ];
+    let errors;
 
-    it("should accept all constants that are uppercase", function(done) {
-        let code = [
-            "uint constant HE = 100;",
-            "address constant HELLO_WORLD = 0x0;",
-            "bytes32 constant HELLOWORLD = \"dd\";",
-            "string constant HELLO = \"dd\";",
-            "address constant HELLO_NUMBER_9 = 0x0;",
-            "uint constant HELLO_NUMBER_0 = 190;",
-            "string constant HELLO_NUMBER89116 = \"hello\";",
-            "string constant HELLO_98_NUMBER = \"number\";",
-            "address constant H0 = 0x1;"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toContract(item);});
-
-        code.forEach(function(declaration) {
-            errors = Solium.lint(declaration, userConfig);
-            errors.constructor.name.should.equal("Array");
-            errors.length.should.equal(0);
-        });
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
+    code.forEach(function(declaration) {
+      errors = Solium.lint(declaration, userConfig);
+      errors.constructor.name.should.equal("Array");
+      errors.length.should.equal(0);
+    });
+
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] uppercase: Rejections", function() {
+  it("should reject all constants which are not uppercase", function(done) {
+    let code = [
+      "uint constant he = 100;",
+      "address constant hello_world = 0x0;",
+      'bytes32 constant helloworld= "dd";',
+      'string constant HellO = "dd";',
+      'string constant HeO = "dd";'
+    ];
+    let errors;
 
-    it("should reject all constants which are not uppercase", function(done) {
-        let code = [
-            "uint constant he = 100;",
-            "address constant hello_world = 0x0;",
-            "bytes32 constant helloworld= \"dd\";",
-            "string constant HellO = \"dd\";",
-            "string constant HeO = \"dd\";"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toContract(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/value-in-payable/value-in-payable.js
+++ b/test/lib/rules/value-in-payable/value-in-payable.js
@@ -6,79 +6,81 @@
 "use strict";
 
 const Solium = require("../../../../lib/solium"),
-    { toContract } = require("../../../utils/wrappers");
+  { toContract } = require("../../../utils/wrappers");
 
 let userConfig = {
-    "rules": {
-        "value-in-payable": "error"
-    }
+  rules: {
+    "value-in-payable": "error"
+  }
 };
 
 describe("[RULE] value-in-payable: Acceptances", () => {
+  it("should accept functions that access 'msg.value' and have the 'payable' modifier", function(done) {
+    const code = toContract(
+        "function pay() payable { require(msg.value >= MIN_PRICE); }"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept functions that access 'msg.value' and have the 'payable' modifier", function(done) {
-        const code = toContract("function pay() payable { require(msg.value >= MIN_PRICE); }"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept functions that access 'msg.value' and have the 'private' modifier", function(done) {
+    const code = toContract(
+        "function pay() private { require(msg.value >= MIN_PRICE); }"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept functions that access 'msg.value' and have the 'private' modifier", function(done) {
-        const code = toContract("function pay() private { require(msg.value >= MIN_PRICE); }"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("should accept functions that access 'msg.value' and have the 'internal' modifier", function(done) {
+    const code = toContract(
+        "function pay() internal { require(msg.value >= MIN_PRICE); }"
+      ),
+      errors = Solium.lint(code, userConfig);
 
-    it("should accept functions that access 'msg.value' and have the 'internal' modifier", function(done) {
-        const code = toContract("function pay() internal { require(msg.value >= MIN_PRICE); }"),
-            errors = Solium.lint(code, userConfig);
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
-
-    it("should accept code that accesses 'msg.value' outside a function", function(done) {
-        const code = toContract(`function foo() { }
+  it("should accept code that accesses 'msg.value' outside a function", function(done) {
+    const code = toContract(`function foo() { }
                                unit foo1 = msg.value;`);
-        const errors = Solium.lint(code, userConfig);
+    const errors = Solium.lint(code, userConfig);
 
-        errors.should.be.Array();
-        errors.should.be.empty();
+    errors.should.be.Array();
+    errors.should.be.empty();
 
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
 describe("[RULE] value-in-payable: Rejections", function() {
+  it("should reject all functions that access 'msg.value' and don't have the 'payable' modifier", function(done) {
+    let code = ["function pay() public { require(msg.value >= MIN_PRICE); }"];
+    let errors;
 
-    it("should reject all functions that access 'msg.value' and don't have the 'payable' modifier", function(done) {
-        let code = [
-            "function pay() public { require(msg.value >= MIN_PRICE); }"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toContract(item);});
-
-        errors = Solium.lint(code[0], userConfig);
-        errors.should.be.Array();
-        errors.should.have.size(1);
-
-        Solium.reset();
-        done();
+    code = code.map(function(item) {
+      return toContract(item);
     });
 
+    errors = Solium.lint(code[0], userConfig);
+    errors.should.be.Array();
+    errors.should.have.size(1);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/variable-declarations/variable-declarations.js
+++ b/test/lib/rules/variable-declarations/variable-declarations.js
@@ -6,226 +6,256 @@
 "use strict";
 
 let Solium = require("../../../../lib/solium"),
-    wrappers = require("../../../utils/wrappers");
-let toFunction = wrappers.toFunction, toContract = wrappers.toContract;
+  wrappers = require("../../../utils/wrappers");
+let toFunction = wrappers.toFunction,
+  toContract = wrappers.toContract;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "variable-declarations": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    "variable-declarations": true
+  }
 };
 
 describe("[RULE] variable-declarations: Rejections", function() {
+  it('should reject all variables having names "l", "o" or "I"', function(done) {
+    let declarations = [
+      "var l; var O; var I;",
+      "uint l; uint O; uint I;",
+      "string l; string O; string I;",
+      "bytes32 l; bytes32 O; bytes32 I;",
+      "mapping (uint => string) l; mapping (uint => string) O; mapping (uint => string) I;"
+    ];
+    let errors, code;
 
-    it("should reject all variables having names \"l\", \"o\" or \"I\"", function(done) {
-        let declarations = [
-            "var l; var O; var I;",
-            "uint l; uint O; uint I;",
-            "string l; string O; string I;",
-            "bytes32 l; bytes32 O; bytes32 I;",
-            "mapping (uint => string) l; mapping (uint => string) O; mapping (uint => string) I;"
-        ];
-        let errors, code;
-
-        code = declarations.map(function(item){return toFunction(item);});
-		
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-
-        // var cannot be used to declare state variables, so truncate it from declarations array.
-        code = declarations.slice(1).map(function(item){return toContract(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        Solium.reset();
-        done();
+    code = declarations.map(function(item) {
+      return toFunction(item);
     });
 
-    it("should reject variables whose names are provided via config instead of the default names", function(done) {
-        let configWithCustomVarNames = {
-            "rules": {
-                "variable-declarations": ["error", ["myOwnVar", "myOwnVar2"]]
-            }
-        };
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        let declarations = [
-            "var l; var O; var I;",
-            "uint l; uint O; uint I;",
-            "string l; string O; string I;",
-            "bytes32 l; bytes32 O; bytes32 I;",
-            "mapping (uint => string) l; mapping (uint => string) O; mapping (uint => string) I;",
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-            "var myOwnVar; var myOwnVar2;",
-            "uint myOwnVar; uint myOwnVar2;",
-            "string myOwnVar; string myOwnVar2;",
-            "bytes32 myOwnVar; bytes32 myOwnVar2;",
-            "mapping (uint => string) myOwnVar; mapping (uint => string) myOwnVar2;"
-        ];
-        let errors, code;
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        code = declarations.map(function(item){return toFunction(item);});
-		
-        errors = Solium.lint(code [0], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        errors = Solium.lint(code [1], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        errors = Solium.lint(code [2], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [3], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [4], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [5], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [6], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [7], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [8], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [9], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-
-        // var cannot be used to declare state variables, so truncate it from declarations array.
-        code = declarations.slice(1).map(function(item){return toContract(item);});
-
-        errors = Solium.lint(code [0], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [1], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [2], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        errors = Solium.lint(code [3], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        // code [4] was purposely skipped since it is var and var can't be a state variable
-        errors = Solium.lint(code [5], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [6], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [7], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        errors = Solium.lint(code [8], configWithCustomVarNames);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        Solium.reset();
-        done();
+    // var cannot be used to declare state variables, so truncate it from declarations array.
+    code = declarations.slice(1).map(function(item) {
+      return toContract(item);
     });
 
-    it("should not accept invalid values for its option", function(done) {
-        let configWithCustomVarNames = {
-            "rules": {
-                "variable-declarations": ["error", null]
-            }
-        };
-        let code = toFunction(""),
-            exceptionMessage = "Invalid options were passed to rule \"variable-declarations\".";
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = {};
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = 0;
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
 
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = "";
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
+    Solium.reset();
+    done();
+  });
 
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = "hello world";
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
+  it("should reject variables whose names are provided via config instead of the default names", function(done) {
+    let configWithCustomVarNames = {
+      rules: {
+        "variable-declarations": ["error", ["myOwnVar", "myOwnVar2"]]
+      }
+    };
 
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = ["d", 10];
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
+    let declarations = [
+      "var l; var O; var I;",
+      "uint l; uint O; uint I;",
+      "string l; string O; string I;",
+      "bytes32 l; bytes32 O; bytes32 I;",
+      "mapping (uint => string) l; mapping (uint => string) O; mapping (uint => string) I;",
 
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = [{}];
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
+      "var myOwnVar; var myOwnVar2;",
+      "uint myOwnVar; uint myOwnVar2;",
+      "string myOwnVar; string myOwnVar2;",
+      "bytes32 myOwnVar; bytes32 myOwnVar2;",
+      "mapping (uint => string) myOwnVar; mapping (uint => string) myOwnVar2;"
+    ];
+    let errors, code;
 
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = [null];
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
-
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = 190.2897;
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
-
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = [-1982];
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
-
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = -1982;
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
-
-        // Empty array is a invalid option. If you need to allow all names, simply disable the rule.
-        configWithCustomVarNames.rules ["variable-declarations"] [1] = [];
-        Solium.lint.bind(Solium, code, configWithCustomVarNames).should.throw(exceptionMessage);
-
-        Solium.reset();
-        done();
+    code = declarations.map(function(item) {
+      return toFunction(item);
     });
 
+    errors = Solium.lint(code[0], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[1], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[2], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[3], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[4], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[5], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[6], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[7], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[8], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[9], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    // var cannot be used to declare state variables, so truncate it from declarations array.
+    code = declarations.slice(1).map(function(item) {
+      return toContract(item);
+    });
+
+    errors = Solium.lint(code[0], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[1], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[2], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    errors = Solium.lint(code[3], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    // code [4] was purposely skipped since it is var and var can't be a state variable
+    errors = Solium.lint(code[5], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[6], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[7], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    errors = Solium.lint(code[8], configWithCustomVarNames);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should not accept invalid values for its option", function(done) {
+    let configWithCustomVarNames = {
+      rules: {
+        "variable-declarations": ["error", null]
+      }
+    };
+    let code = toFunction(""),
+      exceptionMessage =
+        'Invalid options were passed to rule "variable-declarations".';
+
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = {};
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = 0;
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = "";
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = "hello world";
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = ["d", 10];
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = [{}];
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = [null];
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = 190.2897;
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = [-1982];
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    configWithCustomVarNames.rules["variable-declarations"][1] = -1982;
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    // Empty array is a invalid option. If you need to allow all names, simply disable the rule.
+    configWithCustomVarNames.rules["variable-declarations"][1] = [];
+    Solium.lint
+      .bind(Solium, code, configWithCustomVarNames)
+      .should.throw(exceptionMessage);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/visibility-first/visibility-first.js
+++ b/test/lib/rules/visibility-first/visibility-first.js
@@ -6,67 +6,66 @@
 "use strict";
 
 const Solium = require("../../../../lib/solium"),
-    { toContract } = require("../../../utils/wrappers");
+  { toContract } = require("../../../utils/wrappers");
 
 const userConfig = {
-    "rules": {
-        "visibility-first": "warning"
-    }
+  rules: {
+    "visibility-first": "warning"
+  }
 };
 
 describe("[RULE] visibility-first: Acceptances", () => {
-    it("accepts valid contract names", done => {
-        let code = [
-            "function test() public onlyOwner modA modB modC modD private modE {}",
-            "function test() public onlyOwner {}",
-            "function test() external onlyOwner {}",
-            "function test() internal onlyOwner {}",
-            "function test() private onlyOwner {}",
-            "function test() onlyOwner {}",
-            "function test() public {}",
-            "function test() external {}",
-            "function test() internal {}",
-            "function test() private {}",
-            "function test() {}"
-        ];
-        let errors;
+  it("accepts valid contract names", done => {
+    let code = [
+      "function test() public onlyOwner modA modB modC modD private modE {}",
+      "function test() public onlyOwner {}",
+      "function test() external onlyOwner {}",
+      "function test() internal onlyOwner {}",
+      "function test() private onlyOwner {}",
+      "function test() onlyOwner {}",
+      "function test() public {}",
+      "function test() external {}",
+      "function test() internal {}",
+      "function test() private {}",
+      "function test() {}"
+    ];
+    let errors;
 
-        code = code.map(item => toContract(item));
+    code = code.map(item => toContract(item));
 
-        code.forEach(snip => {
-            errors = Solium.lint(snip, userConfig);
-            errors.should.be.Array();
-            errors.should.be.empty();
-        });
-
-        Solium.reset();
-        done();
+    code.forEach(snip => {
+      errors = Solium.lint(snip, userConfig);
+      errors.should.be.Array();
+      errors.should.be.empty();
     });
+
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] visibility-first: Rejections", () => {
-    it("rejects invalid struct names", done => {
-        let code = [
-            "function test() onlyOwner modA modB modC public {}",
-            "function test() onlyOwner modA modB modC external modD modE {}",
-            "function test() onlyOwner modA modB modC internal modD modE private {}",
-            "function test() onlyOwner public {}",
-            "function test() onlyOwner external {}",
-            "function test() onlyOwner internal {}",
-            "function test() onlyOwner private {}"
-        ];
-        let errors;
+  it("rejects invalid struct names", done => {
+    let code = [
+      "function test() onlyOwner modA modB modC public {}",
+      "function test() onlyOwner modA modB modC external modD modE {}",
+      "function test() onlyOwner modA modB modC internal modD modE private {}",
+      "function test() onlyOwner public {}",
+      "function test() onlyOwner external {}",
+      "function test() onlyOwner internal {}",
+      "function test() onlyOwner private {}"
+    ];
+    let errors;
 
-        code = code.map(item => toContract(item));
+    code = code.map(item => toContract(item));
 
-        code.forEach(snip => {
-            errors = Solium.lint(snip, userConfig);
-            errors.should.be.Array();
-            errors.should.have.size(1);
-        });
-
-        Solium.reset();
-        done();
+    code.forEach(snip => {
+      errors = Solium.lint(snip, userConfig);
+      errors.should.be.Array();
+      errors.should.have.size(1);
     });
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/rules/whitespace/whitespace.js
+++ b/test/lib/rules/whitespace/whitespace.js
@@ -7,734 +7,739 @@
 
 const { EOL } = require("os");
 const Solium = require("../../../../lib/solium"),
-    wrappers = require("../../../utils/wrappers"), { toContract, toFunction, addPragma } = wrappers;
+  wrappers = require("../../../utils/wrappers"),
+  { toContract, toFunction, addPragma } = wrappers;
 
 let userConfig = {
-    "custom-rules-filename": null,
-    "rules": {
-        "whitespace": true,
-        "conditionals-whitespace": true,
-        "comma-whitespace": true,
-        "operator-whitespace": true,
-        "semicolon-whitespace": true,
-        "function-whitespace": true
-    }
+  "custom-rules-filename": null,
+  rules: {
+    whitespace: true,
+    "conditionals-whitespace": true,
+    "comma-whitespace": true,
+    "operator-whitespace": true,
+    "semicolon-whitespace": true,
+    "function-whitespace": true
+  }
 };
 
 describe("[RULE] whitespace: Acceptances", function() {
+  it('should allow function / event calls with 0 args only if the name is followed by "()"', function(done) {
+    let code = "func ();",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-    it("should allow function / event calls with 0 args only if the name is followed by \"()\"", function(done) {
-        let code = "func ();",
-            errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    code = "foo.func ();";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "foo.func ();";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
+  it("should allow function / event calls with no extraneous whitespace", function(done) {
+    let code = 'spam(ham[1], Coin({name: "ham"}));',
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "foo.bar (10, 20, 30);";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "foo.bar (10, 20, 30);";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "foo (10, 20).func ();";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = 'foo ["func ()"] ();';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = 'foo ["func (10, 20)"] ();';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should allow single-line function body to have 1 extraneous space on either side", function(done) {
+    let code = "function singleLine() { spam(); }",
+      errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "constructor() { spam(); }";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    //it is fine EVEN IF there is no extraneous space
+    code = "function singleLine() {spam();}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "constructor() {spam();}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should allow informal params in function declaration which don't have whitespace immediately before a comma or semicolon", function(done) {
+    let code = "function spam(uint i, Coin coin);",
+      errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = 'var foobar = "Hello World";';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = 'fooBar (baz ({\nhello: "world"\n}));';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "function foo (uint x, string y);";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "constructor(uint x, string y) {}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "constructor() {}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "constructor(uint x, string y, address z, string foobar) {}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should allow informal params in modifier declaration which don't have whitespace immediately before a comma or semicolon", function(done) {
+    let code = "modifier spam(uint i, Coin coin) {_;}",
+      errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "modifier foo (uint extralargevarname, string yoloswag) {_;}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should allow exactly 1 space on either side of an assignment operator", function(done) {
+    let code = 'x = 100; y = "hello world"; string exa = "bytes";',
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code =
+      "x += 100; y *= 10; z -= 10; f /= 100; p |= akjh; ufx ^= 10.289; jack &= jones; p <<= 78; c >>= 100; perc %= 0;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "var x = 100;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "var (x, y, z) = (10, 20, 30);";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "var (x, y, z) = fooBar ();";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "uint newNumber = (10 * 78 + 982 % 6**2);";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "x = foo ().baz;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should allow the code that provides nothing to check, i.e., no arguments in CallExpression", function(done) {
+    let code = "call ();",
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "function foo () {}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "constructor() {}";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    code = "if (true) {}";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it('should allow Name-Value assignments following either of the spacing patterns: ":", " : ", ": "', function(done) {
+    let code = 'myStruct ({a: 100, b : "hello", c : -1908});',
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should allow acceptable comma whitespace between Name-Value declarations", function(done) {
+    let code = `myStruct ({a:100, b:9028,${EOL}c: 19082,d:\"hello world\",${EOL}\t\te:\"this passes YOLO\"});`,
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should allow a valid mix of CallExpression & MemberExpression", function(done) {
+    let errors,
+      statements = [
+        "d(wall.dir()[9]);",
+        "require(msg.sender == address(wallet.directory().brg()));",
+        "balance = balance.add(balance.mul(dividends[currentDividend].amount).div(dividends[currentDividend].supply));",
+        "require(destination.call.value(value)(data));"
+      ];
+
+    statements.forEach(function(stmt) {
+      errors = Solium.lint(toFunction(stmt), userConfig);
+
+      errors.should.be.Array();
+      errors.length.should.equal(0);
     });
 
-    it("should allow function / event calls with no extraneous whitespace", function(done) {
-        let code = "spam(ham[1], Coin({name: \"ham\"}));",
-            errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+  it("should accept SequenceExpression & tuple nodes with no extraneous whitespace", function(done) {
+    const code = [
+      'var (a, b) = (10, foo(90, "hello"));',
+      "var (a) = 10;",
+      "var (a) = (10);",
+      "var (a, b, abra, kadabra) = (i,i,i,i);",
+      "var (myVar) = callSomeFunc(0x00, true);",
+      "var (,, myVar, ,,) = callSomeFunc(0x00, true);",
 
-        code = "foo.bar (10, 20, 30);";
-        errors = Solium.lint(toFunction(code), userConfig);
+      '(a, b) = (10, foo(90, "hello"));',
+      "(a) = 10;",
+      "(a) = (10);",
+      "(a, b, abra, kadabra) = (i,i,i,i);",
+      "(myVar) = callSomeFunc(0x00, true);",
+      "(,, myVar, ,,) = callSomeFunc(0x00, true);",
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+      '(a, b) += (10, foo(90, "hello"));',
+      "(a) += 10;",
+      "(a) += (10);",
+      "(a, b, abra, kadabra) += (i,i,i,i);",
+      "(myVar) += callSomeFunc(0x00, true);",
+      "(,, myVar, ,,) += callSomeFunc(0x00, true);",
 
-        code = "foo.bar (10, 20, 30);";
-        errors = Solium.lint(toFunction(code), userConfig);
+      '(a, b) *= (10, foo(90, "hello"));',
+      "(a) *= 10;",
+      "(a) *= (10);",
+      "(a, b, abra, kadabra) *= (i,i,i,i);",
+      "(myVar) *= callSomeFunc(0x00, true);",
+      "(,, myVar, ,,) *= callSomeFunc(0x00, true);",
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+      '(a, b) /= (10, foo(90, "hello"));',
+      "(a) /= 10;",
+      "(a) /= (10);",
+      "(a, b, abra, kadabra) /= (i,i,i,i);",
+      "(myVar) /= callSomeFunc(0x00, true);",
+      "(,, myVar, ,,) /= callSomeFunc(0x00, true);",
 
-        code = "foo (10, 20).func ();";
-        errors = Solium.lint(toFunction(code), userConfig);
+      '(a, b) -= (10, foo(90, "hello"));',
+      "(a) -= 10;",
+      "(a) -= (10);",
+      "(a, b, abra, kadabra) -= (i,i,i,i);",
+      "(myVar) -= callSomeFunc(0x00, true);",
+      "(,, myVar, ,,) -= callSomeFunc(0x00, true);",
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
+      '(a, b) %= (10, foo(90, "hello"));',
+      "(a) %= 10;",
+      "(a) %= (10);",
+      "(a, b, abra, kadabra) %= (i,i,i,i);",
+      "(myVar) %= callSomeFunc(0x00, true);",
+      "(,, myVar, ,,) %= callSomeFunc(0x00, true);"
+    ];
 
-        code = "foo [\"func ()\"] ();";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code.forEach(statement => {
+      const errors = Solium.lint(toFunction(statement), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "foo [\"func (10, 20)\"] ();";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
+      errors.should.be.Array();
+      errors.should.have.size(0);
     });
 
-    it("should allow single-line function body to have 1 extraneous space on either side", function(done) {
-        let code = "function singleLine() { spam(); }",
-            errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "constructor() { spam(); }";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        //it is fine EVEN IF there is no extraneous space
-        code = "function singleLine() {spam();}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "constructor() {spam();}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should allow informal params in function declaration which don't have whitespace immediately before a comma or semicolon", function(done) {
-        let code = "function spam(uint i, Coin coin);",
-            errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "var foobar = \"Hello World\";";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "fooBar (baz ({\nhello: \"world\"\n}));";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "function foo (uint x, string y);";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "constructor(uint x, string y) {}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "constructor() {}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "constructor(uint x, string y, address z, string foobar) {}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should allow informal params in modifier declaration which don't have whitespace immediately before a comma or semicolon", function(done) {
-        let code = "modifier spam(uint i, Coin coin) {_;}",
-            errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "modifier foo (uint extralargevarname, string yoloswag) {_;}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should allow exactly 1 space on either side of an assignment operator", function(done) {
-        let code = "x = 100; y = \"hello world\"; string exa = \"bytes\";",
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "x += 100; y *= 10; z -= 10; f /= 100; p |= akjh; ufx ^= 10.289; jack &= jones; p <<= 78; c >>= 100; perc %= 0;";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "var x = 100;";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "var (x, y, z) = (10, 20, 30);";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "var (x, y, z) = fooBar ();";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "uint newNumber = (10 * 78 + 982 % 6**2);";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "x = foo ().baz;";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should allow the code that provides nothing to check, i.e., no arguments in CallExpression", function(done) {
-        let code = "call ();",
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "function foo () {}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "constructor() {}";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        code = "if (true) {}";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should allow Name-Value assignments following either of the spacing patterns: \":\", \" : \", \": \"", function(done) {
-        let code = "myStruct ({a: 100, b : \"hello\", c : -1908});",
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should allow acceptable comma whitespace between Name-Value declarations", function(done) {
-        let code = `myStruct ({a:100, b:9028,${EOL}c: 19082,d:\"hello world\",${EOL}\t\te:\"this passes YOLO\"});`,
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should allow a valid mix of CallExpression & MemberExpression", function(done) {
-        let errors, statements = [
-            "d(wall.dir()[9]);",
-            "require(msg.sender == address(wallet.directory().brg()));",
-            "balance = balance.add(balance.mul(dividends[currentDividend].amount).div(dividends[currentDividend].supply));",
-            "require(destination.call.value(value)(data));"
-        ];
-
-        statements.forEach(function(stmt) {
-            errors = Solium.lint(toFunction(stmt), userConfig);
-
-            errors.should.be.Array();
-            errors.length.should.equal(0);
-        });
-
-        Solium.reset();
-        done();
-    });
-
-    it("should accept SequenceExpression & tuple nodes with no extraneous whitespace", function(done) {
-        const code = [
-            "var (a, b) = (10, foo(90, \"hello\"));",
-            "var (a) = 10;",
-            "var (a) = (10);",
-            "var (a, b, abra, kadabra) = (i,i,i,i);",
-            "var (myVar) = callSomeFunc(0x00, true);",
-            "var (,, myVar, ,,) = callSomeFunc(0x00, true);",
-
-            "(a, b) = (10, foo(90, \"hello\"));",
-            "(a) = 10;",
-            "(a) = (10);",
-            "(a, b, abra, kadabra) = (i,i,i,i);",
-            "(myVar) = callSomeFunc(0x00, true);",
-            "(,, myVar, ,,) = callSomeFunc(0x00, true);",
-
-            "(a, b) += (10, foo(90, \"hello\"));",
-            "(a) += 10;",
-            "(a) += (10);",
-            "(a, b, abra, kadabra) += (i,i,i,i);",
-            "(myVar) += callSomeFunc(0x00, true);",
-            "(,, myVar, ,,) += callSomeFunc(0x00, true);",
-
-            "(a, b) *= (10, foo(90, \"hello\"));",
-            "(a) *= 10;",
-            "(a) *= (10);",
-            "(a, b, abra, kadabra) *= (i,i,i,i);",
-            "(myVar) *= callSomeFunc(0x00, true);",
-            "(,, myVar, ,,) *= callSomeFunc(0x00, true);",
-
-            "(a, b) /= (10, foo(90, \"hello\"));",
-            "(a) /= 10;",
-            "(a) /= (10);",
-            "(a, b, abra, kadabra) /= (i,i,i,i);",
-            "(myVar) /= callSomeFunc(0x00, true);",
-            "(,, myVar, ,,) /= callSomeFunc(0x00, true);",
-
-            "(a, b) -= (10, foo(90, \"hello\"));",
-            "(a) -= 10;",
-            "(a) -= (10);",
-            "(a, b, abra, kadabra) -= (i,i,i,i);",
-            "(myVar) -= callSomeFunc(0x00, true);",
-            "(,, myVar, ,,) -= callSomeFunc(0x00, true);",
-
-            "(a, b) %= (10, foo(90, \"hello\"));",
-            "(a) %= 10;",
-            "(a) %= (10);",
-            "(a, b, abra, kadabra) %= (i,i,i,i);",
-            "(myVar) %= callSomeFunc(0x00, true);",
-            "(,, myVar, ,,) %= callSomeFunc(0x00, true);"
-        ];
-
-        code.forEach(statement => {
-            const errors = Solium.lint(toFunction(statement), userConfig);
-
-            errors.should.be.Array();
-            errors.should.have.size(0);
-        });
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
 });
 
-
 describe("[RULE] whitespace: Rejections", function() {
+  it("should reject function / event calls with 0 args if the name is followed by brackets with whitespace between them", function(done) {
+    let code = "func ( );",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-    it("should reject function / event calls with 0 args if the name is followed by brackets with whitespace between them", function(done) {
-        let code = "func ( );",
-            errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "func (\t);";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "func (\t);";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "func (\n);";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "func (\n);";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "func (/**/);";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "func (/**/);";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = 'foo ["func ()"] ( );';
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "foo [\"func ()\"] ( );";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "foo ().func (\t);";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "foo ().func (\t);";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
+  it("should reject function / event calls having extraneous whitespace", function(done) {
+    let code = 'spam( ham[ 1 ], Coin( { name: "ham" } ) );',
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(4);
+
+    code = 'ham[/**/"1"/**/];';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    code = 'ham[\t"1"\t];';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should reject code which has whitespace immediately before a comma or semicolon", function(done) {
+    ////////////////////////////////////////////////////////////////////////////
+    // SEMICOLON
+
+    let code = "function spam(uint i , Coin coin) ;",
+      errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    code = "function spam() ;";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    (code = "constructor(uint i , Coin coin) {}"),
+      (errors = Solium.lint(toContract(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    (code = "constructor(uint i , Coin coin\t,address lulu) {}"),
+      (errors = Solium.lint(toContract(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    code = "var foobar = 100 ;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "var foobar = 100\n;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "var foobar = 100\t;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "var foobar = 100/*abc*/;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "function foo (uint x, string y) ;";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "function foo (uint x, string y)\t;";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "function foo (uint x, string y)\n;";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "function foo (uint x, string y)/*abc*/;";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "x [0] = fooBar () ;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "x [0] = fooBar ()/**/;";
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = 'import * as C from "chuh"/**/;';
+    errors = Solium.lint(addPragma(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "using Foo for *\t;";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    code = "using Foo for Bar.baz\t;";
+    errors = Solium.lint(toContract(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
+
+    ////////////////////////////////////////////////////////////////////////////
+
+    ////////////////////////////////////////////////////////////////////////////
+    // COMMA
+
+    (code = "[1 , 2, 3 , 4,5];"),
+      (errors = Solium.lint(toFunction(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    (code = "call (10\t, 20, 30 ,40,50);"),
+      (errors = Solium.lint(toFunction(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    (code = 'call ({name: "foo"\n, age: 20,id: 1 ,dept: "math"});'),
+      (errors = Solium.lint(toFunction(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    (code = "(1 ,2\t,3\n,4);"),
+      (errors = Solium.lint(toFunction(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
+
+    (code = "var (x  , y,z\t,  foo) = (1,2,3,4);"),
+      (errors = Solium.lint(toFunction(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    (code = "var (x, y, z, foo) = (1 ,2,3\t,4);"),
+      (errors = Solium.lint(toFunction(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
+
+    (code =
+      "modifier foo (uint xyz , string less\t, string chiken\n, address bar/*hello*/, mapping mp, uint errorless) {_;}"),
+      (errors = Solium.lint(toContract(code), userConfig));
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(4);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should reject assignment operators that do not have exactly 1 space on either side of them", function(done) {
+    let code = [
+      "x             = 1;",
+      "y =             1;",
+      'string exa\t=\t"bytes";',
+      "uint a = \t20;",
+      "uint c\t=190;",
+      'string octa\n= "gon";',
+      'bytes32 hexa="gon";',
+      "address mine= 0x0;",
+      "address his =0x1;",
+      'var humpty\n="dumpty";'
+    ];
+    let errors;
+
+    code = code.map(function(item) {
+      return toFunction(item);
     });
 
-    it("should reject function / event calls having extraneous whitespace", function(done) {
-        let code = "spam( ham[ 1 ], Coin( { name: \"ham\" } ) );",
-            errors = Solium.lint(toFunction(code), userConfig);
+    errors = Solium.lint(code[0], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(4);
+    errors = Solium.lint(code[1], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "ham[/**/\"1\"/**/];";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors = Solium.lint(code[2], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
+    errors = Solium.lint(code[3], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "ham[\t\"1\"\t];";
-        errors = Solium.lint(toFunction(code), userConfig);
+    errors = Solium.lint(code[4], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
+    errors = Solium.lint(code[5], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        Solium.reset();
-        done();
-    });
+    errors = Solium.lint(code[6], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-    it("should reject code which has whitespace immediately before a comma or semicolon", function(done) {
-        ////////////////////////////////////////////////////////////////////////////
-        // SEMICOLON
+    errors = Solium.lint(code[7], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        let code = "function spam(uint i , Coin coin) ;",
-            errors = Solium.lint(toContract(code), userConfig);
+    errors = Solium.lint(code[8], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
+    errors = Solium.lint(code[9], userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        code = "function spam() ;";
-        errors = Solium.lint(toContract(code), userConfig);
+    code = 'var x\n=\n"hello world";';
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        code = "constructor(uint i , Coin coin) {}",
-        errors = Solium.lint(toContract(code), userConfig);
+    code = 'var x\t=\t"hello world";';
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        code = "constructor(uint i , Coin coin\t,address lulu) {}",
-        errors = Solium.lint(toContract(code), userConfig);
+    code = 'var x = /*abc*/"hello world";';
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "var foobar = 100 ;";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = 'var x =/*abc*/ "hello world";';
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "var foobar = 100\n;";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = 'var x/*abc*/ = "hello world";';
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "var foobar = 100\t;";
-        errors = Solium.lint(toFunction(code), userConfig);
+    code = 'var x /*abc*/= "hello world";';
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        code = "var foobar = 100/*abc*/;";
-        errors = Solium.lint(toFunction(code), userConfig);
+    Solium.reset();
+    done();
+  });
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+  it("should reject control structures 'if', 'while', and 'for' if there is no space between them and the parenthetic block representing their conditional.", function(done) {
+    let code = "if(true) {}\nelse if(true) {}",
+      errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "function foo (uint x, string y) ;";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(2);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "for(;;) {}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "function foo (uint x, string y)\t;";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
+    code = "while(true) {}";
+    errors = Solium.lint(toFunction(code), userConfig);
 
-        code = "function foo (uint x, string y)\n;";
-        errors = Solium.lint(toContract(code), userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(1);
 
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "function foo (uint x, string y)/*abc*/;";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "x [0] = fooBar () ;";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "x [0] = fooBar ()/**/;";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "import * as C from \"chuh\"/**/;";
-        errors = Solium.lint(addPragma(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "using Foo for *\t;";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "using Foo for Bar.baz\t;";
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        ////////////////////////////////////////////////////////////////////////////
-
-        ////////////////////////////////////////////////////////////////////////////
-        // COMMA
-
-        code = "[1 , 2, 3 , 4,5];",
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "call (10\t, 20, 30 ,40,50);",
-        errors = Solium.lint(toFunction(code), userConfig);
-		
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "call ({name: \"foo\"\n, age: 20,id: 1 ,dept: \"math\"});",
-        errors = Solium.lint(toFunction(code), userConfig);
-		
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "(1 ,2\t,3\n,4);",
-        errors = Solium.lint(toFunction(code), userConfig);
-		
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        code = "var (x  , y,z\t,  foo) = (1,2,3,4);",
-        errors = Solium.lint(toFunction(code), userConfig);
-		
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "var (x, y, z, foo) = (1 ,2,3\t,4);",
-        errors = Solium.lint(toFunction(code), userConfig);
-		
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "modifier foo (uint xyz , string less\t, string chiken\n, address bar/*hello*/, mapping mp, uint errorless) {_;}",
-        errors = Solium.lint(toContract(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(4);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should reject assignment operators that do not have exactly 1 space on either side of them", function(done) {
-        let code = [
-            "x             = 1;",
-            "y =             1;",
-            "string exa\t=\t\"bytes\";",
-            "uint a = \t20;",
-            "uint c\t=190;",
-            "string octa\n= \"gon\";",
-            "bytes32 hexa=\"gon\";",
-            "address mine= 0x0;",
-            "address his =0x1;",
-            "var humpty\n=\"dumpty\";"
-        ];
-        let errors;
-
-        code = code.map(function(item){return toFunction(item);});
-
-        errors = Solium.lint(code [0], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [1], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [2], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [3], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [4], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [5], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [6], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [7], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [8], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        errors = Solium.lint(code [9], userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "var x\n=\n\"hello world\";";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "var x\t=\t\"hello world\";";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "var x = /*abc*/\"hello world\";";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "var x =/*abc*/ \"hello world\";";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "var x/*abc*/ = \"hello world\";";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "var x /*abc*/= \"hello world\";";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should reject control structures 'if', 'while', and 'for' if there is no space between them and the parenthetic block representing their conditional.", function(done) {
-        let code = "if(true) {}\nelse if(true) {}",
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(2);
-
-        code = "for(;;) {}";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        code = "while(true) {}";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(1);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should reject the Name-Value assignments NOT following either of the spacing patterns: \":\", \" : \", \": \"", function(done) {
-        let code = "myStruct ({a: 100, b : \"hello\", c : -1908, d:  10, e :190, f  :  19098, g   : 100, h        :       19028, i\n:100, j\n:\n81972, k : \t\"hola\"});",
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(8);
-
-        //With comments
-        code = "myStruct ({a: /*hello*/\"hello\", b/*ss*/: 190, c/*ssaa*/:/*67*/-19028});";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(3);
-
-        Solium.reset();
-        done();
-    });
-
-    it("should reject unacceptable comma whitespace between Name-Value declarations", function(done) {
-        let code = "myStruct ({a:100 , b:9028 ,c: 19082,  d:\"hello world\",\n\ne:\"this passes YOLO\"  ,e: 100\t,\tf: 18972, \ng: \"cola\"});",
-            errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(7);
-
-        //even comments are not acceptable between commas
-        code = "myStruct ({a:100/*hello*/, b:foo (100),/**/c: 19082, /*shi*/d:\"hello world\",\n/**/e:\"this passes YOLO\",e: 100/**/,/**/f: 18972});";
-        errors = Solium.lint(toFunction(code), userConfig);
-
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(5);
-
-        Solium.reset();
-        done();
-    });
-
+    Solium.reset();
+    done();
+  });
+
+  it('should reject the Name-Value assignments NOT following either of the spacing patterns: ":", " : ", ": "', function(done) {
+    let code =
+        'myStruct ({a: 100, b : "hello", c : -1908, d:  10, e :190, f  :  19098, g   : 100, h        :       19028, i\n:100, j\n:\n81972, k : \t"hola"});',
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(8);
+
+    //With comments
+    code =
+      'myStruct ({a: /*hello*/"hello", b/*ss*/: 190, c/*ssaa*/:/*67*/-19028});';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(3);
+
+    Solium.reset();
+    done();
+  });
+
+  it("should reject unacceptable comma whitespace between Name-Value declarations", function(done) {
+    let code =
+        'myStruct ({a:100 , b:9028 ,c: 19082,  d:"hello world",\n\ne:"this passes YOLO"  ,e: 100\t,\tf: 18972, \ng: "cola"});',
+      errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(7);
+
+    //even comments are not acceptable between commas
+    code =
+      'myStruct ({a:100/*hello*/, b:foo (100),/**/c: 19082, /*shi*/d:"hello world",\n/**/e:"this passes YOLO",e: 100/**/,/**/f: 18972});';
+    errors = Solium.lint(toFunction(code), userConfig);
+
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(5);
+
+    Solium.reset();
+    done();
+  });
 });

--- a/test/lib/utils/ast-utils.js
+++ b/test/lib/utils/ast-utils.js
@@ -10,370 +10,368 @@ const astUtils = require("../../../lib/utils/ast-utils");
 /* eslint-disable no-mixed-spaces-and-tabs */
 
 describe("Testing astUtils Object", function() {
-
-    let sourceCode = "contract Visual {\n\n\tfunction foo () {\n\t\tvar x = 100;\n\t}\n\n}",
-
-        varDeclarator = {
-            "type": "VariableDeclarator",
-            "id": {
-                "type": "Identifier",
-                "name": "x",
-                "start": 44,
-                "end": 45
-            },
-            "init": {
-                "type": "Literal",
-                "value": 100,
-                "start": 48,
-                "end": 51
-            },
-            "start": 44,
-            "end": 51
-        },
-
-        functionDeclaration = {
-            "type": "FunctionDeclaration",
-            "name": "foo",
-            "params": null,
-            "modifiers": null,
-            "body": {
-                "type": "BlockStatement",
-                "body": [
-                    {
-                        "type": "VariableDeclaration",
-                        "declarations": [
-                            {
-                                "type": "VariableDeclarator",
-                                "id": {
-                                    "type": "Identifier",
-                                    "name": "x",
-                                    "start": 44,
-                                    "end": 45
-                                },
-                                "init": {
-                                    "type": "Literal",
-                                    "value": 100,
-                                    "start": 48,
-                                    "end": 51
-                                },
-                                "start": 44,
-                                "end": 51
-                            }
-                        ],
-                        "start": 40,
-                        "end": 52
-                    }
-                ],
-                "start": 40,
-                "end": 52
-            },
-            "is_abstract": false,
-            "start": 20,
-            "end": 55
-        };
-
-
-    it("should expose a set of functions for use", function(done) {
-        astUtils.should.have.ownProperty("init");
-        astUtils.init.should.be.type("function");
-
-        astUtils.should.have.ownProperty("isASTNode");
-        astUtils.isASTNode.should.be.type("function");
-
-        astUtils.should.have.ownProperty("isBlockStatement");
-        astUtils.isBlockStatement.should.be.type("function");
-
-        astUtils.should.have.ownProperty("isMember");
-        astUtils.isMember.should.be.type("function");
-
-        astUtils.should.have.ownProperty("isIfStatement");
-        astUtils.isIfStatement.should.be.type("function");
-
-        astUtils.should.have.ownProperty("isLoopStatement");
-        astUtils.isLoopStatement.should.be.type("function");
-
-        astUtils.should.have.ownProperty("getParent");
-        astUtils.getParent.should.be.type("function");
-
-        astUtils.should.have.ownProperty("getLine");
-        astUtils.getLine.should.be.type("function");
-
-        astUtils.should.have.ownProperty("getColumn");
-        astUtils.getColumn.should.be.type("function");
-
-        done();
-    });
-
-    it("should correctly classify argument as AST Node or non-AST Node upon calling isASTNode ()", function(done) {
-        let ian = astUtils.isASTNode;
-
-        ian().should.equal(false);
-        ian(null).should.equal(false);
-        ian(100).should.equal(false);
-        ian({}).should.equal(false);
-
-        ian({type: "TestNode", start: 0, end: 10}).should.equal(true);
-
-        done();
-    });
-
-    it("should return node.parent when a valid node is passed to getParent ()", function(done) {
-        let node = {
-            type: "TestNode",
-            start: 0, end: 190,
-            parent: {type: "TestParentNode", start: 21, end: 981}
-        };
-
-        let parent = astUtils.getParent(node);
-
-        parent.should.be.type("object");
-        parent.should.have.ownProperty("type");
-        parent.type.should.equal("TestParentNode");
-
-        done();
-    });
-
-    it("should handle invalid argument(s) passed to utility functions", function(done) {
-        astUtils.isIfStatement.bind(astUtils).should.throw();
-        astUtils.isIfStatement.bind(astUtils, null).should.throw();
-        astUtils.isIfStatement.bind(astUtils, 100).should.throw();
-        astUtils.isIfStatement.bind(astUtils, "foo").should.throw();
-        astUtils.isIfStatement.bind(astUtils, []).should.throw();
-
-        done();
-    });
-
-    it("should handle invalid argument(s) passed to getParent ()", function(done) {
-        astUtils.getParent.bind(astUtils).should.throw();
-        astUtils.getParent.bind(astUtils, null).should.throw();
-        astUtils.getParent.bind(astUtils, 100).should.throw();
-        astUtils.getParent.bind(astUtils, "foo").should.throw();
-        astUtils.getParent.bind(astUtils, []).should.throw();
-
-        done();
-    });
-
-    it("should return correct line no. upon getLine() with valid AST node & sourceCode init()ed", function(done) {
-        astUtils.init(sourceCode);
-        astUtils.getLine(varDeclarator).should.equal(4);
-        astUtils.getLine(functionDeclaration).should.equal(3);
-        astUtils.init("");
-
-        done();
-    });
-
-    it("should handle invalid argument(s) passed to getLine ()", function(done) {
-        astUtils.getLine.bind(astUtils).should.throw();
-        astUtils.getLine.bind(astUtils, null).should.throw();
-        astUtils.getLine.bind(astUtils, 100).should.throw();
-        astUtils.getLine.bind(astUtils, "foo").should.throw();
-        astUtils.getLine.bind(astUtils, []).should.throw();
-
-        done();
-    });
-
-    it("should return correct column no. upon getColumn() with valid AST node & sourceCode init()ed", function(done) {
-        astUtils.init("[1,2,386267,-19028.87];");
-        let literals = [
-            { type: "Literal", value: 1, start: 1, end: 2 },
-            { type: "Literal", value: 2, start: 3, end: 4 },
-            { type: "Literal", value: 386267, start: 5, end: 11 },
-            {
-                type: "UnaryExpression",
-                operator: "-",
-                argument: { type: "Literal", value: 19028.87, start: 13, end: 21 },
-                prefix: true,
-                start: 12,
-                end: 21
-            } 
-        ];
-
-        astUtils.getColumn(literals [0]).should.equal(1);
-        astUtils.getColumn(literals [1]).should.equal(3);
-        astUtils.getColumn(literals [2]).should.equal(5);
-        astUtils.getColumn(literals [3]).should.equal(12);
-
-        astUtils.init("\n[\"foo\",\n\"bar\",\t\t\"baz\"];");
-        literals = [
-            { type: "Literal", value: "foo", start: 2, end: 7 },
-  			{ type: "Literal", value: "bar", start: 9, end: 14 },
-  			{ type: "Literal", value: "baz", start: 17, end: 22 }
-  		];
-
-        astUtils.getColumn(literals [0]).should.equal(1);
-        astUtils.getColumn(literals [1]).should.equal(0);
-        astUtils.getColumn(literals [2]).should.equal(8);
-
-        astUtils.init("function foo () {\n\t[1,2,3,4];\n}");
-        literals = [
-            { type: "Literal", value: 1, start: 20, end: 21 },
-     		{ type: "Literal", value: 2, start: 22, end: 23 },
-     		{ type: "Literal", value: 3, start: 24, end: 25 },
-     		{ type: "Literal", value: 4, start: 26, end: 27 }
-     	];
-
-     	astUtils.getColumn(literals [0]).should.equal(2);
-        astUtils.getColumn(literals [1]).should.equal(4);
-        astUtils.getColumn(literals [2]).should.equal(6);
-        astUtils.getColumn(literals [3]).should.equal(8);
-
-        astUtils.init("\n\n(10,\n\n \"foo\"\n\n,\t189.2786)");
-        literals = [
-            { type: "Literal", value: 10, start: 3, end: 5 },
-     		{ type: "Literal", value: "foo", start: 9, end: 14 },
-     		{ type: "Literal", value: 189.2786, start: 18, end: 26 }
-     	];
-
-     	astUtils.getColumn(literals [0]).should.equal(1);
-        astUtils.getColumn(literals [1]).should.equal(1);
-        astUtils.getColumn(literals [2]).should.equal(2);
-
-        astUtils.init("");
-
-        done();
-    });
-
-    it("should handle invalid argument(s) passed to getColumn ()", function(done) {
-        astUtils.getColumn.bind(astUtils).should.throw();
-        astUtils.getColumn.bind(astUtils, null).should.throw();
-        astUtils.getColumn.bind(astUtils, 100).should.throw();
-        astUtils.getColumn.bind(astUtils, "foo").should.throw();
-        astUtils.getColumn.bind(astUtils, []).should.throw();
-
-        done();
-    });
-
-    it("should return correct ending column upon getEndingColumn () with valid AST node & sourceCode init()ed", function(done) {
-        astUtils.init("[1,2,386267,-19028.87];");
-        let literals = [
-            { type: "Literal", value: 1, start: 1, end: 2 },
-            { type: "Literal", value: 2, start: 3, end: 4 },
-            { type: "Literal", value: 386267, start: 5, end: 11 },
-            {
-                type: "UnaryExpression",
-                operator: "-",
-                argument: { type: "Literal", value: 19028.87, start: 13, end: 21 },
-                prefix: true,
-                start: 12,
-                end: 21
-            } 
-        ];
-
-        astUtils.getEndingColumn(literals [0]).should.equal(1);
-        astUtils.getEndingColumn(literals [1]).should.equal(3);
-        astUtils.getEndingColumn(literals [2]).should.equal(10);
-        astUtils.getEndingColumn(literals [3]).should.equal(20);
-
-        astUtils.init("\n[\"foo\",\n\"bar\",\t\t\"baz\"];");
-        literals = [
-            { type: "Literal", value: "foo", start: 2, end: 7 },
-  			{ type: "Literal", value: "bar", start: 9, end: 14 },
-  			{ type: "Literal", value: "baz", start: 17, end: 22 }
-  		];
-
-        astUtils.getEndingColumn(literals [0]).should.equal(5);
-        astUtils.getEndingColumn(literals [1]).should.equal(4);
-        astUtils.getEndingColumn(literals [2]).should.equal(12);
-
-        astUtils.init("function foo () {\n\t[1,2,3,4];\n}");
-        literals = [
-            { type: "Literal", value: 1, start: 20, end: 21 },
-     		{ type: "Literal", value: 2, start: 22, end: 23 },
-     		{ type: "Literal", value: 3, start: 24, end: 25 },
-     		{ type: "Literal", value: 4, start: 26, end: 27 }
-     	];
-
-     	astUtils.getEndingColumn(literals [0]).should.equal(2);
-        astUtils.getEndingColumn(literals [1]).should.equal(4);
-        astUtils.getEndingColumn(literals [2]).should.equal(6);
-        astUtils.getEndingColumn(literals [3]).should.equal(8);
-
-        astUtils.init("\n\n(10,\n\n \"foo\"\n\n,\t189.2786)");
-        literals = [
-            { type: "Literal", value: 10, start: 3, end: 5 },
-     		{ type: "Literal", value: "foo", start: 9, end: 14 },
-     		{ type: "Literal", value: 189.2786, start: 18, end: 26 }
-     	];
-
-     	astUtils.getEndingColumn(literals [0]).should.equal(2);
-        astUtils.getEndingColumn(literals [1]).should.equal(5);
-        astUtils.getEndingColumn(literals [2]).should.equal(9);
-
-        astUtils.init("");
-
-        done();
-    });
-
-    it("should handle invalid argument(s) passed to getEndingColumn ()", function(done) {
-        astUtils.getEndingLine.bind(astUtils).should.throw();
-        astUtils.getEndingLine.bind(astUtils, null).should.throw();
-        astUtils.getEndingLine.bind(astUtils, 100).should.throw();
-        astUtils.getEndingLine.bind(astUtils, "foo").should.throw();
-        astUtils.getEndingLine.bind(astUtils, []).should.throw();
-
-        done();
-    });
-
-    it("should return correct line no. on getEndingLine() with valid AST node & sourceCode init()ed", function(done) {
-        astUtils.init(sourceCode);
-        astUtils.getEndingLine(varDeclarator).should.equal(4);
-        astUtils.getEndingLine(functionDeclaration).should.equal(5);
-        astUtils.init("");
-
-        done();
-    });
-
-    it("should handle invalid argument(s) passed to getLine ()", function(done) {
-        astUtils.getEndingLine.bind(astUtils).should.throw();
-        astUtils.getEndingLine.bind(astUtils, null).should.throw();
-        astUtils.getEndingLine.bind(astUtils, 100).should.throw();
-        astUtils.getEndingLine.bind(astUtils, "foo").should.throw();
-        astUtils.getEndingLine.bind(astUtils, []).should.throw();
-
-        done();
-    });
-
-    it("should behave correctly when calling isAChildOf()", done => {
-        const child = {type: "Blah", start: 10, end: 20},
-            parent = {type: "Blah", start: 0, end: 30}, notChild = {type: "Blah", start: 45, end: 80};
-
-        astUtils.isAChildOf(child, parent).should.be.true();
-        astUtils.isAChildOf(parent, child).should.be.false();
-        astUtils.isAChildOf(parent, parent).should.be.false();
-        astUtils.isAChildOf(notChild, parent).should.be.false();
-        astUtils.isAChildOf(child, notChild).should.be.false();
-
-        done();
-    });
-
-    it("should reject invalid nodes when calling isAChildOf()", done => {
-        const validNode = {type: "Blah", start: 10, end: 20},
-            invalidNode = {start: 10, end: 20};
-
-        astUtils.isAChildOf.bind(astUtils).should.throw();
-        astUtils.isAChildOf.bind(astUtils, null).should.throw();
-        astUtils.isAChildOf.bind(astUtils, 100).should.throw();
-        astUtils.isAChildOf.bind(astUtils, "foo").should.throw();
-        astUtils.isAChildOf.bind(astUtils, []).should.throw();
-
-        astUtils.isAChildOf.bind(astUtils, validNode, null).should.throw();
-        astUtils.isAChildOf.bind(astUtils, validNode, 100).should.throw();
-        astUtils.isAChildOf.bind(astUtils, validNode, "foo").should.throw();
-        astUtils.isAChildOf.bind(astUtils, validNode, []).should.throw();
-
-        astUtils.isAChildOf.bind(astUtils, null, validNode).should.throw();
-        astUtils.isAChildOf.bind(astUtils, 100, validNode).should.throw();
-        astUtils.isAChildOf.bind(astUtils, "foo", validNode).should.throw();
-        astUtils.isAChildOf.bind(astUtils, [], validNode).should.throw();
-
-        astUtils.isAChildOf.bind(astUtils, invalidNode, validNode).should.throw();
-        astUtils.isAChildOf.bind(astUtils, validNode, invalidNode).should.throw();
-
-        astUtils.isAChildOf.bind(astUtils, validNode, validNode).should.not.throw();
-
-        done();
-    });
-
+  let sourceCode =
+      "contract Visual {\n\n\tfunction foo () {\n\t\tvar x = 100;\n\t}\n\n}",
+    varDeclarator = {
+      type: "VariableDeclarator",
+      id: {
+        type: "Identifier",
+        name: "x",
+        start: 44,
+        end: 45
+      },
+      init: {
+        type: "Literal",
+        value: 100,
+        start: 48,
+        end: 51
+      },
+      start: 44,
+      end: 51
+    },
+    functionDeclaration = {
+      type: "FunctionDeclaration",
+      name: "foo",
+      params: null,
+      modifiers: null,
+      body: {
+        type: "BlockStatement",
+        body: [
+          {
+            type: "VariableDeclaration",
+            declarations: [
+              {
+                type: "VariableDeclarator",
+                id: {
+                  type: "Identifier",
+                  name: "x",
+                  start: 44,
+                  end: 45
+                },
+                init: {
+                  type: "Literal",
+                  value: 100,
+                  start: 48,
+                  end: 51
+                },
+                start: 44,
+                end: 51
+              }
+            ],
+            start: 40,
+            end: 52
+          }
+        ],
+        start: 40,
+        end: 52
+      },
+      is_abstract: false,
+      start: 20,
+      end: 55
+    };
+
+  it("should expose a set of functions for use", function(done) {
+    astUtils.should.have.ownProperty("init");
+    astUtils.init.should.be.type("function");
+
+    astUtils.should.have.ownProperty("isASTNode");
+    astUtils.isASTNode.should.be.type("function");
+
+    astUtils.should.have.ownProperty("isBlockStatement");
+    astUtils.isBlockStatement.should.be.type("function");
+
+    astUtils.should.have.ownProperty("isMember");
+    astUtils.isMember.should.be.type("function");
+
+    astUtils.should.have.ownProperty("isIfStatement");
+    astUtils.isIfStatement.should.be.type("function");
+
+    astUtils.should.have.ownProperty("isLoopStatement");
+    astUtils.isLoopStatement.should.be.type("function");
+
+    astUtils.should.have.ownProperty("getParent");
+    astUtils.getParent.should.be.type("function");
+
+    astUtils.should.have.ownProperty("getLine");
+    astUtils.getLine.should.be.type("function");
+
+    astUtils.should.have.ownProperty("getColumn");
+    astUtils.getColumn.should.be.type("function");
+
+    done();
+  });
+
+  it("should correctly classify argument as AST Node or non-AST Node upon calling isASTNode ()", function(done) {
+    let ian = astUtils.isASTNode;
+
+    ian().should.equal(false);
+    ian(null).should.equal(false);
+    ian(100).should.equal(false);
+    ian({}).should.equal(false);
+
+    ian({ type: "TestNode", start: 0, end: 10 }).should.equal(true);
+
+    done();
+  });
+
+  it("should return node.parent when a valid node is passed to getParent ()", function(done) {
+    let node = {
+      type: "TestNode",
+      start: 0,
+      end: 190,
+      parent: { type: "TestParentNode", start: 21, end: 981 }
+    };
+
+    let parent = astUtils.getParent(node);
+
+    parent.should.be.type("object");
+    parent.should.have.ownProperty("type");
+    parent.type.should.equal("TestParentNode");
+
+    done();
+  });
+
+  it("should handle invalid argument(s) passed to utility functions", function(done) {
+    astUtils.isIfStatement.bind(astUtils).should.throw();
+    astUtils.isIfStatement.bind(astUtils, null).should.throw();
+    astUtils.isIfStatement.bind(astUtils, 100).should.throw();
+    astUtils.isIfStatement.bind(astUtils, "foo").should.throw();
+    astUtils.isIfStatement.bind(astUtils, []).should.throw();
+
+    done();
+  });
+
+  it("should handle invalid argument(s) passed to getParent ()", function(done) {
+    astUtils.getParent.bind(astUtils).should.throw();
+    astUtils.getParent.bind(astUtils, null).should.throw();
+    astUtils.getParent.bind(astUtils, 100).should.throw();
+    astUtils.getParent.bind(astUtils, "foo").should.throw();
+    astUtils.getParent.bind(astUtils, []).should.throw();
+
+    done();
+  });
+
+  it("should return correct line no. upon getLine() with valid AST node & sourceCode init()ed", function(done) {
+    astUtils.init(sourceCode);
+    astUtils.getLine(varDeclarator).should.equal(4);
+    astUtils.getLine(functionDeclaration).should.equal(3);
+    astUtils.init("");
+
+    done();
+  });
+
+  it("should handle invalid argument(s) passed to getLine ()", function(done) {
+    astUtils.getLine.bind(astUtils).should.throw();
+    astUtils.getLine.bind(astUtils, null).should.throw();
+    astUtils.getLine.bind(astUtils, 100).should.throw();
+    astUtils.getLine.bind(astUtils, "foo").should.throw();
+    astUtils.getLine.bind(astUtils, []).should.throw();
+
+    done();
+  });
+
+  it("should return correct column no. upon getColumn() with valid AST node & sourceCode init()ed", function(done) {
+    astUtils.init("[1,2,386267,-19028.87];");
+    let literals = [
+      { type: "Literal", value: 1, start: 1, end: 2 },
+      { type: "Literal", value: 2, start: 3, end: 4 },
+      { type: "Literal", value: 386267, start: 5, end: 11 },
+      {
+        type: "UnaryExpression",
+        operator: "-",
+        argument: { type: "Literal", value: 19028.87, start: 13, end: 21 },
+        prefix: true,
+        start: 12,
+        end: 21
+      }
+    ];
+
+    astUtils.getColumn(literals[0]).should.equal(1);
+    astUtils.getColumn(literals[1]).should.equal(3);
+    astUtils.getColumn(literals[2]).should.equal(5);
+    astUtils.getColumn(literals[3]).should.equal(12);
+
+    astUtils.init('\n["foo",\n"bar",\t\t"baz"];');
+    literals = [
+      { type: "Literal", value: "foo", start: 2, end: 7 },
+      { type: "Literal", value: "bar", start: 9, end: 14 },
+      { type: "Literal", value: "baz", start: 17, end: 22 }
+    ];
+
+    astUtils.getColumn(literals[0]).should.equal(1);
+    astUtils.getColumn(literals[1]).should.equal(0);
+    astUtils.getColumn(literals[2]).should.equal(8);
+
+    astUtils.init("function foo () {\n\t[1,2,3,4];\n}");
+    literals = [
+      { type: "Literal", value: 1, start: 20, end: 21 },
+      { type: "Literal", value: 2, start: 22, end: 23 },
+      { type: "Literal", value: 3, start: 24, end: 25 },
+      { type: "Literal", value: 4, start: 26, end: 27 }
+    ];
+
+    astUtils.getColumn(literals[0]).should.equal(2);
+    astUtils.getColumn(literals[1]).should.equal(4);
+    astUtils.getColumn(literals[2]).should.equal(6);
+    astUtils.getColumn(literals[3]).should.equal(8);
+
+    astUtils.init('\n\n(10,\n\n "foo"\n\n,\t189.2786)');
+    literals = [
+      { type: "Literal", value: 10, start: 3, end: 5 },
+      { type: "Literal", value: "foo", start: 9, end: 14 },
+      { type: "Literal", value: 189.2786, start: 18, end: 26 }
+    ];
+
+    astUtils.getColumn(literals[0]).should.equal(1);
+    astUtils.getColumn(literals[1]).should.equal(1);
+    astUtils.getColumn(literals[2]).should.equal(2);
+
+    astUtils.init("");
+
+    done();
+  });
+
+  it("should handle invalid argument(s) passed to getColumn ()", function(done) {
+    astUtils.getColumn.bind(astUtils).should.throw();
+    astUtils.getColumn.bind(astUtils, null).should.throw();
+    astUtils.getColumn.bind(astUtils, 100).should.throw();
+    astUtils.getColumn.bind(astUtils, "foo").should.throw();
+    astUtils.getColumn.bind(astUtils, []).should.throw();
+
+    done();
+  });
+
+  it("should return correct ending column upon getEndingColumn () with valid AST node & sourceCode init()ed", function(done) {
+    astUtils.init("[1,2,386267,-19028.87];");
+    let literals = [
+      { type: "Literal", value: 1, start: 1, end: 2 },
+      { type: "Literal", value: 2, start: 3, end: 4 },
+      { type: "Literal", value: 386267, start: 5, end: 11 },
+      {
+        type: "UnaryExpression",
+        operator: "-",
+        argument: { type: "Literal", value: 19028.87, start: 13, end: 21 },
+        prefix: true,
+        start: 12,
+        end: 21
+      }
+    ];
+
+    astUtils.getEndingColumn(literals[0]).should.equal(1);
+    astUtils.getEndingColumn(literals[1]).should.equal(3);
+    astUtils.getEndingColumn(literals[2]).should.equal(10);
+    astUtils.getEndingColumn(literals[3]).should.equal(20);
+
+    astUtils.init('\n["foo",\n"bar",\t\t"baz"];');
+    literals = [
+      { type: "Literal", value: "foo", start: 2, end: 7 },
+      { type: "Literal", value: "bar", start: 9, end: 14 },
+      { type: "Literal", value: "baz", start: 17, end: 22 }
+    ];
+
+    astUtils.getEndingColumn(literals[0]).should.equal(5);
+    astUtils.getEndingColumn(literals[1]).should.equal(4);
+    astUtils.getEndingColumn(literals[2]).should.equal(12);
+
+    astUtils.init("function foo () {\n\t[1,2,3,4];\n}");
+    literals = [
+      { type: "Literal", value: 1, start: 20, end: 21 },
+      { type: "Literal", value: 2, start: 22, end: 23 },
+      { type: "Literal", value: 3, start: 24, end: 25 },
+      { type: "Literal", value: 4, start: 26, end: 27 }
+    ];
+
+    astUtils.getEndingColumn(literals[0]).should.equal(2);
+    astUtils.getEndingColumn(literals[1]).should.equal(4);
+    astUtils.getEndingColumn(literals[2]).should.equal(6);
+    astUtils.getEndingColumn(literals[3]).should.equal(8);
+
+    astUtils.init('\n\n(10,\n\n "foo"\n\n,\t189.2786)');
+    literals = [
+      { type: "Literal", value: 10, start: 3, end: 5 },
+      { type: "Literal", value: "foo", start: 9, end: 14 },
+      { type: "Literal", value: 189.2786, start: 18, end: 26 }
+    ];
+
+    astUtils.getEndingColumn(literals[0]).should.equal(2);
+    astUtils.getEndingColumn(literals[1]).should.equal(5);
+    astUtils.getEndingColumn(literals[2]).should.equal(9);
+
+    astUtils.init("");
+
+    done();
+  });
+
+  it("should handle invalid argument(s) passed to getEndingColumn ()", function(done) {
+    astUtils.getEndingLine.bind(astUtils).should.throw();
+    astUtils.getEndingLine.bind(astUtils, null).should.throw();
+    astUtils.getEndingLine.bind(astUtils, 100).should.throw();
+    astUtils.getEndingLine.bind(astUtils, "foo").should.throw();
+    astUtils.getEndingLine.bind(astUtils, []).should.throw();
+
+    done();
+  });
+
+  it("should return correct line no. on getEndingLine() with valid AST node & sourceCode init()ed", function(done) {
+    astUtils.init(sourceCode);
+    astUtils.getEndingLine(varDeclarator).should.equal(4);
+    astUtils.getEndingLine(functionDeclaration).should.equal(5);
+    astUtils.init("");
+
+    done();
+  });
+
+  it("should handle invalid argument(s) passed to getLine ()", function(done) {
+    astUtils.getEndingLine.bind(astUtils).should.throw();
+    astUtils.getEndingLine.bind(astUtils, null).should.throw();
+    astUtils.getEndingLine.bind(astUtils, 100).should.throw();
+    astUtils.getEndingLine.bind(astUtils, "foo").should.throw();
+    astUtils.getEndingLine.bind(astUtils, []).should.throw();
+
+    done();
+  });
+
+  it("should behave correctly when calling isAChildOf()", done => {
+    const child = { type: "Blah", start: 10, end: 20 },
+      parent = { type: "Blah", start: 0, end: 30 },
+      notChild = { type: "Blah", start: 45, end: 80 };
+
+    astUtils.isAChildOf(child, parent).should.be.true();
+    astUtils.isAChildOf(parent, child).should.be.false();
+    astUtils.isAChildOf(parent, parent).should.be.false();
+    astUtils.isAChildOf(notChild, parent).should.be.false();
+    astUtils.isAChildOf(child, notChild).should.be.false();
+
+    done();
+  });
+
+  it("should reject invalid nodes when calling isAChildOf()", done => {
+    const validNode = { type: "Blah", start: 10, end: 20 },
+      invalidNode = { start: 10, end: 20 };
+
+    astUtils.isAChildOf.bind(astUtils).should.throw();
+    astUtils.isAChildOf.bind(astUtils, null).should.throw();
+    astUtils.isAChildOf.bind(astUtils, 100).should.throw();
+    astUtils.isAChildOf.bind(astUtils, "foo").should.throw();
+    astUtils.isAChildOf.bind(astUtils, []).should.throw();
+
+    astUtils.isAChildOf.bind(astUtils, validNode, null).should.throw();
+    astUtils.isAChildOf.bind(astUtils, validNode, 100).should.throw();
+    astUtils.isAChildOf.bind(astUtils, validNode, "foo").should.throw();
+    astUtils.isAChildOf.bind(astUtils, validNode, []).should.throw();
+
+    astUtils.isAChildOf.bind(astUtils, null, validNode).should.throw();
+    astUtils.isAChildOf.bind(astUtils, 100, validNode).should.throw();
+    astUtils.isAChildOf.bind(astUtils, "foo", validNode).should.throw();
+    astUtils.isAChildOf.bind(astUtils, [], validNode).should.throw();
+
+    astUtils.isAChildOf.bind(astUtils, invalidNode, validNode).should.throw();
+    astUtils.isAChildOf.bind(astUtils, validNode, invalidNode).should.throw();
+
+    astUtils.isAChildOf.bind(astUtils, validNode, validNode).should.not.throw();
+
+    done();
+  });
 });
 
 /* eslint-enable no-mixed-spaces-and-tabs */

--- a/test/lib/utils/config-inspector.js
+++ b/test/lib/utils/config-inspector.js
@@ -8,206 +8,372 @@
 let configInspector = require("../../../lib/utils/config-inspector");
 
 describe("Test config-inspector functions", function() {
+  it("should have a set of functions exposed as API", function(done) {
+    configInspector.should.be.size(3);
 
-    it("should have a set of functions exposed as API", function(done) {
-        configInspector.should.be.size(3);
+    configInspector.should.have.ownProperty("isValid");
+    configInspector.isValid.should.be.type("function");
 
-        configInspector.should.have.ownProperty("isValid");
-        configInspector.isValid.should.be.type("function");
+    configInspector.should.have.ownProperty("isFormatDeprecated");
+    configInspector.isFormatDeprecated.should.be.type("function");
 
-        configInspector.should.have.ownProperty("isFormatDeprecated");
-        configInspector.isFormatDeprecated.should.be.type("function");
+    configInspector.should.have.ownProperty("isAValidSharableConfig");
+    configInspector.isAValidSharableConfig.should.be.type("function");
 
-        configInspector.should.have.ownProperty("isAValidSharableConfig");
-        configInspector.isAValidSharableConfig.should.be.type("function");
+    done();
+  });
 
-        done();
-    });
+  it("isValid() should correctly classify invalid config objects", function(done) {
+    configInspector.isValid().should.equal(false);
+    configInspector.isValid(undefined).should.equal(false);
+    configInspector.isValid(null).should.equal(false);
+    configInspector.isValid(-1).should.equal(false);
+    configInspector.isValid(0).should.equal(false);
+    configInspector.isValid(1.829).should.equal(false);
+    configInspector.isValid("hello world").should.equal(false);
+    configInspector.isValid([]).should.equal(false);
+    configInspector.isValid(false).should.equal(false);
+    configInspector.isValid(true).should.equal(false);
+    configInspector.isValid({}).should.equal(false);
+    configInspector.isValid({ rules: [] }).should.equal(false);
+    configInspector
+      .isValid({ rules: 1, extends: "blahblah" })
+      .should.equal(false);
+    configInspector.isValid({ rules: {}, extends: 89.28 }).should.equal(false);
+    configInspector.isValid({ extends: "" }).should.equal(false);
+    configInspector.isValid({ extends: "", rules: {} }).should.equal(false);
+    configInspector.isValid({ extends: [] }).should.equal(false);
+    configInspector.isValid({ rules: { a: [] } }).should.equal(false);
+    configInspector
+      .isValid({ extends: "lola", options: { randomAttr: true } })
+      .should.equal(false);
+    configInspector
+      .isValid({ extends: "lola", rules: {}, options: { randomAttr: true } })
+      .should.equal(false);
+    configInspector.isValid({ rules: {}, randomAttr: {} }).should.equal(false);
+    configInspector
+      .isValid({ rules: { a: 1 }, options: { randomAttr: true } })
+      .should.equal(false);
+    configInspector
+      .isValid({
+        rules: { a: 1 },
+        options: { returnInternalIssues: "hello world" }
+      })
+      .should.equal(false);
+    configInspector
+      .isValid({ rules: {}, options: { randomAttr: true } })
+      .should.equal(false);
+    configInspector.isValid({ rules: {}, randomAttr: {} }).should.equal(false);
+    configInspector
+      .isValid({ rules: {}, options: { returnInternalIssues: "hello" } })
+      .should.equal(false);
 
-    it("isValid() should correctly classify invalid config objects", function(done) {
-        configInspector.isValid().should.equal(false);
-        configInspector.isValid(undefined).should.equal(false);
-        configInspector.isValid(null).should.equal(false);
-        configInspector.isValid(-1).should.equal(false);
-        configInspector.isValid(0).should.equal(false);
-        configInspector.isValid(1.829).should.equal(false);
-        configInspector.isValid("hello world").should.equal(false);
-        configInspector.isValid([]).should.equal(false);
-        configInspector.isValid(false).should.equal(false);
-        configInspector.isValid(true).should.equal(false);
-        configInspector.isValid({}).should.equal(false);
-        configInspector.isValid({ rules: [] }).should.equal(false);
-        configInspector.isValid({ rules: 1, extends: "blahblah" }).should.equal(false);
-        configInspector.isValid({ rules: {}, extends: 89.28 }).should.equal(false);
-        configInspector.isValid({ extends: "" }).should.equal(false);
-        configInspector.isValid({ extends: "", rules: {} }).should.equal(false);
-        configInspector.isValid({ extends: [] }).should.equal(false);
-        configInspector.isValid({ rules: {a: []} }).should.equal(false);
-        configInspector.isValid({ extends: "lola", options: {randomAttr: true} }).should.equal(false);
-        configInspector.isValid({ extends: "lola", rules: {}, options: {randomAttr: true} }).should.equal(false);
-        configInspector.isValid({ rules: {}, randomAttr: {} }).should.equal(false);
-        configInspector.isValid({ rules: {a: 1}, options: {randomAttr: true} }).should.equal(false);
-        configInspector.isValid({ rules: {a: 1}, options: {returnInternalIssues: "hello world"} }).should.equal(false);
-        configInspector.isValid({ rules: {}, options: {randomAttr: true} }).should.equal(false);
-        configInspector.isValid({ rules: {}, randomAttr: {} }).should.equal(false);
-        configInspector.isValid({ rules: {}, options: {returnInternalIssues: "hello"} }).should.equal(false);
+    configInspector.isValid({ plugins: [""], rules: {} }).should.equal(false);
+    configInspector.isValid({ plugins: null, rules: {} }).should.equal(false);
+    configInspector.isValid({ plugins: 19072, rules: {} }).should.equal(false);
+    configInspector
+      .isValid({ plugins: 19.2873, rules: {} })
+      .should.equal(false);
+    configInspector.isValid({ plugins: {}, rules: {} }).should.equal(false);
+    configInspector
+      .isValid({ plugins: { a: "b" }, rules: {} })
+      .should.equal(false);
+    configInspector
+      .isValid({ plugins: "myplugin", rules: {} })
+      .should.equal(false);
+    configInspector
+      .isValid({ plugins: [""], extends: "a" })
+      .should.equal(false);
+    configInspector
+      .isValid({ plugins: null, extends: "a" })
+      .should.equal(false);
+    configInspector
+      .isValid({ plugins: 19072, extends: "a" })
+      .should.equal(false);
+    configInspector
+      .isValid({ plugins: 19.2873, extends: "a" })
+      .should.equal(false);
+    configInspector.isValid({ plugins: {}, extends: "a" }).should.equal(false);
+    configInspector
+      .isValid({ plugins: { a: "b" }, extends: "a" })
+      .should.equal(false);
+    configInspector
+      .isValid({ plugins: "myplugin", extends: "a" })
+      .should.equal(false);
+    configInspector.isValid({ plugins: "myplugin" }).should.equal(false);
+    configInspector.isValid({ plugins: 10927 }).should.equal(false);
+    configInspector.isValid({ plugins: null }).should.equal(false);
+    configInspector.isValid({ plugins: {} }).should.equal(false);
 
-        configInspector.isValid({ plugins: [""], rules: {} }).should.equal(false);
-        configInspector.isValid({ plugins: null, rules: {} }).should.equal(false);
-        configInspector.isValid({ plugins: 19072, rules: {} }).should.equal(false);
-        configInspector.isValid({ plugins: 19.2873, rules: {} }).should.equal(false);
-        configInspector.isValid({ plugins: {}, rules: {} }).should.equal(false);
-        configInspector.isValid({ plugins: {a: "b"}, rules: {} }).should.equal(false);
-        configInspector.isValid({ plugins: "myplugin", rules: {} }).should.equal(false);
-        configInspector.isValid({ plugins: [""], extends: "a" }).should.equal(false);
-        configInspector.isValid({ plugins: null, extends: "a" }).should.equal(false);
-        configInspector.isValid({ plugins: 19072, extends: "a" }).should.equal(false);
-        configInspector.isValid({ plugins: 19.2873, extends: "a" }).should.equal(false);
-        configInspector.isValid({ plugins: {}, extends: "a" }).should.equal(false);
-        configInspector.isValid({ plugins: {a: "b"}, extends: "a" }).should.equal(false);
-        configInspector.isValid({ plugins: "myplugin", extends: "a" }).should.equal(false);
-        configInspector.isValid({ plugins: "myplugin" }).should.equal(false);
-        configInspector.isValid({ plugins: 10927 }).should.equal(false);
-        configInspector.isValid({ plugins: null }).should.equal(false);
-        configInspector.isValid({ plugins: {} }).should.equal(false);
+    configInspector
+      .isValid({ extends: "ab", plugins: ["xy", {}] })
+      .should.equal(false);
+    configInspector
+      .isValid({ extends: "ab", plugins: ["xy", 1090] })
+      .should.equal(false);
 
-        configInspector.isValid({ extends: "ab", plugins: ["xy", {}] }).should.equal(false);
-        configInspector.isValid({ extends: "ab", plugins: ["xy", 1090] }).should.equal(false);
+    // This will be valid in future when extends is allowed to be array of strings.
+    configInspector
+      .isValid({ extends: ["/dev", "/payments"] })
+      .should.equal(false);
 
-        // This will be valid in future when extends is allowed to be array of strings.
-        configInspector.isValid({ extends: ["/dev", "/payments"] }).should.equal(false);
+    // Deprecated
+    configInspector
+      .isValid({ "custom-rules-filename": [] })
+      .should.equal(false);
+    configInspector
+      .isValid({ "custom-rules-filename": 89172, rules: { a: true } })
+      .should.equal(false);
+    configInspector
+      .isValid({ "custom-rules-filename": {} })
+      .should.equal(false);
+    configInspector
+      .isValid({ "custom-rules-filename": true })
+      .should.equal(false);
+    configInspector
+      .isValid({ "custom-rules-filename": "" })
+      .should.equal(false);
+    configInspector
+      .isValid({ "custom-rules-filename": "lola", options: { auto: true } })
+      .should.equal(false);
+    configInspector
+      .isValid({
+        "custom-rules-filename": "lola",
+        options: { autofix: "hello" }
+      })
+      .should.equal(false);
 
-        // Deprecated
-        configInspector.isValid({ "custom-rules-filename": [] }).should.equal(false);
-        configInspector.isValid({ "custom-rules-filename": 89172, rules: {a: true} }).should.equal(false);
-        configInspector.isValid({ "custom-rules-filename": {} }).should.equal(false);
-        configInspector.isValid({ "custom-rules-filename": true }).should.equal(false);
-        configInspector.isValid({ "custom-rules-filename": "" }).should.equal(false);
-        configInspector.isValid({ "custom-rules-filename": "lola", options: {auto: true} }).should.equal(false);
-        configInspector.isValid({ "custom-rules-filename": "lola", options: {autofix: "hello"} }).should.equal(false);
+    configInspector
+      .isValid({
+        "custom-rules-filename": "lola",
+        options: { autofix: true, returnInternalIssues: "hello" }
+      })
+      .should.equal(false);
 
-        configInspector.isValid({
-            "custom-rules-filename": "lola",
-            options: {autofix: true, returnInternalIssues: "hello"}
-        }).should.equal(false);
+    configInspector
+      .isValid({
+        "custom-rules-filename": "lola",
+        options: { autofix: true, returnInternalIssue: false }
+      })
+      .should.equal(false);
 
-        configInspector.isValid({
-            "custom-rules-filename": "lola",
-            options: {autofix: true, returnInternalIssue: false}
-        }).should.equal(false);
+    // Mixed
+    configInspector
+      .isValid({ "custom-rules-filename": "iuyu", extends: "sss" })
+      .should.equal(false);
+    configInspector
+      .isValid({ extends: "sss", rules: { a: true } })
+      .should.equal(false);
+    configInspector
+      .isValid({ "custom-rules-filename": "goaka", rules: { a: 1 } })
+      .should.equal(false);
 
-        // Mixed
-        configInspector.isValid({ "custom-rules-filename": "iuyu", extends: "sss" }).should.equal(false);
-        configInspector.isValid({ extends: "sss", rules: {a: true} }).should.equal(false);
-        configInspector.isValid({ "custom-rules-filename": "goaka", rules: {a: 1} }).should.equal(false);
+    done();
+  });
 
-        done();
-    });
+  it("isValid() should correctly classify valid config objects", function(done) {
+    configInspector.isValid({ rules: { a: [1] } }).should.equal(true);
+    configInspector.isValid({ extends: "blahblah" }).should.equal(true);
+    configInspector
+      .isValid({ rules: { a: [1] }, extends: "blahblah" })
+      .should.equal(true);
+    configInspector.isValid({ rules: {} }).should.equal(true);
+    configInspector.isValid({ rules: {}, options: {} }).should.equal(true);
+    configInspector
+      .isValid({ rules: {}, extends: "lola", options: {} })
+      .should.equal(true);
+    configInspector
+      .isValid({ rules: {}, options: { autofix: true } })
+      .should.equal(true);
+    configInspector
+      .isValid({ rules: {}, options: { returnInternalIssues: true } })
+      .should.equal(true);
+    configInspector
+      .isValid({
+        rules: {},
+        options: { autofix: false, returnInternalIssues: true }
+      })
+      .should.equal(true);
+    configInspector
+      .isValid({
+        rules: { a: 1 },
+        options: { autofix: false, returnInternalIssues: true }
+      })
+      .should.equal(true);
 
-    it("isValid() should correctly classify valid config objects", function(done) {
-        configInspector.isValid({ rules: {a: [1]} }).should.equal(true);
-        configInspector.isValid({ extends: "blahblah" }).should.equal(true);
-        configInspector.isValid({ rules: {a: [1]}, extends: "blahblah" }).should.equal(true);
-        configInspector.isValid({ rules: {} }).should.equal(true);
-        configInspector.isValid({ rules: {}, options: {} }).should.equal(true);
-        configInspector.isValid({ rules: {}, extends: "lola", options: {} }).should.equal(true);
-        configInspector.isValid({ rules: {}, options: {autofix: true} }).should.equal(true);
-        configInspector.isValid({ rules: {}, options: {returnInternalIssues: true} }).should.equal(true);
-        configInspector.isValid({ rules: {}, options: {autofix: false, returnInternalIssues: true} }).should.equal(true);
-        configInspector.isValid({ rules: {a: 1}, options: {autofix: false, returnInternalIssues: true} }).should.equal(true);
+    configInspector.isValid({ extends: "ab", plugins: [] }).should.equal(true);
+    configInspector
+      .isValid({ extends: "ab", plugins: ["x"] })
+      .should.equal(true);
+    configInspector
+      .isValid({ extends: "ab", plugins: ["xy", "a-c_d"] })
+      .should.equal(true);
+    configInspector
+      .isValid({ extends: "ab", plugins: ["x"], options: {} })
+      .should.equal(true);
+    configInspector.isValid({ rules: {}, plugins: [] }).should.equal(true);
+    configInspector.isValid({ rules: {}, plugins: ["x"] }).should.equal(true);
+    configInspector
+      .isValid({ rules: {}, plugins: ["xy", "a-c_d"] })
+      .should.equal(true);
+    configInspector
+      .isValid({ rules: {}, plugins: ["x"], options: {} })
+      .should.equal(true);
 
-        configInspector.isValid({ extends: "ab", plugins: [] }).should.equal(true);
-        configInspector.isValid({ extends: "ab", plugins: ["x"] }).should.equal(true);
-        configInspector.isValid({ extends: "ab", plugins: ["xy", "a-c_d"] }).should.equal(true);
-        configInspector.isValid({ extends: "ab", plugins: ["x"], options: {} }).should.equal(true);
-        configInspector.isValid({ rules: {}, plugins: [] }).should.equal(true);
-        configInspector.isValid({ rules: {}, plugins: ["x"] }).should.equal(true);
-        configInspector.isValid({ rules: {}, plugins: ["xy", "a-c_d"] }).should.equal(true);
-        configInspector.isValid({ rules: {}, plugins: ["x"], options: {} }).should.equal(true);
+    // Deprecated
+    configInspector.isValid({ rules: { a: true } }).should.equal(true);
+    configInspector
+      .isValid({ rules: { a: false, b: false, c: true } })
+      .should.equal(true);
+    configInspector
+      .isValid({ "custom-rules-filename": "koala", rules: { a: false } })
+      .should.equal(true);
+    configInspector
+      .isValid({ "custom-rules-filename": null, rules: { a: true } })
+      .should.equal(true);
+    configInspector
+      .isValid({ "custom-rules-filename": null, rules: {} })
+      .should.equal(true);
 
-        // Deprecated
-        configInspector.isValid({ rules: {a: true} }).should.equal(true);
-        configInspector.isValid({ rules: {a: false, b: false, c: true} }).should.equal(true);
-        configInspector.isValid({ "custom-rules-filename": "koala", rules: {a: false} }).should.equal(true);
-        configInspector.isValid({ "custom-rules-filename": null, rules: {a: true} }).should.equal(true);
-        configInspector.isValid({ "custom-rules-filename": null, rules: {} }).should.equal(true);
+    configInspector.isValid({ plugins: ["standard"] }).should.equal(true);
+    configInspector
+      .isValid({ plugins: ["s"], rules: { "s/foo": 1 } })
+      .should.equal(true);
+    configInspector
+      .isValid({ plugins: ["s"], extends: "blah" })
+      .should.equal(true);
+    configInspector
+      .isValid({ plugins: ["s"], rules: { "s/foo": 1 }, extends: "blah" })
+      .should.equal(true);
 
-        configInspector.isValid({ plugins: ["standard"] }).should.equal(true);
-        configInspector.isValid({ plugins: ["s"], rules: {"s/foo": 1} }).should.equal(true);
-        configInspector.isValid({ plugins: ["s"], extends: "blah" }).should.equal(true);
-        configInspector.isValid({ plugins: ["s"], rules: {"s/foo": 1}, extends: "blah" }).should.equal(true);
+    done();
+  });
 
-        done();
-    });
+  it("isFormatDeprecated() should correctly classify a deprecated config format", function(done) {
+    configInspector
+      .isFormatDeprecated({ rules: { a: true } })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({ rules: { a: false } })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({ rules: { a: false, b: true, c: true } })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({ rules: { a: false }, options: {} })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({ rules: { a: true }, options: { autofix: true } })
+      .should.equal(true);
 
-    it("isFormatDeprecated() should correctly classify a deprecated config format", function(done) {
-        configInspector.isFormatDeprecated({ rules: {a: true} }).should.equal(true);
-        configInspector.isFormatDeprecated({ rules: {a: false} }).should.equal(true);
-        configInspector.isFormatDeprecated({ rules: {a: false, b: true, c: true} }).should.equal(true);
-        configInspector.isFormatDeprecated({ rules: {a: false}, options: {} }).should.equal(true);
-        configInspector.isFormatDeprecated({ rules: {a: true}, options: {autofix: true} }).should.equal(true);
+    configInspector
+      .isFormatDeprecated({ "custom-rules-filename": "koala" })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({ "custom-rules-filename": "koala", rules: {} })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({
+        "custom-rules-filename": "koala",
+        rules: { a: true }
+      })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({ "custom-rules-filename": null })
+      .should.equal(true);
+    configInspector
+      .isFormatDeprecated({ "custom-rules-filename": null, rules: { a: true } })
+      .should.equal(true);
 
-        configInspector.isFormatDeprecated({ "custom-rules-filename": "koala" }).should.equal(true);
-        configInspector.isFormatDeprecated({ "custom-rules-filename": "koala", rules: {} }).should.equal(true);
-        configInspector.isFormatDeprecated({ "custom-rules-filename": "koala", rules: {a: true} }).should.equal(true);
-        configInspector.isFormatDeprecated({ "custom-rules-filename": null }).should.equal(true);
-        configInspector.isFormatDeprecated({ "custom-rules-filename": null, rules: {a: true} }).should.equal(true);
+    done();
+  });
 
-        done();
-    });
+  it("isFormatDeprecated() should correctly classify a non-deprecated config format", function(done) {
+    configInspector.isFormatDeprecated({ rules: {} }).should.equal(false);
+    configInspector
+      .isFormatDeprecated({ rules: {}, options: {} })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({ rules: {}, options: { autofix: true } })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({ extends: "helloworld" })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({ rules: {}, extends: "jon-snow" })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({ rules: { abc: [1] }, extends: "mowgli" })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({ rules: { abc: 2 } })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({ rules: { abc: "off" } })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({
+        rules: { abc: "off", bcd: "warning", cde: "error" }
+      })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({ rules: { abc: 2, bcd: ["error", 100] } })
+      .should.equal(false);
+    configInspector
+      .isFormatDeprecated({
+        rules: { abc: 2, bcd: ["error", 100] },
+        extends: "jellyfish"
+      })
+      .should.equal(false);
 
-    it("isFormatDeprecated() should correctly classify a non-deprecated config format", function(done) {
-        configInspector.isFormatDeprecated({ rules: {} }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: {}, options: {} }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: {}, options: {autofix: true} }).should.equal(false);
-        configInspector.isFormatDeprecated({ extends: "helloworld" }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: {}, extends: "jon-snow" }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: { abc: [1] }, extends: "mowgli" }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: { abc: 2 } }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: { abc: "off" } }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: { abc: "off", bcd: "warning", cde: "error" } }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: { abc: 2, bcd: ["error", 100] } }).should.equal(false);
-        configInspector.isFormatDeprecated({ rules: { abc: 2, bcd: ["error", 100] }, extends: "jellyfish" }).should.equal(false);
+    done();
+  });
 
-        done();
-    });
+  // No need for extensive testing of "rules" attribute since its schema is imported from config,
+  // which is extensively tested.
+  it("isAValidSharableConfig() should correctly classify a valid sharable config", function(done) {
+    configInspector.isAValidSharableConfig({ rules: {} }).should.equal(true);
+    configInspector
+      .isAValidSharableConfig({ rules: { quotes: [1] } })
+      .should.equal(true);
+    configInspector
+      .isAValidSharableConfig({ rules: { quotes: [1] } })
+      .should.equal(true);
+    configInspector
+      .isAValidSharableConfig({ rules: { quotes: 1 } })
+      .should.equal(true);
+    configInspector
+      .isAValidSharableConfig({ rules: { quotes: "error" } })
+      .should.equal(true);
 
-    // No need for extensive testing of "rules" attribute since its schema is imported from config,
-    // which is extensively tested.
-    it("isAValidSharableConfig() should correctly classify a valid sharable config", function(done) {
-        configInspector.isAValidSharableConfig({rules: {}}).should.equal(true);
-        configInspector.isAValidSharableConfig({rules: {quotes: [1]}}).should.equal(true);
-        configInspector.isAValidSharableConfig({rules: {quotes: [1]}}).should.equal(true);
-        configInspector.isAValidSharableConfig({rules: {quotes: 1}}).should.equal(true);
-        configInspector.isAValidSharableConfig({rules: {quotes: "error"}}).should.equal(true);
+    done();
+  });
 
-        done();
-    });
+  it("isAValidSharableConfig() should correctly classify an invalid sharable config", function(done) {
+    configInspector.isAValidSharableConfig(null).should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector.isAValidSharableConfig().should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector.isAValidSharableConfig(19072).should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector.isAValidSharableConfig([]).should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector.isAValidSharableConfig(function() {}).should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector.isAValidSharableConfig("hello world").should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector.isAValidSharableConfig(189.2783).should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector.isAValidSharableConfig({}).should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
+    configInspector
+      .isAValidSharableConfig({
+        rules: {},
+        extraUnwantedAttribute: [1, 2, 3]
+      })
+      .should.equal(false);
+    configInspector.isAValidSharableConfig.errors.should.have.size(1);
 
-    it("isAValidSharableConfig() should correctly classify an invalid sharable config", function(done) {
-        configInspector.isAValidSharableConfig(null).should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig().should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig(19072).should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig([]).should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig(function(){}).should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig("hello world").should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig(189.2783).should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig({}).should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-        configInspector.isAValidSharableConfig({
-            rules: {},
-            extraUnwantedAttribute: [1, 2, 3]
-        }).should.equal(false);
-        configInspector.isAValidSharableConfig.errors.should.have.size(1);
-
-        done();
-    });
-
+    done();
+  });
 });

--- a/test/lib/utils/js-utils.js
+++ b/test/lib/utils/js-utils.js
@@ -8,25 +8,24 @@
 let jsUtils = require("../../../lib/utils/js-utils");
 
 describe("Test jsUtils functions", function() {
+  it("should have a set of functions exposed as API", function(done) {
+    jsUtils.should.have.ownProperty("isStrictlyObject");
+    jsUtils.isStrictlyObject.should.be.type("function");
 
-    it("should have a set of functions exposed as API", function(done) {
-        jsUtils.should.have.ownProperty("isStrictlyObject");
-        jsUtils.isStrictlyObject.should.be.type("function");
+    done();
+  });
 
-        done();
-    });
+  it("isStrictlyObject: should correctly classify whether argument is a non-array, non-null object", function(done) {
+    let iso = jsUtils.isStrictlyObject;
 
-    it("isStrictlyObject: should correctly classify whether argument is a non-array, non-null object", function(done) {
-        let iso = jsUtils.isStrictlyObject;
+    iso().should.equal(false);
+    iso(100).should.equal(false);
+    iso(null).should.equal(false);
+    iso("foo").should.equal(false);
+    iso([1, 2]).should.equal(false);
 
-        iso().should.equal(false);
-        iso(100).should.equal(false);
-        iso(null).should.equal(false);
-        iso("foo").should.equal(false);
-        iso([1, 2]).should.equal(false);
+    iso({}).should.equal(true);
 
-        iso({}).should.equal(true);
-
-        done();
-    });
+    done();
+  });
 });

--- a/test/lib/utils/node-event-generator.js
+++ b/test/lib/utils/node-event-generator.js
@@ -6,56 +6,54 @@
 "use strict";
 
 let EventGenerator = require("../../../lib/utils/node-event-generator"),
-    Solium = require("../../../lib/solium");
+  Solium = require("../../../lib/solium");
 
 describe("Testing EventGenerator instance for exposed functionality", function() {
+  it("should create a new instance of EventGenerator and expose a set of functions", function(done) {
+    let generator = new EventGenerator(Solium);
 
-    it("should create a new instance of EventGenerator and expose a set of functions", function(done) {
-        let generator = new EventGenerator(Solium);
+    generator.should.be.type("object");
+    generator.should.be.instanceof(EventGenerator);
 
-        generator.should.be.type("object");
-        generator.should.be.instanceof(EventGenerator);
+    generator.should.have.ownProperty("emitter");
+    generator.emitter.constructor.name.should.equal("EventEmitter");
 
-        generator.should.have.ownProperty("emitter");
-        generator.emitter.constructor.name.should.equal("EventEmitter");
+    generator.should.have.property("enterNode");
+    generator.enterNode.should.be.type("function");
 
-        generator.should.have.property("enterNode");
-        generator.enterNode.should.be.type("function");
+    generator.should.have.property("leaveNode");
+    generator.leaveNode.should.be.type("function");
 
-        generator.should.have.property("leaveNode");
-        generator.leaveNode.should.be.type("function");
+    done();
+  });
 
-        done();
+  it("should behave as expected upon calling enterNode ()", function(done) {
+    let successCountDown = 2;
+    let generator = new EventGenerator(Solium);
+
+    Solium.on("TestNodeEnter", function(emitted) {
+      emitted.should.have.ownProperty("node");
+      emitted.node.should.have.ownProperty("type");
+      emitted.node.type.should.equal("TestNodeEnter");
+      emitted.should.have.ownProperty("exit");
+      emitted.exit.should.equal(false);
+
+      successCountDown--;
+      !successCountDown && (Solium.reset() || done());
     });
 
-    it("should behave as expected upon calling enterNode ()", function(done) {
-        let successCountDown = 2;
-        let generator = new EventGenerator(Solium);
+    Solium.on("TestNodeLeave", function(emitted) {
+      emitted.should.have.ownProperty("node");
+      emitted.node.should.have.ownProperty("type");
+      emitted.node.type.should.equal("TestNodeLeave");
+      emitted.should.have.ownProperty("exit");
+      emitted.exit.should.equal(true);
 
-        Solium.on("TestNodeEnter", function(emitted) {
-            emitted.should.have.ownProperty("node");
-            emitted.node.should.have.ownProperty("type");
-            emitted.node.type.should.equal("TestNodeEnter");
-            emitted.should.have.ownProperty("exit");
-            emitted.exit.should.equal(false);
-
-            successCountDown--;
-            !successCountDown && (Solium.reset() || done());
-        });
-
-        Solium.on("TestNodeLeave", function(emitted) {
-            emitted.should.have.ownProperty("node");
-            emitted.node.should.have.ownProperty("type");
-            emitted.node.type.should.equal("TestNodeLeave");
-            emitted.should.have.ownProperty("exit");
-            emitted.exit.should.equal(true);
-
-            successCountDown--;
-            !successCountDown && (Solium.reset() || done());
-        });
-
-        generator.enterNode({ type: "TestNodeEnter" });
-        generator.leaveNode({ type: "TestNodeLeave" });
+      successCountDown--;
+      !successCountDown && (Solium.reset() || done());
     });
 
+    generator.enterNode({ type: "TestNodeEnter" });
+    generator.leaveNode({ type: "TestNodeLeave" });
+  });
 });

--- a/test/lib/utils/rule-inspector.js
+++ b/test/lib/utils/rule-inspector.js
@@ -10,515 +10,562 @@ let ruleInspector = require("../../../lib/utils/rule-inspector");
 /* eslint-disable no-unused-vars */
 
 describe("Test rule-inspector functions", function() {
+  it("should expose a set of functions", function(done) {
+    ruleInspector.should.have.size(3);
 
-    it("should expose a set of functions", function(done) {
-        ruleInspector.should.have.size(3);
+    ruleInspector.should.have.ownProperty("isAValidRuleObject");
+    ruleInspector.isAValidRuleObject.should.be.type("function");
 
-        ruleInspector.should.have.ownProperty("isAValidRuleObject");
-        ruleInspector.isAValidRuleObject.should.be.type("function");
+    ruleInspector.should.have.ownProperty("isAValidRuleResponseObject");
+    ruleInspector.isAValidRuleResponseObject.should.be.type("function");
 
-        ruleInspector.should.have.ownProperty("isAValidRuleResponseObject");
-        ruleInspector.isAValidRuleResponseObject.should.be.type("function");
+    ruleInspector.should.have.ownProperty("areValidOptionsPassed");
+    ruleInspector.areValidOptionsPassed.should.be.type("function");
 
-        ruleInspector.should.have.ownProperty("areValidOptionsPassed");
-        ruleInspector.areValidOptionsPassed.should.be.type("function");
+    done();
+  });
 
-        done();
+  it("should correctly classify all valid rule objects", function(done) {
+    let configObjects = [];
+
+    // Complete object
+    configObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule",
+          replacedBy: ["new-rule"]
+        },
+        schema: [],
+        fixable: "code",
+        deprecated: true
+      },
+      create: function(context) {}
     });
 
-    it("should correctly classify all valid rule objects", function(done) {
-        let configObjects = [];
-
-        // Complete object
-        configObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule",
-                    "replacedBy": ["new-rule"]
-                },
-                "schema": [],
-                "fixable": "code",
-                "deprecated": true
-            },
-            "create": function(context) {}
-        });
-
-        // No fixable
-        configObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": []
-            },
-            "create": function(context) {}
-        });
-
-        // Schemas for passed options
-        configObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [
-                    { type: "string", minLength: 5 },
-                    { type: "object", properties: {modifies: {type: "boolean"}} },
-                    { type: "integer", minimum: 0, maximum: 69 }
-                ]
-            },
-            "create": function(context) {}
-        });
-
-        // No deprecation
-        configObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Only deprecation, no replacement
-        configObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code",
-                "deprecated": true
-            },
-            "create": function(context) {}
-        });
-
-        // "replacedBy" attr without the "deprecated: true"
-        // In this case, "replacedBy" is redundant & will be ignored by solium, but its not invalid.
-        configObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule",
-                    "replacedBy": ["new-rule"]
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-		
-        configObjects.forEach(function(c) {
-            ruleInspector.isAValidRuleObject(c).should.equal(true);
-        });
-
-        done();
+    // No fixable
+    configObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: []
+      },
+      create: function(context) {}
     });
 
-    it("should correctly classify all invalid rule objects", function(done) {
-        let invalidConfigObjects = [, null,
-            undefined, 0, "", "harry potter", -190, 8927, 88.2891, [], [{}], [0], {}, function() {}];
-
-        /**
-		 * First rule out all the obviously invalid args.
-		 * Then check for subtle invalidities.
-		 */
-        invalidConfigObjects.forEach(function(c) {
-            ruleInspector.isAValidRuleObject(c).should.equal(false);
-        });
-
-        invalidConfigObjects = [];
-
-        // No create attr
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code"
-            }
-        });
-
-        // No meta attr
-        invalidConfigObjects.push({
-            "create": function(context) {}
-        });
-
-        // Invalid value for create
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": "jon snow dies"
-        });
-
-        // Invalid value for meta
-        invalidConfigObjects.push({
-            "meta": [10, {}, null],
-            "create": function(context) {}
-        });
-
-        // No meta.docs
-        invalidConfigObjects.push({
-            "meta": {
-                "schema": []
-            },
-            "create": function(context) {}
-        });
-
-        // No meta.schema
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                }
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid meta.docs
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": null,
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid meta.schema
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [{"type": "object"}, "think again"],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid meta.fixable
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "somerandomnonsense"
-            },
-            "create": function(context) {}
-        });
-
-        // No meta.docs.recommended
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // No meta.docs.type
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // No meta.docs.description
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error"
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid meta.docs.recommended
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": 0,
-                    "type": "error",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid meta.docs.type
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "woo woo",
-                    "description": "This is a rule"
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid meta.docs.description
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": {"cutie": 3.142}
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Empty meta.docs.description
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": ""
-                },
-                "schema": [],
-                "fixable": "code"
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid value for "deprecated"
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule",
-                    "replacedBy": ["new-rule"]
-                },
-                "schema": [],
-                "fixable": "code",
-                "deprecated": null
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid value for "replacedBy"
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule",
-                    "replacedBy": "new-rule"
-                },
-                "schema": [],
-                "fixable": "code",
-                "deprecated": true
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid value for "replacedBy"
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule",
-                    "replacedBy": []
-                },
-                "schema": [],
-                "fixable": "code",
-                "deprecated": true
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid value for "replacedBy"
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule",
-                    "replacedBy": [""]
-                },
-                "schema": [],
-                "fixable": "code",
-                "deprecated": true
-            },
-            "create": function(context) {}
-        });
-
-        // Invalid value for "replacedBy"
-        invalidConfigObjects.push({
-            "meta": {
-                "docs": {
-                    "recommended": true,
-                    "type": "error",
-                    "description": "This is a rule",
-                    "replacedBy": null
-                },
-                "schema": [],
-                "fixable": "code",
-                "deprecated": true
-            },
-            "create": function(context) {}
-        });
-
-        invalidConfigObjects.forEach(function(c, i) {
-            ruleInspector.isAValidRuleObject(c).should.equal(false);
-            // Because rule-inspector directly exposes an AJV object compiled with the schema as
-            // "isAValidRuleObject", we can even access other properties of this AJV object like "errors".
-            ruleInspector.isAValidRuleObject.should.have.ownProperty("errors");
-            ruleInspector.isAValidRuleObject.errors.should.be.Array();
-
-            // Because each invalid object above must have exactly 1 invalid piece of info
-            // to test that specific validation in isolation.
-            ruleInspector.isAValidRuleObject.errors.should.have.size(1);
-        });
-
-        done();
+    // Schemas for passed options
+    configObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [
+          { type: "string", minLength: 5 },
+          { type: "object", properties: { modifies: { type: "boolean" } } },
+          { type: "integer", minimum: 0, maximum: 69 }
+        ]
+      },
+      create: function(context) {}
     });
 
-    it("should correctly classify all valid rule response objects", function(done) {
-        let response = {};
-        ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
-
-        response = {
-            Literal: function(context) {}
-        };
-        ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
-
-        // Keys that aren't actually node names are still valid. The emitter would simply never emit anything for this node,
-        // so it will just be ignored.
-        response = {
-            NotAnActualNodeName: function(context) {}
-        };
-        ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
-
-        response = {
-            Program: function(context) {},
-            ContractStatement: function(context) {},
-            ArrayExpression: function(context) {}
-        };
-        ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
-
-        done();
+    // No deprecation
+    configObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
     });
 
-    it("should correctly classify all invalid rule response objects", function(done) {
-        let invalidResponses = [, null,
-            undefined, 0, "", "harry potter", -190, 8927, 88.2891, [], [{}], [0], function() {}];
-
-        invalidResponses.push({
-            "": function(ctx) {}
-        });
-
-        invalidResponses.push({
-            Literal: "Hello world"
-        });
-
-        invalidResponses.push({
-            Literal: undefined
-        });
-
-        invalidResponses.push({
-            Literal: null
-        });
-
-        invalidResponses.push({
-            NodaA: function(c) {},
-            NodaB: function(c) {},
-            Literal: null
-        });
-
-        invalidResponses.forEach(function(res) {
-            ruleInspector.isAValidRuleResponseObject(res).should.equal(false);
-            ruleInspector.isAValidRuleResponseObject.should.have.ownProperty("errors");
-            ruleInspector.isAValidRuleResponseObject.errors.should.be.Array();
-        });
-
-        done();
+    // Only deprecation, no replacement
+    configObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code",
+        deprecated: true
+      },
+      create: function(context) {}
     });
 
-    let listItemsSchema = [
-        {type: "string", minLength: 3},
-        {type: "integer", minimum: 0, maximum: 10},
-        {type: "object", properties: { name: {type: "string", minLength: 1} }, additionalProperties: false}
+    // "replacedBy" attr without the "deprecated: true"
+    // In this case, "replacedBy" is redundant & will be ignored by solium, but its not invalid.
+    configObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule",
+          replacedBy: ["new-rule"]
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    configObjects.forEach(function(c) {
+      ruleInspector.isAValidRuleObject(c).should.equal(true);
+    });
+
+    done();
+  });
+
+  it("should correctly classify all invalid rule objects", function(done) {
+    let invalidConfigObjects = [
+      ,
+      null,
+      undefined,
+      0,
+      "",
+      "harry potter",
+      -190,
+      8927,
+      88.2891,
+      [],
+      [{}],
+      [0],
+      {},
+      function() {}
     ];
 
-    it("should correctly classify when a rule is provided a valid set of options", function(done) {
-        ruleInspector.areValidOptionsPassed(["hello", 5, {name: "chuck norris"}], listItemsSchema).should.equal(true);
-        done();
+    /**
+     * First rule out all the obviously invalid args.
+     * Then check for subtle invalidities.
+     */
+    invalidConfigObjects.forEach(function(c) {
+      ruleInspector.isAValidRuleObject(c).should.equal(false);
     });
 
-    it("should correctly classify when a rule is provided an invalid set of options", function(done) {
-        let invalidOptionLists = [
-            null, undefined, "", {}, 100, -9, 89.23, 0, function() {}, NaN,
-            ["", 5, {name: "chuck norris"}],
-            ["hello", -189, {name: "chuck norris"}],
-            ["", 5, {name: ""}],
-            [],
-            ["hello"],
-            ["hell", 9],
-            [9, {name: "chuck norris"}],
-            ["sss", {name: "chuck norris"}]
-        ];
+    invalidConfigObjects = [];
 
-        invalidOptionLists.forEach(function(ops) {
-            ruleInspector.areValidOptionsPassed(ops, listItemsSchema).should.equal(false);
-        });
-
-        done();
+    // No create attr
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code"
+      }
     });
 
+    // No meta attr
+    invalidConfigObjects.push({
+      create: function(context) {}
+    });
+
+    // Invalid value for create
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: "jon snow dies"
+    });
+
+    // Invalid value for meta
+    invalidConfigObjects.push({
+      meta: [10, {}, null],
+      create: function(context) {}
+    });
+
+    // No meta.docs
+    invalidConfigObjects.push({
+      meta: {
+        schema: []
+      },
+      create: function(context) {}
+    });
+
+    // No meta.schema
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        }
+      },
+      create: function(context) {}
+    });
+
+    // Invalid meta.docs
+    invalidConfigObjects.push({
+      meta: {
+        docs: null,
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // Invalid meta.schema
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [{ type: "object" }, "think again"],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // Invalid meta.fixable
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "somerandomnonsense"
+      },
+      create: function(context) {}
+    });
+
+    // No meta.docs.recommended
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // No meta.docs.type
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // No meta.docs.description
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error"
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // Invalid meta.docs.recommended
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: 0,
+          type: "error",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // Invalid meta.docs.type
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "woo woo",
+          description: "This is a rule"
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // Invalid meta.docs.description
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: { cutie: 3.142 }
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // Empty meta.docs.description
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: ""
+        },
+        schema: [],
+        fixable: "code"
+      },
+      create: function(context) {}
+    });
+
+    // Invalid value for "deprecated"
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule",
+          replacedBy: ["new-rule"]
+        },
+        schema: [],
+        fixable: "code",
+        deprecated: null
+      },
+      create: function(context) {}
+    });
+
+    // Invalid value for "replacedBy"
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule",
+          replacedBy: "new-rule"
+        },
+        schema: [],
+        fixable: "code",
+        deprecated: true
+      },
+      create: function(context) {}
+    });
+
+    // Invalid value for "replacedBy"
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule",
+          replacedBy: []
+        },
+        schema: [],
+        fixable: "code",
+        deprecated: true
+      },
+      create: function(context) {}
+    });
+
+    // Invalid value for "replacedBy"
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule",
+          replacedBy: [""]
+        },
+        schema: [],
+        fixable: "code",
+        deprecated: true
+      },
+      create: function(context) {}
+    });
+
+    // Invalid value for "replacedBy"
+    invalidConfigObjects.push({
+      meta: {
+        docs: {
+          recommended: true,
+          type: "error",
+          description: "This is a rule",
+          replacedBy: null
+        },
+        schema: [],
+        fixable: "code",
+        deprecated: true
+      },
+      create: function(context) {}
+    });
+
+    invalidConfigObjects.forEach(function(c, i) {
+      ruleInspector.isAValidRuleObject(c).should.equal(false);
+      // Because rule-inspector directly exposes an AJV object compiled with the schema as
+      // "isAValidRuleObject", we can even access other properties of this AJV object like "errors".
+      ruleInspector.isAValidRuleObject.should.have.ownProperty("errors");
+      ruleInspector.isAValidRuleObject.errors.should.be.Array();
+
+      // Because each invalid object above must have exactly 1 invalid piece of info
+      // to test that specific validation in isolation.
+      ruleInspector.isAValidRuleObject.errors.should.have.size(1);
+    });
+
+    done();
+  });
+
+  it("should correctly classify all valid rule response objects", function(done) {
+    let response = {};
+    ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
+
+    response = {
+      Literal: function(context) {}
+    };
+    ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
+
+    // Keys that aren't actually node names are still valid. The emitter would simply never emit anything for this node,
+    // so it will just be ignored.
+    response = {
+      NotAnActualNodeName: function(context) {}
+    };
+    ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
+
+    response = {
+      Program: function(context) {},
+      ContractStatement: function(context) {},
+      ArrayExpression: function(context) {}
+    };
+    ruleInspector.isAValidRuleResponseObject(response).should.equal(true);
+
+    done();
+  });
+
+  it("should correctly classify all invalid rule response objects", function(done) {
+    let invalidResponses = [
+      ,
+      null,
+      undefined,
+      0,
+      "",
+      "harry potter",
+      -190,
+      8927,
+      88.2891,
+      [],
+      [{}],
+      [0],
+      function() {}
+    ];
+
+    invalidResponses.push({
+      "": function(ctx) {}
+    });
+
+    invalidResponses.push({
+      Literal: "Hello world"
+    });
+
+    invalidResponses.push({
+      Literal: undefined
+    });
+
+    invalidResponses.push({
+      Literal: null
+    });
+
+    invalidResponses.push({
+      NodaA: function(c) {},
+      NodaB: function(c) {},
+      Literal: null
+    });
+
+    invalidResponses.forEach(function(res) {
+      ruleInspector.isAValidRuleResponseObject(res).should.equal(false);
+      ruleInspector.isAValidRuleResponseObject.should.have.ownProperty(
+        "errors"
+      );
+      ruleInspector.isAValidRuleResponseObject.errors.should.be.Array();
+    });
+
+    done();
+  });
+
+  let listItemsSchema = [
+    { type: "string", minLength: 3 },
+    { type: "integer", minimum: 0, maximum: 10 },
+    {
+      type: "object",
+      properties: { name: { type: "string", minLength: 1 } },
+      additionalProperties: false
+    }
+  ];
+
+  it("should correctly classify when a rule is provided a valid set of options", function(done) {
+    ruleInspector
+      .areValidOptionsPassed(
+        ["hello", 5, { name: "chuck norris" }],
+        listItemsSchema
+      )
+      .should.equal(true);
+    done();
+  });
+
+  it("should correctly classify when a rule is provided an invalid set of options", function(done) {
+    let invalidOptionLists = [
+      null,
+      undefined,
+      "",
+      {},
+      100,
+      -9,
+      89.23,
+      0,
+      function() {},
+      NaN,
+      ["", 5, { name: "chuck norris" }],
+      ["hello", -189, { name: "chuck norris" }],
+      ["", 5, { name: "" }],
+      [],
+      ["hello"],
+      ["hell", 9],
+      [9, { name: "chuck norris" }],
+      ["sss", { name: "chuck norris" }]
+    ];
+
+    invalidOptionLists.forEach(function(ops) {
+      ruleInspector
+        .areValidOptionsPassed(ops, listItemsSchema)
+        .should.equal(false);
+    });
+
+    done();
+  });
 });
 
 /* eslint-enable no-unused-vars */

--- a/test/lib/utils/rule-loader.js
+++ b/test/lib/utils/rule-loader.js
@@ -8,139 +8,150 @@
 let ruleLoader = require("../../../lib/utils/rule-loader");
 
 describe("Test rule-loader functions", function() {
+  it("should expose a set of functions", function(done) {
+    ruleLoader.should.be.size(4); // including "constants" property
 
-    it("should expose a set of functions", function(done) {
-        ruleLoader.should.be.size(4);	// including "constants" property
+    ruleLoader.should.have.ownProperty("resolveUpstream");
+    ruleLoader.resolveUpstream.should.be.type("function");
 
-        ruleLoader.should.have.ownProperty("resolveUpstream");
-        ruleLoader.resolveUpstream.should.be.type("function");
+    ruleLoader.should.have.ownProperty("resolvePluginConfig");
+    ruleLoader.resolvePluginConfig.should.be.type("function");
 
-        ruleLoader.should.have.ownProperty("resolvePluginConfig");
-        ruleLoader.resolvePluginConfig.should.be.type("function");
+    ruleLoader.should.have.ownProperty("load");
+    ruleLoader.load.should.be.type("function");
 
-        ruleLoader.should.have.ownProperty("load");
-        ruleLoader.load.should.be.type("function");
+    done();
+  });
 
-        done();
-    });
+  it("should expose a set of constants", function(done) {
+    ruleLoader.should.have.ownProperty("constants");
+    ruleLoader.constants.should.be.type("object");
+    ruleLoader.constants.should.be.size(6);
 
-    it("should expose a set of constants", function(done) {
-        ruleLoader.should.have.ownProperty("constants");
-        ruleLoader.constants.should.be.type("object");
-        ruleLoader.constants.should.be.size(6);
+    ruleLoader.constants.should.have.ownProperty("SOLIUM_RULESET_ALL");
+    ruleLoader.constants.SOLIUM_RULESET_ALL.should.be.type("string");
 
-        ruleLoader.constants.should.have.ownProperty("SOLIUM_RULESET_ALL");
-        ruleLoader.constants.SOLIUM_RULESET_ALL.should.be.type("string");
+    ruleLoader.constants.should.have.ownProperty("SOLIUM_RULESET_RECOMMENDED");
+    ruleLoader.constants.SOLIUM_RULESET_RECOMMENDED.should.be.type("string");
 
-        ruleLoader.constants.should.have.ownProperty("SOLIUM_RULESET_RECOMMENDED");
-        ruleLoader.constants.SOLIUM_RULESET_RECOMMENDED.should.be.type("string");
-        
+    ruleLoader.constants.should.have.ownProperty("SOLIUM_CORE_RULES_DIRNAME");
+    ruleLoader.constants.SOLIUM_CORE_RULES_DIRNAME.should.be.type("string");
 
-        ruleLoader.constants.should.have.ownProperty("SOLIUM_CORE_RULES_DIRNAME");
-        ruleLoader.constants.SOLIUM_CORE_RULES_DIRNAME.should.be.type("string");
+    ruleLoader.constants.should.have.ownProperty("SOLIUM_CORE_RULES_DIRPATH");
+    ruleLoader.constants.SOLIUM_CORE_RULES_DIRPATH.should.be.type("string");
 
-        ruleLoader.constants.should.have.ownProperty("SOLIUM_CORE_RULES_DIRPATH");
-        ruleLoader.constants.SOLIUM_CORE_RULES_DIRPATH.should.be.type("string");
+    ruleLoader.constants.should.have.ownProperty("SOLIUM_PLUGIN_PREFIX");
+    ruleLoader.constants.SOLIUM_PLUGIN_PREFIX.should.be.type("string");
 
-        ruleLoader.constants.should.have.ownProperty("SOLIUM_PLUGIN_PREFIX");
-        ruleLoader.constants.SOLIUM_PLUGIN_PREFIX.should.be.type("string");
+    ruleLoader.constants.should.have.ownProperty(
+      "SOLIUM_SHARABLE_CONFIG_PREFIX"
+    );
+    ruleLoader.constants.SOLIUM_SHARABLE_CONFIG_PREFIX.should.be.type("string");
 
-        ruleLoader.constants.should.have.ownProperty("SOLIUM_SHARABLE_CONFIG_PREFIX");
-        ruleLoader.constants.SOLIUM_SHARABLE_CONFIG_PREFIX.should.be.type("string");
+    done();
+  });
 
-        done();
-    });
+  it("should handle invalid input given to resolveUpstream()", function(done) {
+    ruleLoader.resolveUpstream.bind(ruleLoader).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, undefined).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, null).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, 0).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, 11).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, -192).should.throw();
+    ruleLoader.resolveUpstream
+      .bind(ruleLoader, function foo() {})
+      .should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, []).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, [11]).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, {}).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, { a: 11 }).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, true).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, false).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, 10.2897).should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, "").should.throw();
+    ruleLoader.resolveUpstream
+      .bind(ruleLoader, "solium:blahblah")
+      .should.throw();
 
-    it("should handle invalid input given to resolveUpstream()", function(done) {
-        ruleLoader.resolveUpstream.bind(ruleLoader).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, undefined).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, null).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, 0).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, 11).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, -192).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, function foo() {}).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, []).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, [11]).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, {}).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, {a: 11}).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, true).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, false).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, 10.2897).should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, "").should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, "solium:blahblah").should.throw();
+    // Valid sharable config names, but not installed
+    ruleLoader.resolveUpstream.bind(ruleLoader, "17623").should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, "**(&&6%^").should.throw();
+    ruleLoader.resolveUpstream.bind(ruleLoader, ":").should.throw();
 
-        // Valid sharable config names, but not installed
-        ruleLoader.resolveUpstream.bind(ruleLoader, "17623").should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, "**(&&6%^").should.throw();
-        ruleLoader.resolveUpstream.bind(ruleLoader, ":").should.throw();
+    // Valid, installed but invalid JS syntax
+    ruleLoader.resolveUpstream
+      .bind(ruleLoader, "test-invalid-syntax")
+      .should.throw();
 
-        // Valid, installed but invalid JS syntax
-        ruleLoader.resolveUpstream.bind(ruleLoader, "test-invalid-syntax").should.throw();
+    // Valid, installed, valid syntax but invalid sharable config Schema
+    ruleLoader.resolveUpstream
+      .bind(ruleLoader, "test-invalid-schema")
+      .should.throw();
 
-        // Valid, installed, valid syntax but invalid sharable config Schema
-        ruleLoader.resolveUpstream.bind(ruleLoader, "test-invalid-schema").should.throw();
+    // Valid & installed, valid syntax & valid sharable config schema, ie, acceptable
+    ruleLoader.resolveUpstream.bind(ruleLoader, "test").should.not.throw();
 
-        // Valid & installed, valid syntax & valid sharable config schema, ie, acceptable
-        ruleLoader.resolveUpstream.bind(ruleLoader, "test").should.not.throw();
+    done();
+  });
 
-        done();
-    });
+  it("should return expected result when valid upstream value is passed", function(done) {
+    let result = ruleLoader.resolveUpstream(
+      ruleLoader.constants.SOLIUM_RULESET_ALL
+    );
+    result.should.be.type("object");
 
-    it("should return expected result when valid upstream value is passed", function(done) {
-        let result = ruleLoader.resolveUpstream(ruleLoader.constants.SOLIUM_RULESET_ALL);
-        result.should.be.type("object");
+    // Installed plugin
+    result = ruleLoader.resolveUpstream("test");
+    result.should.be.type("object");
 
-        // Installed plugin
-        result = ruleLoader.resolveUpstream("test");
-        result.should.be.type("object");
+    done();
+  });
 
-        done();
-    });
+  it("should return rule config when a valid plugin is passed to resolvePluginConfig()", function(done) {
+    let testPlugin = require("solium-plugin-test"),
+      config = ruleLoader.resolvePluginConfig("test", testPlugin);
 
-    it("should return rule config when a valid plugin is passed to resolvePluginConfig()", function(done) {
-        let testPlugin = require("solium-plugin-test"),
-            config = ruleLoader.resolvePluginConfig("test", testPlugin);
+    config.should.be.type("object");
+    config.should.have.size(2);
 
-        config.should.be.type("object");
-        config.should.have.size(2);
+    config.should.have.ownProperty("test/foo");
+    config["test/foo"].should.equal("warning");
 
-        config.should.have.ownProperty("test/foo");
-        config ["test/foo"].should.equal("warning");
+    config.should.have.ownProperty("test/bar");
+    config["test/bar"].should.equal("warning");
 
-        config.should.have.ownProperty("test/bar");
-        config ["test/bar"].should.equal("warning");
+    done();
+  });
 
-        done();
-    });
+  it("should throw when non-existent rule names are given to load()", function(done) {
+    ruleLoader.load.bind(ruleLoader, ["nihi2yo87isuhlush"]).should.throw();
 
-    it("should throw when non-existent rule names are given to load()", function(done) {
-        ruleLoader.load.bind(ruleLoader, ["nihi2yo87isuhlush"]).should.throw();
+    done();
+  });
 
-        done();
-    });
+  it("should return empty object when empty list is given to load()", function(done) {
+    let result = ruleLoader.load([]);
 
-    it("should return empty object when empty list is given to load()", function(done) {
-        let result = ruleLoader.load([]);
+    result.should.be.type("object");
+    Object.keys(result).length.should.equal(0);
 
-        result.should.be.type("object");
-        Object.keys(result).length.should.equal(0);
+    done();
+  });
 
-        done();
-    });
+  it("should load rules from plugins if they're installed", function(done) {
+    ruleLoader.load
+      .bind(ruleLoader, ["non-existent-plugin/foo"])
+      .should.throw();
 
-    it("should load rules from plugins if they're installed", function(done) {
-        ruleLoader.load.bind(ruleLoader, ["non-existent-plugin/foo"]).should.throw();
+    let result = ruleLoader.load(["test/foo", "test/bar", "test/baz"]);
 
-        let result = ruleLoader.load(["test/foo", "test/bar", "test/baz"]);
+    result.should.be.type("object");
+    result.should.be.size(3);
 
-        result.should.be.type("object");
-        result.should.be.size(3);
+    result["test/foo"].should.be.type("object");
+    result["test/bar"].should.be.type("object");
+    (result["test/baz"] === undefined).should.be.true();
 
-        result ["test/foo"].should.be.type("object");
-        result ["test/bar"].should.be.type("object");
-        (result ["test/baz"] === undefined).should.be.true();
-
-        done();
-    });
-
+    done();
+  });
 });

--- a/test/lib/utils/source-code-utils.js
+++ b/test/lib/utils/source-code-utils.js
@@ -6,291 +6,310 @@
 "use strict";
 
 const { EOL } = require("os"),
-    SourceCode = require("../../../lib/utils/source-code-utils");
+  SourceCode = require("../../../lib/utils/source-code-utils");
 
 describe("Testing SourceCode instance for exposed functionality", function() {
-    let sourceCodeText = "contract Visual {\n\n\tfunction foo () {\n\t\tvar x = 100;\n\t}\n\n}",
-        varDeclarator = {
-            type: "VariableDeclarator",
-            id: { type: "Identifier", name: "x", start: 44, end: 45 },
-            init: { type: "Literal", value: 100, start: 48, end: 51 },
-            start: 44,
-            end: 51
-        };
+  let sourceCodeText =
+      "contract Visual {\n\n\tfunction foo () {\n\t\tvar x = 100;\n\t}\n\n}",
+    varDeclarator = {
+      type: "VariableDeclarator",
+      id: { type: "Identifier", name: "x", start: 44, end: 45 },
+      init: { type: "Literal", value: 100, start: 48, end: 51 },
+      start: 44,
+      end: 51
+    };
 
-    it("should create instance of SourceCode & expose set of functions (its own & those of astUtils)", function(done) {
-        let sourceCodeObject = new SourceCode(sourceCodeText);
+  it("should create instance of SourceCode & expose set of functions (its own & those of astUtils)", function(done) {
+    let sourceCodeObject = new SourceCode(sourceCodeText);
 
-        sourceCodeObject.should.be.type("object");
-        sourceCodeObject.should.be.instanceof(SourceCode);
+    sourceCodeObject.should.be.type("object");
+    sourceCodeObject.should.be.instanceof(SourceCode);
 
-        sourceCodeObject.should.have.ownProperty("text");
-        sourceCodeObject.text.should.equal(sourceCodeText);
+    sourceCodeObject.should.have.ownProperty("text");
+    sourceCodeObject.text.should.equal(sourceCodeText);
 
-        //functions inherited from astUtils
-        sourceCodeObject.should.have.property("getLine");
-        sourceCodeObject.getLine.should.be.type("function");
+    //functions inherited from astUtils
+    sourceCodeObject.should.have.property("getLine");
+    sourceCodeObject.getLine.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getEndingLine");
-        sourceCodeObject.getLine.should.be.type("function");
+    sourceCodeObject.should.have.property("getEndingLine");
+    sourceCodeObject.getLine.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getColumn");
-        sourceCodeObject.getColumn.should.be.type("function");
+    sourceCodeObject.should.have.property("getColumn");
+    sourceCodeObject.getColumn.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getEndingColumn");
-        sourceCodeObject.getEndingColumn.should.be.type("function");
+    sourceCodeObject.should.have.property("getEndingColumn");
+    sourceCodeObject.getEndingColumn.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getParent");
-        sourceCodeObject.getParent.should.be.type("function");
+    sourceCodeObject.should.have.property("getParent");
+    sourceCodeObject.getParent.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isAChildOf");
-        sourceCodeObject.isAChildOf.should.be.type("function");
+    sourceCodeObject.should.have.property("isAChildOf");
+    sourceCodeObject.isAChildOf.should.be.type("function");
 
-        // functions for node type checking
-        sourceCodeObject.should.have.property("isBlockStatement");
-        sourceCodeObject.isBlockStatement.should.be.type("function");
+    // functions for node type checking
+    sourceCodeObject.should.have.property("isBlockStatement");
+    sourceCodeObject.isBlockStatement.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isBreakStatement");
-        sourceCodeObject.isBreakStatement.should.be.type("function");
+    sourceCodeObject.should.have.property("isBreakStatement");
+    sourceCodeObject.isBreakStatement.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isExpression");
-        sourceCodeObject.isExpression.should.be.type("function");
+    sourceCodeObject.should.have.property("isExpression");
+    sourceCodeObject.isExpression.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isAssignment");
-        sourceCodeObject.isAssignment.should.be.type("function");
+    sourceCodeObject.should.have.property("isAssignment");
+    sourceCodeObject.isAssignment.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isUpdate");
-        sourceCodeObject.isUpdate.should.be.type("function");
+    sourceCodeObject.should.have.property("isUpdate");
+    sourceCodeObject.isUpdate.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isMember");
-        sourceCodeObject.isMember.should.be.type("function");
+    sourceCodeObject.should.have.property("isMember");
+    sourceCodeObject.isMember.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isIfStatement");
-        sourceCodeObject.isIfStatement.should.be.type("function");
+    sourceCodeObject.should.have.property("isIfStatement");
+    sourceCodeObject.isIfStatement.should.be.type("function");
 
-        sourceCodeObject.should.have.property("isLoopStatement");
-        sourceCodeObject.isLoopStatement.should.be.type("function");
+    sourceCodeObject.should.have.property("isLoopStatement");
+    sourceCodeObject.isLoopStatement.should.be.type("function");
 
-        //prototype functions
-        sourceCodeObject.should.have.property("getText");
-        sourceCodeObject.getText.should.be.type("function");
+    //prototype functions
+    sourceCodeObject.should.have.property("getText");
+    sourceCodeObject.getText.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getTextOnLine");
-        sourceCodeObject.getText.should.be.type("function");
+    sourceCodeObject.should.have.property("getTextOnLine");
+    sourceCodeObject.getText.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getNextChar");
-        sourceCodeObject.getNextChar.should.be.type("function");
+    sourceCodeObject.should.have.property("getNextChar");
+    sourceCodeObject.getNextChar.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getPrevChar");
-        sourceCodeObject.getPrevChar.should.be.type("function");
+    sourceCodeObject.should.have.property("getPrevChar");
+    sourceCodeObject.getPrevChar.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getNextChars");
-        sourceCodeObject.getNextChars.should.be.type("function");
+    sourceCodeObject.should.have.property("getNextChars");
+    sourceCodeObject.getNextChars.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getPrevChars");
-        sourceCodeObject.getPrevChars.should.be.type("function");
+    sourceCodeObject.should.have.property("getPrevChars");
+    sourceCodeObject.getPrevChars.should.be.type("function");
 
-        sourceCodeObject.should.have.property("getStringBetweenNodes");
-        sourceCodeObject.getPrevChars.should.be.type("function");
+    sourceCodeObject.should.have.property("getStringBetweenNodes");
+    sourceCodeObject.getPrevChars.should.be.type("function");
 
-        done();
-    });
+    done();
+  });
 
-    it("should behave as expected upon calling getText ()", function(done) {
-        let sourceCodeObject = new SourceCode(sourceCodeText);
-        let functionCallText = "fooBar ();",
-            functionCallNode = { type: "ExpressionStatement",
-                expression: 
-                { type: "CallExpression",
-                    callee: { type: "Identifier", name: "fooBar", start: 0, end: 6 },
-                    arguments: [],
-                    start: 0,
-                    end: 9 },
-                start: 0,
-                end: 10 };
+  it("should behave as expected upon calling getText ()", function(done) {
+    let sourceCodeObject = new SourceCode(sourceCodeText);
+    let functionCallText = "fooBar ();",
+      functionCallNode = {
+        type: "ExpressionStatement",
+        expression: {
+          type: "CallExpression",
+          callee: { type: "Identifier", name: "fooBar", start: 0, end: 6 },
+          arguments: [],
+          start: 0,
+          end: 9
+        },
+        start: 0,
+        end: 10
+      };
 
-        sourceCodeObject.getText.bind(sourceCodeObject, {}).should.throw();
+    sourceCodeObject.getText.bind(sourceCodeObject, {}).should.throw();
 
-        sourceCodeObject.getText().should.equal(sourceCodeText);
-        sourceCodeObject.getText(varDeclarator).should.equal("x = 100");
-        sourceCodeObject.getText(varDeclarator, 0, 0).should.equal("x = 100");
-        sourceCodeObject.getText(varDeclarator, 4).should.equal("var x = 100");
-        sourceCodeObject.getText(varDeclarator, 4, 1).should.equal("var x = 100;");
-        sourceCodeObject.getText(varDeclarator, -4, -1).should.equal("var x = 100;");
-        sourceCodeObject.getText(varDeclarator, 100, 100).should.equal(sourceCodeText);
+    sourceCodeObject.getText().should.equal(sourceCodeText);
+    sourceCodeObject.getText(varDeclarator).should.equal("x = 100");
+    sourceCodeObject.getText(varDeclarator, 0, 0).should.equal("x = 100");
+    sourceCodeObject.getText(varDeclarator, 4).should.equal("var x = 100");
+    sourceCodeObject.getText(varDeclarator, 4, 1).should.equal("var x = 100;");
+    sourceCodeObject
+      .getText(varDeclarator, -4, -1)
+      .should.equal("var x = 100;");
+    sourceCodeObject
+      .getText(varDeclarator, 100, 100)
+      .should.equal(sourceCodeText);
 
-        sourceCodeObject = new SourceCode(functionCallText);
+    sourceCodeObject = new SourceCode(functionCallText);
 
-        sourceCodeObject.getText(functionCallNode).should.equal(functionCallText);
+    sourceCodeObject.getText(functionCallNode).should.equal(functionCallText);
 
-        done();
-    });
+    done();
+  });
 
-    it("should behave as expected upon calling getNextChar ()", function(done) {
-        let sourceCodeObject = new SourceCode(sourceCodeText);
+  it("should behave as expected upon calling getNextChar ()", function(done) {
+    let sourceCodeObject = new SourceCode(sourceCodeText);
 
-        sourceCodeObject.getNextChar.bind(sourceCodeObject, {}).should.throw();
-        sourceCodeObject.getNextChar.bind(sourceCodeObject).should.throw();
-        sourceCodeObject.getNextChar(varDeclarator).should.equal(";");
-        //Imitate the last node (with no chars after its code), the function should return null
-        (sourceCodeObject.getNextChar(
-            {type: "LastNode", end: sourceCodeText.length, start: 2}
-        ) === null).should.equal(true);
+    sourceCodeObject.getNextChar.bind(sourceCodeObject, {}).should.throw();
+    sourceCodeObject.getNextChar.bind(sourceCodeObject).should.throw();
+    sourceCodeObject.getNextChar(varDeclarator).should.equal(";");
+    //Imitate the last node (with no chars after its code), the function should return null
+    (
+      sourceCodeObject.getNextChar({
+        type: "LastNode",
+        end: sourceCodeText.length,
+        start: 2
+      }) === null
+    ).should.equal(true);
 
-        //extreme
-        (sourceCodeObject.getNextChar(
-            {type: "LastNode", end: 100000, start: 90}
-        ) === null).should.equal(true);
+    //extreme
+    (
+      sourceCodeObject.getNextChar({
+        type: "LastNode",
+        end: 100000,
+        start: 90
+      }) === null
+    ).should.equal(true);
 
-        done();
-    });
+    done();
+  });
 
-    it("should behave as expected upon calling getPrevChar ()", function(done) {
-        let sourceCodeObject = new SourceCode(sourceCodeText);
+  it("should behave as expected upon calling getPrevChar ()", function(done) {
+    let sourceCodeObject = new SourceCode(sourceCodeText);
 
-        sourceCodeObject.getPrevChar.bind(sourceCodeObject, {}).should.throw();
-        sourceCodeObject.getPrevChar.bind(sourceCodeObject).should.throw();
-        sourceCodeObject.getPrevChar(varDeclarator).should.equal(" ");
-        //Imitate the first node (with no chars before its code), the function should return null
-        (sourceCodeObject.getPrevChar(
-            {type: "FirstNode", start: 0, end: 90}
-        ) === null).should.equal(true);
+    sourceCodeObject.getPrevChar.bind(sourceCodeObject, {}).should.throw();
+    sourceCodeObject.getPrevChar.bind(sourceCodeObject).should.throw();
+    sourceCodeObject.getPrevChar(varDeclarator).should.equal(" ");
+    //Imitate the first node (with no chars before its code), the function should return null
+    (
+      sourceCodeObject.getPrevChar({ type: "FirstNode", start: 0, end: 90 }) ===
+      null
+    ).should.equal(true);
 
-        done();
-    });
+    done();
+  });
 
-    it("should behave as expected upon calling getNextChars ()", function(done) {
-        let sourceCodeObject = new SourceCode(sourceCodeText);
+  it("should behave as expected upon calling getNextChars ()", function(done) {
+    let sourceCodeObject = new SourceCode(sourceCodeText);
 
-        sourceCodeObject.getNextChars.bind(sourceCodeObject, {}).should.throw();
-        sourceCodeObject.getNextChars.bind(sourceCodeObject).should.throw();
-        sourceCodeObject.getNextChars(varDeclarator).should.equal("");
-        sourceCodeObject.getNextChars(varDeclarator, 1).should.equal(";");
-        sourceCodeObject.getNextChars(varDeclarator, -1).should.equal(";");
-        sourceCodeObject.getNextChars(varDeclarator, 100).should.equal(";\n\t}\n\n}");
+    sourceCodeObject.getNextChars.bind(sourceCodeObject, {}).should.throw();
+    sourceCodeObject.getNextChars.bind(sourceCodeObject).should.throw();
+    sourceCodeObject.getNextChars(varDeclarator).should.equal("");
+    sourceCodeObject.getNextChars(varDeclarator, 1).should.equal(";");
+    sourceCodeObject.getNextChars(varDeclarator, -1).should.equal(";");
+    sourceCodeObject
+      .getNextChars(varDeclarator, 100)
+      .should.equal(";\n\t}\n\n}");
 
-        done();
-    });
+    done();
+  });
 
-    it("should behave as expected upon calling getPrevChars ()", function(done) {
-        let sourceCodeObject = new SourceCode(sourceCodeText);
+  it("should behave as expected upon calling getPrevChars ()", function(done) {
+    let sourceCodeObject = new SourceCode(sourceCodeText);
 
-        sourceCodeObject.getPrevChars.bind(sourceCodeObject, {}).should.throw();
-        sourceCodeObject.getPrevChars.bind(sourceCodeObject).should.throw();
-        sourceCodeObject.getPrevChars(varDeclarator).should.equal("");
-        sourceCodeObject.getPrevChars(varDeclarator, 4).should.equal("var ");
-        sourceCodeObject.getPrevChars(varDeclarator, -4).should.equal("var ");
-        sourceCodeObject.getPrevChars(varDeclarator, 100).should.equal(
-            "contract Visual {\n\n\tfunction foo () {\n\t\tvar "
-        );
+    sourceCodeObject.getPrevChars.bind(sourceCodeObject, {}).should.throw();
+    sourceCodeObject.getPrevChars.bind(sourceCodeObject).should.throw();
+    sourceCodeObject.getPrevChars(varDeclarator).should.equal("");
+    sourceCodeObject.getPrevChars(varDeclarator, 4).should.equal("var ");
+    sourceCodeObject.getPrevChars(varDeclarator, -4).should.equal("var ");
+    sourceCodeObject
+      .getPrevChars(varDeclarator, 100)
+      .should.equal("contract Visual {\n\n\tfunction foo () {\n\t\tvar ");
 
-        done();
-    });
+    done();
+  });
 
-    it("should behave as expected upon calling getStringBetweenNodes ()", function(done) {
-        let sourceCodeText = "var x = 100;\n\tvar (y) = 200;\n\n\tvar z = 300;",
-            sourceCodeObject = new SourceCode(sourceCodeText);
+  it("should behave as expected upon calling getStringBetweenNodes ()", function(done) {
+    let sourceCodeText = "var x = 100;\n\tvar (y) = 200;\n\n\tvar z = 300;",
+      sourceCodeObject = new SourceCode(sourceCodeText);
 
-        let prevNode = {
-            "type": "VariableDeclaration",
-            "declarations": [
-                {
-                    "type": "VariableDeclarator",
-                    "id": {
-                        "type": "Identifier",
-                        "name": "x",
-                        "start": 4,
-                        "end": 5
-                    },
-                    "init": {
-                        "type": "Literal",
-                        "value": 100,
-                        "start": 8,
-                        "end": 11
-                    },
-                    "start": 4,
-                    "end": 11
-                }
-            ],
-            "start": 0,
-            "end": 12
-        };
-
-        let currentNode = {
-            "type": "VariableDeclaration",
-            "declarations": [
-                {
-                    "type": "VariableDeclarator",
-                    "id": {
-                        "type": "Identifier",
-                        "name": "z",
-                        "start": 35,
-                        "end": 36
-                    },
-                    "init": {
-                        "type": "Literal",
-                        "value": 300,
-                        "start": 39,
-                        "end": 42
-                    },
-                    "start": 35,
-                    "end": 42
-                }
-            ],
-            "start": 31,
-            "end": 43
-        };
-
-        sourceCodeObject
-            .getStringBetweenNodes(prevNode, currentNode)
-            .should.equal("\n\tvar (y) = 200;\n\n\t");
-
-        sourceCodeObject
-            .getStringBetweenNodes
-            .bind(sourceCodeObject).should.throw();
-
-        sourceCodeObject
-            .getStringBetweenNodes
-            .bind(sourceCodeObject, 1, 1).should.throw();
-
-        sourceCodeObject
-            .getStringBetweenNodes
-            .bind(sourceCodeObject, {}, {}).should.throw();
-
-        sourceCodeObject
-            .getStringBetweenNodes
-            .bind(sourceCodeObject, null, null).should.throw();
-
-        sourceCodeObject
-            .getStringBetweenNodes
-            .bind(sourceCodeObject, [], []).should.throw();
-
-        sourceCodeObject
-            .getStringBetweenNodes
-            .bind(sourceCodeObject, currentNode, prevNode).should.throw();
-
-        done();
-    });
-
-    it("should behave as expected upon calling getTextOnLine()", function(done) {
-        let sourceCodeObject = new SourceCode(sourceCodeText),
-            sourceCodeTextLines = sourceCodeText.split(EOL);
-
-        for (let i = 0; i < sourceCodeTextLines.length; i++) {
-            sourceCodeObject.getTextOnLine(i+1)
-                .should.equal(sourceCodeTextLines [i]);
+    let prevNode = {
+      type: "VariableDeclaration",
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          id: {
+            type: "Identifier",
+            name: "x",
+            start: 4,
+            end: 5
+          },
+          init: {
+            type: "Literal",
+            value: 100,
+            start: 8,
+            end: 11
+          },
+          start: 4,
+          end: 11
         }
+      ],
+      start: 0,
+      end: 12
+    };
 
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject).should.throw();
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject, null).should.throw();
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject, "").should.throw();
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject, 0).should.throw();
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject, "1").should.throw();
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject, -1).should.throw();
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject, 100).should.throw();
-        sourceCodeObject.getTextOnLine.bind(sourceCodeObject, 2.3).should.throw();
+    let currentNode = {
+      type: "VariableDeclaration",
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          id: {
+            type: "Identifier",
+            name: "z",
+            start: 35,
+            end: 36
+          },
+          init: {
+            type: "Literal",
+            value: 300,
+            start: 39,
+            end: 42
+          },
+          start: 35,
+          end: 42
+        }
+      ],
+      start: 31,
+      end: 43
+    };
 
-        done();
-    });
+    sourceCodeObject
+      .getStringBetweenNodes(prevNode, currentNode)
+      .should.equal("\n\tvar (y) = 200;\n\n\t");
 
+    sourceCodeObject.getStringBetweenNodes
+      .bind(sourceCodeObject)
+      .should.throw();
+
+    sourceCodeObject.getStringBetweenNodes
+      .bind(sourceCodeObject, 1, 1)
+      .should.throw();
+
+    sourceCodeObject.getStringBetweenNodes
+      .bind(sourceCodeObject, {}, {})
+      .should.throw();
+
+    sourceCodeObject.getStringBetweenNodes
+      .bind(sourceCodeObject, null, null)
+      .should.throw();
+
+    sourceCodeObject.getStringBetweenNodes
+      .bind(sourceCodeObject, [], [])
+      .should.throw();
+
+    sourceCodeObject.getStringBetweenNodes
+      .bind(sourceCodeObject, currentNode, prevNode)
+      .should.throw();
+
+    done();
+  });
+
+  it("should behave as expected upon calling getTextOnLine()", function(done) {
+    let sourceCodeObject = new SourceCode(sourceCodeText),
+      sourceCodeTextLines = sourceCodeText.split(EOL);
+
+    for (let i = 0; i < sourceCodeTextLines.length; i++) {
+      sourceCodeObject
+        .getTextOnLine(i + 1)
+        .should.equal(sourceCodeTextLines[i]);
+    }
+
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject).should.throw();
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject, null).should.throw();
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject, "").should.throw();
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject, 0).should.throw();
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject, "1").should.throw();
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject, -1).should.throw();
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject, 100).should.throw();
+    sourceCodeObject.getTextOnLine.bind(sourceCodeObject, 2.3).should.throw();
+
+    done();
+  });
 });

--- a/test/lib/utils/wrappers.js
+++ b/test/lib/utils/wrappers.js
@@ -6,79 +6,81 @@
 "use strict";
 
 const wrappers = require("../../utils/wrappers"),
-    Solium = require("../../../lib/solium"),
-    { EOL } = require("os");
+  Solium = require("../../../lib/solium"),
+  { EOL } = require("os");
 
 let userConfig = {
-    "custom-rules-filename": null,
-    rules: {}
+  "custom-rules-filename": null,
+  rules: {}
 };
 
 describe("Test wrappers", function() {
+  it("should have a set of functions exposed as API", function(done) {
+    wrappers.should.have.ownProperty("toContract");
+    wrappers.toContract.should.be.type("function");
 
-    it("should have a set of functions exposed as API", function(done) {
-        
-        wrappers.should.have.ownProperty("toContract");
-        wrappers.toContract.should.be.type("function");
+    wrappers.should.have.ownProperty("toFunction");
+    wrappers.toFunction.should.be.type("function");
 
-        wrappers.should.have.ownProperty("toFunction");
-        wrappers.toFunction.should.be.type("function");
+    wrappers.should.have.ownProperty("addPragma");
+    wrappers.toFunction.should.be.type("function");
 
-        wrappers.should.have.ownProperty("addPragma");
-        wrappers.toFunction.should.be.type("function");
+    done();
+  });
 
-        done();
-    });
+  it("toContract: should correctly wrap a solidity statement in contract code", function(done) {
+    let toContract = wrappers.toContract;
+    let statement = "uint x = 1;";
+    let expected =
+      `pragma solidity ^0.4.3;${EOL.repeat(3)}` +
+      `contract Wrap {${EOL}` +
+      "\t" +
+      statement +
+      EOL +
+      "}";
 
-    it("toContract: should correctly wrap a solidity statement in contract code", function(done) {
-        let toContract = wrappers.toContract;
-        let statement = "uint x = 1;";
-        let expected = 
-            `pragma solidity ^0.4.3;${EOL.repeat(3)}` +
-            `contract Wrap {${EOL}` +
-            "\t" + statement + EOL +
-            "}";
+    let errors = Solium.lint(expected, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+    toContract(statement).should.equal(expected);
 
-        let errors = Solium.lint(expected, userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-        toContract(statement).should.equal(expected);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("toFunction: should correctly wrap a solidity statement in contract/function code", function(done) {
+    let toFunction = wrappers.toFunction;
+    let statement = "uint x = 1;";
+    let expected =
+      `pragma solidity ^0.4.3;${EOL.repeat(3)}` +
+      `contract Wrap {${EOL}` +
+      `\tfunction wrap() {${EOL}` +
+      "\t\t" +
+      statement +
+      EOL +
+      `\t}${EOL}` +
+      "}";
 
-    it("toFunction: should correctly wrap a solidity statement in contract/function code", function(done) {
-        let toFunction = wrappers.toFunction;
-        let statement = "uint x = 1;";
-        let expected = 
-            `pragma solidity ^0.4.3;${EOL.repeat(3)}` +
-            `contract Wrap {${EOL}` +
-            `\tfunction wrap() {${EOL}` +
-            "\t\t" + statement + EOL +
-            `\t}${EOL}` +
-            "}";
+    let errors = Solium.lint(expected, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+    toFunction(statement).should.equal(expected);
 
-        let errors = Solium.lint(expected, userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-        toFunction(statement).should.equal(expected);
+    Solium.reset();
+    done();
+  });
 
-        Solium.reset();
-        done();
-    });
+  it("addPragma: should correctly pre-pend a pragma statement to a solidity contract or library", function(done) {
+    let addPragma = wrappers.addPragma;
+    let contract = "contract Abc { }";
+    let expected = `pragma solidity ^0.4.3;${EOL.repeat(3)}` + contract;
 
-    it("addPragma: should correctly pre-pend a pragma statement to a solidity contract or library", function(done) {
-        let addPragma = wrappers.addPragma;
-        let contract = "contract Abc { }";
-        let expected = `pragma solidity ^0.4.3;${EOL.repeat(3)}` + contract;
-            
-        let errors = Solium.lint(expected, userConfig);
-        errors.constructor.name.should.equal("Array");
-        errors.length.should.equal(0);
-        addPragma(contract).should.equal(expected);
+    let errors = Solium.lint(expected, userConfig);
+    errors.constructor.name.should.equal("Array");
+    errors.length.should.equal(0);
+    addPragma(contract).should.equal(expected);
 
-        Solium.reset();
-        done();
-    });
+    Solium.reset();
+    done();
+  });
 });

--- a/test/packagejson.js
+++ b/test/packagejson.js
@@ -7,25 +7,32 @@
 
 const packageJSON = require("../package.json");
 
-
 describe("Checking package.json", () => {
+  it("should enforce fixed versions on certain dependencies", done => {
+    const fixedDeps = [
+      "solparse",
+      "sol-digger",
+      "sol-explore",
+      "solium-plugin-security"
+    ];
+    const fixedDevDeps = [
+      "solium-config-test",
+      "solium-config-test-invalid-schema",
+      "solium-config-test-invalid-syntax",
+      "solium-plugin-test",
+      "solium-plugin-test-invalid-schema"
+    ];
+    const deps = packageJSON.dependencies,
+      devDeps = packageJSON.devDependencies;
 
-    it("should enforce fixed versions on certain dependencies", done => {
-        const fixedDeps = ["solparse", "sol-digger", "sol-explore", "solium-plugin-security"];
-        const fixedDevDeps = ["solium-config-test", "solium-config-test-invalid-schema",
-            "solium-config-test-invalid-syntax", "solium-plugin-test", "solium-plugin-test-invalid-schema"];
-        const deps = packageJSON.dependencies, devDeps = packageJSON.devDependencies;
-
-
-        fixedDeps.forEach(fd => {
-            /^[0-9]$/.test(deps[fd][0]).should.be.true();
-        });
-
-        fixedDevDeps.forEach(fdd => {
-            /^[0-9]$/.test(devDeps[fdd][0]).should.be.true();
-        });
-
-        done();
+    fixedDeps.forEach(fd => {
+      /^[0-9]$/.test(deps[fd][0]).should.be.true();
     });
 
+    fixedDevDeps.forEach(fdd => {
+      /^[0-9]$/.test(devDeps[fdd][0]).should.be.true();
+    });
+
+    done();
+  });
 });

--- a/test/utils/wrappers.js
+++ b/test/utils/wrappers.js
@@ -1,7 +1,7 @@
 /**
- * @fileoverview Utility functions to wrap solidity snippets with pragma, contract and/or 
+ * @fileoverview Utility functions to wrap solidity snippets with pragma, contract and/or
  * function code so they can be passed to solidity-parser without erroring. These allow
- * the test cases to be presented in an easily legible form. 
+ * the test cases to be presented in an easily legible form.
  * @author cgewecke <christophergewecke@gmail.com>
  */
 
@@ -10,35 +10,37 @@
 const { EOL } = require("os");
 
 module.exports = {
-    /**
-     * Wrap a solidity statement in valid contract boilerplate. 
-     * @param  {String} code Solidity snippet to wrap
-     * @return {String}      wrapped snippet
-     */
-    toContract: function(code) {
-        let pre = `pragma solidity ^0.4.3;${EOL.repeat(3)}contract Wrap {${EOL}\t`;
-        let post = `${EOL}}`;
-        return pre + code + post;
-    },
+  /**
+   * Wrap a solidity statement in valid contract boilerplate.
+   * @param  {String} code Solidity snippet to wrap
+   * @return {String}      wrapped snippet
+   */
+  toContract: function(code) {
+    let pre = `pragma solidity ^0.4.3;${EOL.repeat(3)}contract Wrap {${EOL}\t`;
+    let post = `${EOL}}`;
+    return pre + code + post;
+  },
 
-    /**
-     * Wrap a solidity statement in valid contract and function boilerplate. 
-     * @param  {String} code Solidity snippet
-     * @return {String}      wrapped snippet
-     */
-    toFunction: function(code) {
-        let pre = `pragma solidity ^0.4.3;${EOL.repeat(3)}contract Wrap {${EOL}\tfunction wrap() {${EOL}\t\t`;
-        let post = `${EOL}\t}${EOL}}`;
-        return pre + code + post;
-    },
+  /**
+   * Wrap a solidity statement in valid contract and function boilerplate.
+   * @param  {String} code Solidity snippet
+   * @return {String}      wrapped snippet
+   */
+  toFunction: function(code) {
+    let pre = `pragma solidity ^0.4.3;${EOL.repeat(
+      3
+    )}contract Wrap {${EOL}\tfunction wrap() {${EOL}\t\t`;
+    let post = `${EOL}\t}${EOL}}`;
+    return pre + code + post;
+  },
 
-    /**
-     * Prepend solidity contract / library with a pragma statement 
-     * @param  {String} code Solidity snippet
-     * @return {String}      snippet with pragma statement.
-     */
-    addPragma: function(code) {
-        let pre = `pragma solidity ^0.4.3;${EOL.repeat(3)}`;
-        return pre + code;
-    }
+  /**
+   * Prepend solidity contract / library with a pragma statement
+   * @param  {String} code Solidity snippet
+   * @return {String}      snippet with pragma statement.
+   */
+  addPragma: function(code) {
+    let pre = `pragma solidity ^0.4.3;${EOL.repeat(3)}`;
+    return pre + code;
+  }
 };


### PR DESCRIPTION
In this PR I propose to use prettier for code formatting. Prettier is an opinionated code formatter, but that can be a really good thing for an open source project. I've wired prettier to format on the pre-commit hook. This will allow contributors to spend less time appeasing the damn linter, write code however they like, in any editor and prettier will make sure all the code is formatted before it's committed. Let me know what you think.