### PR TITLE
Feature: run solium cli without config files

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -73,7 +73,8 @@ Use ``solium --help`` for more information on usage.
 	``-d`` can be used in place of ``--dir`` and ``-f`` in place of ``--file``.
 
 .. note::
-    You can override configuration for plugins and rules with ``--plugin`` and ``--rule``.
+    You can specify rules or plugins to apply as commandline options.
+    If you specify one, it overrides its corresponding configuration in the soliumrc file.
 
     ``solium --plugin zeppelin --rule 'indentation: ["error", 4]' -f contract.sol``
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -72,6 +72,14 @@ Use ``solium --help`` for more information on usage.
 .. note::
 	``-d`` can be used in place of ``--dir`` and ``-f`` in place of ``--file``.
 
+.. note::
+    You can override configuration for plugins and rules with ``--plugin`` and ``--rule``.
+
+    ``solium --plugin zeppelin --rule 'indentation: ["error", 4]' -f contract.sol``
+
+    You can use ``solium --no-soliumrc`` If you want to run solium in any arbitrary folder without the config files.
+
+    ``solium --no-soliumrc --plugin zeppelin --rule 'indentation: ["error", 4]' -f contract.sol``
 
 After linting over your code, Solium produces either warnings, errors or both. The app exits with a non-zero code ONLY if 1 or more errors were found.
 So if all you got was warnings, solium exits with code ``0``.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -72,18 +72,17 @@ Use ``solium --help`` for more information on usage.
 .. note::
 	``-d`` can be used in place of ``--dir`` and ``-f`` in place of ``--file``.
 
-.. note::
-    You can specify rules or plugins to apply as commandline options.
-    If you specify one, it overrides its corresponding configuration in the soliumrc file.
 
-    ``solium --plugin zeppelin --rule 'indentation: ["error", 4]' -f contract.sol``
+You can specify rules or plugins to apply as commandline options. If you specify one, it overrides its corresponding configuration in the soliumrc file.
 
-    You can use ``solium --no-soliumrc`` If you want to run solium in any arbitrary folder without the config files.
+``solium --plugin zeppelin --rule 'indentation: ["error", 4]' -d contracts/``
 
-    ``solium --no-soliumrc --plugin zeppelin --rule 'indentation: ["error", 4]' -f contract.sol``
+Use ``--no-soliumrc`` and ``--no-soliumignore`` if you want to run solium in any arbitrary folder without looking for the config files.
 
-After linting over your code, Solium produces either warnings, errors or both. The app exits with a non-zero code ONLY if 1 or more errors were found.
-So if all you got was warnings, solium exits with code ``0``.
+``solium --no-soliumrc --no-soliumignore --plugin zeppelin --rule 'indentation: ["error", 4]' -f contract.sol``
+
+After linting over your code, Solium produces either warnings, errors or both. The tool exits with a non-zero code only if 1 or more errors were found.
+So if all you got was warnings, solium exits with ``0``.
 
 Whether an issue should be flagged as an error or warning by its rule is configurable through ``.soliumrc.json``.
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -330,38 +330,30 @@ function execute(programArgs) {
     }
 
     for (const rule of cli.rule) {
-        let offset = rule.indexOf(":");
-
-        if (offset !== -1) {
-            let key = rule.substring(0, offset).trim();
-            let value = rule.substring(offset + 1, rule.length).trim();
-
-            try {
-                value = JSON.parse(value);
-            } catch (e) {
-                errorReporter.reportFatal(
-                    `There was an error trying to parse '${value}': ${e.message}`
-                );
-            }
-
-            userConfig.rules[key] = value;
+        // If no ":" was found, it means only the rule's name was specified.
+        // Treat it as an error and adopt its default configuration options.
+        if (!rule.includes(":")) {
+            userConfig.rules[rule] = "error";
             continue;
         }
 
-        // If no ":" was found, it means only the rule's name was specified.
-        // Treat it as an error and adopt its default configuration options.
-        userConfig.rules[rule] = "error";
+        let [key, value] = rule.split(":").map(i => i.trim());
+        try {
+            value = JSON.parse(value);
+        } catch (e) {
+            errorReporter.reportFatal(`There was an error trying to parse '${rule}': ${e.message}`);
+            process.exit(errorCodes.INVALID_PARAMS);
+        }
+        userConfig.rules[key] = value;
     }
 
     //get all files & folders to ignore from .soliumignore
     try {
         ignore = fs.readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8").split("\n");
     } catch (e) {
-        if (cli.soliumrc) {
-            errorReporter.reportInternal(
-                `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`
-            );
-        }
+        errorReporter.reportInternal(
+            `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`
+        );
     }
 
     if (cli.hot) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -203,6 +203,11 @@ function lint(userConfig, input, ignore, errorReporter) {
  * @param {Object} cliObject Commander Object handling the cli
  */
 function createCliOptions(cliObject) {
+    function collect(val, memo) {
+        memo.push(val);
+        return memo;
+    }
+
     cliObject
         .version(`Solium version ${version}`)
         .description("Style and Security checker for Solidity")
@@ -217,7 +222,12 @@ function createCliOptions(cliObject) {
         .option("--fix", "Fix Lint issues where possible")
         .option("--debug", "Display debug information")
         .option("--watch", "Watch for file changes")
-        .option("--hot", "(Deprecated) Same as --watch");
+        .option("--hot", "(Deprecated) Same as --watch")
+        .option("--rule [rule]",
+                "Overwrite or add [rule] additionally to those provided in the solium configuration file", collect, [])
+        .option("--plugin [plugin]",
+                "Add plugin additionally to those provided in the solium configuration file", collect, [])
+        .option("--no-soliumrc", "Do not use the solium configuration file");
 }
 
 /**
@@ -259,31 +269,35 @@ function execute(programArgs) {
         process.exit(errorCodes.INVALID_PARAMS);
     }
 
-    /**
-     * If cli.config option is NOT specified, then resort to .soliumrc in current dir.
-     * Else,
-     *   If path is absolute, assign as-it-is.
-     *   Else (relative pathing) join path with current dir.
-     */
-    const soliumrcAbsPath = cli.config ?
-        (path.isAbsolute(cli.config) ? cli.config : path.join(CWD, cli.config)) :
-        SOLIUMRC_FILENAME_ABSOLUTE;
+    if (cli.soliumrc) {
+        /**
+         * If cli.config option is NOT specified, then resort to .soliumrc in current dir.
+         * Else,
+         *   If path is absolute, assign as-it-is.
+         *   Else (relative pathing) join path with current dir.
+         */
+        const soliumrcAbsPath = cli.config ?
+            (path.isAbsolute(cli.config) ? cli.config : path.join(CWD, cli.config)) :
+            SOLIUMRC_FILENAME_ABSOLUTE;
 
-    try {
-        userConfig = require(soliumrcAbsPath);
-    } catch (e) {
-        // Check if soliumrc file exists. If yes, then the file is in an invalid format.
-        if (fs.existsSync(soliumrcAbsPath)) {
-            errorReporter.reportFatal(`An invalid ${SOLIUMRC_FILENAME} was provided. ${e.message}`);
-        } else {
-            if (cli.config) {
-                errorReporter.reportFatal(`${soliumrcAbsPath} does not exist.`);
+        try {
+            userConfig = require(soliumrcAbsPath);
+        } catch (e) {
+            // Check if soliumrc file exists. If yes, then the file is in an invalid format.
+            if (fs.existsSync(soliumrcAbsPath)) {
+                errorReporter.reportFatal(`An invalid ${SOLIUMRC_FILENAME} was provided. ${e.message}`);
             } else {
-                errorReporter.reportFatal(`Couldn't find ${SOLIUMRC_FILENAME} in the current directory.`);
+                if (cli.config) {
+                    errorReporter.reportFatal(`${soliumrcAbsPath} does not exist.`);
+                } else {
+                    errorReporter.reportFatal(`Couldn't find ${SOLIUMRC_FILENAME} in the current directory.`);
+                }
             }
-        }
 
-        process.exit(errorCodes.NO_SOLIUMRC);
+            process.exit(errorCodes.NO_SOLIUMRC);
+        }
+    } else {
+        userConfig = {};
     }
 
     //if custom rules' file is set, make sure we have its absolute path
@@ -302,13 +316,42 @@ function execute(programArgs) {
         debug: Boolean(cli.debug)
     };
 
+    userConfig.plugins = userConfig.plugins || [];
+    for (var plugin of cli.plugin) {
+      userConfig.plugins.push(plugin);
+    }
+
+    userConfig.rules = userConfig.rules || {};
+    for (var rule of cli.rule) {
+        let offset = rule.indexOf(':');
+
+        if (offset !== -1) {
+            let key = rule.substring(0, offset);
+            let value = rule.substring(offset + 1, rule.length);
+            try {
+                value = JSON.parse(rule.substring(offset + 1, rule.length));
+            } catch (e) {
+                errorReporter.reportFatal(
+                    `There was an error trying to parse '${value}': ${e.message}`
+                );
+            }
+
+            userConfig.rules[key] = value;
+            continue;
+        }
+
+        userConfig.rules[rule] = true;
+    }
+
     //get all files & folders to ignore from .soliumignore
     try {
         ignore = fs.readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8").split("\n");
     } catch (e) {
-        errorReporter.reportInternal(
-            `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`
-        );
+        if (cli.soliumrc) {
+            errorReporter.reportInternal(
+                `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`
+            );
+        }
     }
 
     if (cli.hot) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -224,9 +224,9 @@ function createCliOptions(cliObject) {
         .option("--watch", "Watch for file changes")
         .option("--hot", "(Deprecated) Same as --watch")
         .option("--rule [rule]",
-                "Overwrite or add [rule] additionally to those provided in the solium configuration file", collect, [])
+            "Overwrite or add [rule] additionally to those provided in the solium configuration file", collect, [])
         .option("--plugin [plugin]",
-                "Add plugin additionally to those provided in the solium configuration file", collect, [])
+            "Add plugin additionally to those provided in the solium configuration file", collect, [])
         .option("--no-soliumrc", "Do not use the solium configuration file");
 }
 
@@ -317,13 +317,13 @@ function execute(programArgs) {
     };
 
     userConfig.plugins = userConfig.plugins || [];
-    for (var plugin of cli.plugin) {
-      userConfig.plugins.push(plugin);
+    for (const plugin of cli.plugin) {
+        userConfig.plugins.push(plugin);
     }
 
     userConfig.rules = userConfig.rules || {};
-    for (var rule of cli.rule) {
-        let offset = rule.indexOf(':');
+    for (const rule of cli.rule) {
+        let offset = rule.indexOf(":");
 
         if (offset !== -1) {
             let key = rule.substring(0, offset);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -224,10 +224,10 @@ function createCliOptions(cliObject) {
         .option("--watch", "Watch for file changes")
         .option("--hot", "(Deprecated) Same as --watch")
         .option("--rule [rule]",
-            "Overwrite or add [rule] additionally to those provided in the solium configuration file", collect, [])
+            "Rule to execute. This overrides the specified rule's configuration in soliumrc if present", collect, [])
         .option("--plugin [plugin]",
-            "Add plugin additionally to those provided in the solium configuration file", collect, [])
-        .option("--no-soliumrc", "Do not use the solium configuration file");
+            "Plugin to execute. This overrides the specified plugin's configuration in soliumrc if present", collect, [])
+        .option("--no-soliumrc", "Do not look for soliumrc configuration file");
 }
 
 /**
@@ -340,7 +340,7 @@ function execute(programArgs) {
             continue;
         }
 
-        userConfig.rules[rule] = true;
+        userConfig.rules[rule] = "error";
     }
 
     //get all files & folders to ignore from .soliumignore

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -223,11 +223,19 @@ function createCliOptions(cliObject) {
         .option("--debug", "Display debug information")
         .option("--watch", "Watch for file changes")
         .option("--hot", "(Deprecated) Same as --watch")
-        .option("--rule [rule]",
-            "Rule to execute. This overrides the specified rule's configuration in soliumrc if present", collect, [])
-        .option("--plugin [plugin]",
-            "Plugin to execute. This overrides the specified plugin's configuration in soliumrc if present", collect, [])
-        .option("--no-soliumrc", "Do not look for soliumrc configuration file");
+        .option("--no-soliumrc", "Do not look for soliumrc configuration file")
+        .option(
+            "--rule [rule]",
+            "Rule to execute. This overrides the specified rule's configuration in soliumrc if present",
+            collect,
+            []
+        )
+        .option(
+            "--plugin [plugin]",
+            "Plugin to execute. This overrides the specified plugin's configuration in soliumrc if present",
+            collect,
+            []
+        );
 }
 
 /**
@@ -253,7 +261,7 @@ function getErrorReporter(name) {
  */
 function execute(programArgs) {
 
-    let userConfig, ignore, errorReporter;
+    let userConfig = {}, ignore, errorReporter;
 
     createCliOptions(cli);
     programArgs.length === 2 ? cli.help() : cli.parse(programArgs);
@@ -296,8 +304,6 @@ function execute(programArgs) {
 
             process.exit(errorCodes.NO_SOLIUMRC);
         }
-    } else {
-        userConfig = {};
     }
 
     //if custom rules' file is set, make sure we have its absolute path
@@ -317,17 +323,19 @@ function execute(programArgs) {
     };
 
     userConfig.plugins = userConfig.plugins || [];
+    userConfig.rules = userConfig.rules || {};
+
     for (const plugin of cli.plugin) {
         userConfig.plugins.push(plugin);
     }
 
-    userConfig.rules = userConfig.rules || {};
     for (const rule of cli.rule) {
         let offset = rule.indexOf(":");
 
         if (offset !== -1) {
             let key = rule.substring(0, offset);
             let value = rule.substring(offset + 1, rule.length);
+
             try {
                 value = JSON.parse(rule.substring(offset + 1, rule.length));
             } catch (e) {
@@ -340,6 +348,8 @@ function execute(programArgs) {
             continue;
         }
 
+        // If no ":" was found, it means only the rule's name was specified.
+        // Treat it as an error and adopt its default configuration options.
         userConfig.rules[rule] = "error";
     }
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -223,6 +223,7 @@ function createCliOptions(cliObject) {
         .option("--debug", "Display debug information")
         .option("--watch", "Watch for file changes")
         .option("--hot", "(Deprecated) Same as --watch")
+        .option("--no-soliumignore", "Do not look for .soliumignore file")
         .option("--no-soliumrc", "Do not look for soliumrc configuration file")
         .option(
             "--rule [rule]",
@@ -348,12 +349,13 @@ function execute(programArgs) {
     }
 
     //get all files & folders to ignore from .soliumignore
-    try {
-        ignore = fs.readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8").split("\n");
-    } catch (e) {
-        errorReporter.reportInternal(
-            `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`
-        );
+    if (cli.soliumignore) {
+        try {
+            ignore = fs.readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8").split("\n");
+        } catch (e) {
+            errorReporter.reportInternal(
+                `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`);
+        }
     }
 
     if (cli.hot) {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -333,11 +333,11 @@ function execute(programArgs) {
         let offset = rule.indexOf(":");
 
         if (offset !== -1) {
-            let key = rule.substring(0, offset);
-            let value = rule.substring(offset + 1, rule.length);
+            let key = rule.substring(0, offset).trim();
+            let value = rule.substring(offset + 1, rule.length).trim();
 
             try {
-                value = JSON.parse(rule.substring(offset + 1, rule.length));
+                value = JSON.parse(value);
             } catch (e) {
                 errorReporter.reportFatal(
                     `There was an error trying to parse '${value}': ${e.message}`


### PR DESCRIPTION
Can be used with or without --no-soliumrc.
If used with a solium configuration file,
the commandline options '--plugin [plugin]' and '--rule [rule]'
will add/overwrite values defined in the configuration file.

Examples:
  solium --plugin security --plugin zeppelin --no-soliumrc -d contracts/
  solium --rule 'indentation: ["error", 4]' --rule 'security/no-throw' --no-soliumrc -f contracts/foobar.sol

Fixes #214