### PR TITLE
Accept windows CRLF in .soliumignore

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -348,7 +348,7 @@ function execute(programArgs) {
     //get all files & folders to ignore from .soliumignore
     if (cli.soliumignore) {
         try {
-            ignore = fs.readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8").split("\n");
+            ignore = fs.readFileSync(SOLIUMIGNORE_FILENAME_ABSOLUTE, "utf8").split(EOL);
         } catch (e) {
             errorReporter.reportInternal(
                 `There was an error trying to read '${SOLIUMIGNORE_FILENAME_ABSOLUTE}': ${e.message}`);


### PR DESCRIPTION
Hi there! I had an issue using solium on windows machine, `.soliumignore` had to use LF. This PR fixes it